### PR TITLE
feat(move_note): update wikilinks, markdown links, and canvas refs on move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to `obsidian-mcp-pro` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`move_note` now updates references across the vault by default**, matching
+  Obsidian's "Automatically update internal links" behavior. Wikilinks
+  (`[[old]]`, `![[old]]`, with aliases and `#heading` / `#^block-id`
+  fragments preserved), markdown links (`[text](old.md)` and the
+  extension-less form), and canvas `nodes[].file` fields all follow the
+  move. The link form is preserved when possible — a bare `[[idea]]`
+  stays bare when the basename remains unambiguous post-move, and falls
+  back to the path form (`[[archive/idea]]`) when it doesn't.
+  Pass `updateLinks: false` to skip the rewrite scan (faster on huge
+  vaults, or when the caller is doing its own bookkeeping).
+  Addresses the `move_note` half of
+  [#3](https://github.com/rps321321/obsidian-mcp-pro/issues/3);
+  `delete_note` reference handling is tracked separately.
+
+### Added
+
+- `MoveNoteOptions` and `MoveNoteResult` exported from `lib/vault.ts`. The
+  result reports per-file counts of rewritten and failed referrers so
+  callers can surface partial-failure cases. The rename itself stays
+  committed if the rewrite phase encounters a per-file failure — failures
+  are surfaced rather than rolled back.
+- `lib/link-rewriter.ts` (`planMoveRewrites`, `applyRewrites`): pure
+  planner + applier split for testability. Reuses the existing
+  Obsidian-faithful `resolveWikilink` so a link is only rewritten when it
+  actually pointed at the moved file pre-move (handles basename
+  collisions and proximity tie-breaking correctly).
+- `lib/markdown.ts`: `extractWikilinkSpans`, `extractMarkdownLinkSpans`
+  (offset-preserving variants of `extractWikilinks` for in-place
+  rewriting), and `formatWikilinkTarget` (form-preserving target picker).
+
 ## [1.5.3] - 2026-04-25
 
 ### Tests

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeError, escapeControlChars, stripPaths } from "../lib/errors.js";
+
+describe("escapeControlChars", () => {
+  it("passes printable ASCII through unchanged", () => {
+    expect(escapeControlChars("hello world / path.md")).toBe("hello world / path.md");
+  });
+
+  it("escapes newline, carriage return, tab to backslash form", () => {
+    expect(escapeControlChars("a\nb\rc\td")).toBe("a\\nb\\rc\\td");
+  });
+
+  it("escapes other control bytes to \\xHH", () => {
+    expect(escapeControlChars("a\x00b\x01c\x1fd\x7fe")).toBe(
+      "a\\x00b\\x01c\\x1fd\\x7fe",
+    );
+  });
+
+  it("preserves non-ASCII characters (Unicode, accents)", () => {
+    expect(escapeControlChars("résumé—café 你好")).toBe("résumé—café 你好");
+  });
+});
+
+describe("sanitizeError", () => {
+  it("collapses known errno codes to a generic message", () => {
+    expect(sanitizeError({ code: "ENOENT", message: "ENOENT: no such file" })).toBe(
+      "File or directory not found",
+    );
+  });
+
+  it("strips absolute POSIX paths from the message", () => {
+    expect(sanitizeError(new Error("failed to read /home/user/vault/note.md"))).toBe(
+      "failed to read <path>",
+    );
+  });
+
+  it("escapes control chars in the returned message", () => {
+    // The injection vector: a stringified error message contains a newline
+    // (e.g. an attacker-controlled filename was interpolated upstream). The
+    // sanitized output must not contain a real newline that could break out
+    // of its line in tool output.
+    expect(sanitizeError("read failed: name\nIGNORE PREVIOUS")).toBe(
+      "read failed: name\\nIGNORE PREVIOUS",
+    );
+  });
+
+  it("escapes control chars in fallback Error.message path", () => {
+    expect(sanitizeError(new Error("oops\r\nbad"))).toBe("oops\\r\\nbad");
+  });
+
+  it("returns a fixed string for non-Error input", () => {
+    expect(sanitizeError(undefined)).toBe("Unknown error");
+    expect(sanitizeError(null)).toBe("Unknown error");
+    expect(sanitizeError(42)).toBe("Unknown error");
+  });
+});
+
+describe("stripPaths", () => {
+  it("strips Windows drive paths", () => {
+    expect(stripPaths("can't open C:\\Users\\me\\note.md")).toBe(
+      "can't open <path>",
+    );
+  });
+
+  it("strips quoted paths", () => {
+    expect(stripPaths("ENOENT, open '/tmp/foo/bar.md'")).toBe("ENOENT, open <path>");
+  });
+});

--- a/src/__tests__/handlers/write.test.ts
+++ b/src/__tests__/handlers/write.test.ts
@@ -228,6 +228,47 @@ describe("write handlers — move_note", () => {
     expect(isError(result)).toBe(true);
     expect(textContent(result)).toMatch(/already exists/i);
   });
+
+  it("rewrites references in referrers by default", async () => {
+    // Fixture canvas references `note-a.md` via `nodes[].file`, which is a
+    // structured path reference and must follow the move.
+    const result = await env.client.callTool({
+      name: "move_note",
+      arguments: { oldPath: "note-a.md", newPath: "archive/2026/note-a.md" },
+    });
+    expect(isError(result)).toBe(false);
+    expect(textContent(result)).toMatch(/Updated references in \d+ file\(s\)/);
+
+    const canvasRaw = await fs.readFile(
+      path.join(env.vaultDir, "boards/test.canvas"),
+      "utf-8",
+    );
+    const canvas = JSON.parse(canvasRaw);
+    const fileNode = canvas.nodes.find((n: { type: string }) => n.type === "file");
+    expect(fileNode.file).toBe("archive/2026/note-a.md");
+  });
+
+  it("updateLinks: false skips the rewrite pass", async () => {
+    const result = await env.client.callTool({
+      name: "move_note",
+      arguments: {
+        oldPath: "note-a.md",
+        newPath: "archive/note-a.md",
+        updateLinks: false,
+      },
+    });
+    expect(isError(result)).toBe(false);
+    expect(textContent(result)).not.toMatch(/Updated references/);
+
+    // Canvas reference is left dangling — exactly the legacy behavior.
+    const canvasRaw = await fs.readFile(
+      path.join(env.vaultDir, "boards/test.canvas"),
+      "utf-8",
+    );
+    const canvas = JSON.parse(canvasRaw);
+    const fileNode = canvas.nodes.find((n: { type: string }) => n.type === "file");
+    expect(fileNode.file).toBe("note-a.md");
+  });
 });
 
 describe("write handlers — delete_note", () => {

--- a/src/__tests__/link-rewriter.test.ts
+++ b/src/__tests__/link-rewriter.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
-import { moveNote, readNote, writeNote } from "../lib/vault.js";
+import { listNotes, moveNote, readNote, writeNote } from "../lib/vault.js";
+import { planMoveRewrites, applyRewrites } from "../lib/link-rewriter.js";
 
 let vaultDir: string;
 
@@ -262,5 +263,89 @@ describe("moveNote — wikilink rewriting", () => {
     expect(out).toContain("![[archive/topic]]");
     expect(out).toContain("[link](archive/topic.md)");
     expect(out).toContain("[link](archive/topic)");
+  });
+});
+
+describe("applyRewrites — TOCTOU safety", () => {
+  it("aborts a referrer rewrite when bytes shift between plan and apply", async () => {
+    // Race: plan is built against `ref.md` v1, then a parallel `write_note`
+    // prepends a paragraph and shifts every wikilink offset before
+    // `applyRewrites` runs. Bounds-only validation would still pass and we'd
+    // splice the wrong bytes; the `expected` check catches it.
+    await seed("inbox/idea.md", "# Idea");
+    await seed("ref.md", "See [[inbox/idea]] please.");
+
+    const preMoveNotes = await listNotes(vaultDir);
+    const plan = await planMoveRewrites(
+      vaultDir,
+      "inbox/idea.md",
+      "archive/idea.md",
+      preMoveNotes,
+    );
+
+    const racedContent =
+      "Inserted paragraph that shifts everything.\n\nSee [[inbox/idea]] please.";
+    await fs.writeFile(path.join(vaultDir, "ref.md"), racedContent, "utf-8");
+
+    const result = await applyRewrites(vaultDir, plan);
+
+    expect(result.updated).toEqual([]);
+    expect(result.failed).toEqual([
+      { path: "ref.md", error: "content changed during move; references not updated" },
+    ]);
+
+    // Crucially: ref.md was not corrupted by a misaligned splice.
+    const finalContent = await fs.readFile(path.join(vaultDir, "ref.md"), "utf-8");
+    expect(finalContent).toBe(racedContent);
+  });
+
+  it("aborts when bytes at the same offsets changed in place (no length shift)", async () => {
+    // Subtle case: a parallel edit replaces the wikilink with a different
+    // wikilink of identical length. Bounds still pass, but the `expected`
+    // slice now mismatches — apply must refuse.
+    await seed("inbox/idea.md", "# Idea");
+    await seed("ref.md", "See [[inbox/idea]] now.");
+
+    const preMoveNotes = await listNotes(vaultDir);
+    const plan = await planMoveRewrites(
+      vaultDir,
+      "inbox/idea.md",
+      "archive/idea.md",
+      preMoveNotes,
+    );
+
+    // Same byte length as `[[inbox/idea]]` (14), keeps every offset intact.
+    const racedContent = "See [[other/note]] now.";
+    expect(racedContent.length).toBe("See [[inbox/idea]] now.".length);
+    await fs.writeFile(path.join(vaultDir, "ref.md"), racedContent, "utf-8");
+
+    const result = await applyRewrites(vaultDir, plan);
+
+    expect(result.updated).toEqual([]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].path).toBe("ref.md");
+    const finalContent = await fs.readFile(path.join(vaultDir, "ref.md"), "utf-8");
+    expect(finalContent).toBe(racedContent);
+  });
+
+  it("succeeds when the referrer is unchanged between plan and apply", async () => {
+    // Positive control: with no concurrent modification, the plan applies
+    // cleanly — confirming `expected` doesn't reject the happy path.
+    await seed("inbox/idea.md", "# Idea");
+    await seed("ref.md", "See [[inbox/idea]] please.");
+
+    const preMoveNotes = await listNotes(vaultDir);
+    const plan = await planMoveRewrites(
+      vaultDir,
+      "inbox/idea.md",
+      "archive/idea.md",
+      preMoveNotes,
+    );
+
+    const result = await applyRewrites(vaultDir, plan);
+
+    expect(result.failed).toEqual([]);
+    expect(result.updated).toEqual(["ref.md"]);
+    expect(await readNote(vaultDir, "ref.md")).toBe("See [[archive/idea]] please.");
   });
 });

--- a/src/__tests__/link-rewriter.test.ts
+++ b/src/__tests__/link-rewriter.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import { moveNote, readNote, writeNote } from "../lib/vault.js";
+
+let vaultDir: string;
+
+beforeEach(async () => {
+  vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "rewriter-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(vaultDir, { recursive: true, force: true });
+});
+
+async function seed(rel: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(path.join(vaultDir, rel)), { recursive: true });
+  await fs.writeFile(path.join(vaultDir, rel), content, "utf-8");
+}
+
+describe("moveNote — wikilink rewriting", () => {
+  it("preserves a basename wikilink unchanged when basename stays unambiguous", async () => {
+    // `[[idea]]` is the bare basename. After moving inbox/idea.md →
+    // archive/idea.md the basename is still unique, so the link doesn't need
+    // to be rewritten — and the referrer's mtime is preserved.
+    await seed("inbox/idea.md", "# Idea");
+    await seed("projects/index.md", "See [[idea]] for details.");
+    const result = await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    expect(await readNote(vaultDir, "projects/index.md")).toBe(
+      "See [[idea]] for details.",
+    );
+    // No actual write occurred — the rewrite was a no-op, so no entry here.
+    expect(result.updatedReferrers).toEqual([]);
+    expect(result.failedReferrers).toEqual([]);
+  });
+
+  it("reports referrers that actually had content rewritten", async () => {
+    await seed("inbox/idea.md", "# Idea");
+    await seed("projects/index.md", "See [[inbox/idea]].");
+    const result = await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    expect(result.updatedReferrers).toEqual(["projects/index.md"]);
+    expect(result.failedReferrers).toEqual([]);
+  });
+
+  it("rewrites a path-form wikilink to the new path", async () => {
+    await seed("inbox/idea.md", "# Idea");
+    await seed("projects/index.md", "See [[inbox/idea]].");
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    expect(await readNote(vaultDir, "projects/index.md")).toBe(
+      "See [[archive/idea]].",
+    );
+  });
+
+  it("preserves alias on rewrite", async () => {
+    await seed("inbox/idea.md", "# Idea");
+    await seed("ref.md", "[[inbox/idea|the idea]]");
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    expect(await readNote(vaultDir, "ref.md")).toBe("[[archive/idea|the idea]]");
+  });
+
+  it("preserves heading fragment", async () => {
+    await seed("inbox/idea.md", "# Idea\n## Detail");
+    await seed("ref.md", "[[inbox/idea#Detail]]");
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    expect(await readNote(vaultDir, "ref.md")).toBe("[[archive/idea#Detail]]");
+  });
+
+  it("preserves block-id fragment", async () => {
+    await seed("inbox/idea.md", "Body ^abc");
+    await seed("ref.md", "[[inbox/idea#^abc]]");
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    expect(await readNote(vaultDir, "ref.md")).toBe("[[archive/idea#^abc]]");
+  });
+
+  it("preserves the embed prefix", async () => {
+    await seed("inbox/idea.md", "body");
+    await seed("ref.md", "before ![[inbox/idea]] after");
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    expect(await readNote(vaultDir, "ref.md")).toBe("before ![[archive/idea]] after");
+  });
+
+  it("rewrites markdown link with .md extension", async () => {
+    await seed("inbox/idea.md", "x");
+    await seed("ref.md", "[link](inbox/idea.md) here");
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    expect(await readNote(vaultDir, "ref.md")).toBe("[link](archive/idea.md) here");
+  });
+
+  it("rewrites markdown link without extension and preserves fragment", async () => {
+    await seed("inbox/idea.md", "x");
+    await seed("ref.md", "[link](inbox/idea#Section)");
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    expect(await readNote(vaultDir, "ref.md")).toBe("[link](archive/idea#Section)");
+  });
+
+  it("does not rewrite external URLs that happen to contain a similar path", async () => {
+    await seed("inbox/idea.md", "x");
+    await seed("ref.md", "[a](https://example.com/inbox/idea.md)");
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    expect(await readNote(vaultDir, "ref.md")).toBe(
+      "[a](https://example.com/inbox/idea.md)",
+    );
+  });
+
+  it("does not rewrite wikilinks inside fenced code blocks", async () => {
+    await seed("inbox/idea.md", "x");
+    const body = ["normal [[inbox/idea]]", "```", "[[inbox/idea]]", "```"].join("\n");
+    await seed("ref.md", body);
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    const out = await readNote(vaultDir, "ref.md");
+    expect(out).toContain("normal [[archive/idea]]");
+    expect(out).toContain("```\n[[inbox/idea]]\n```");
+  });
+
+  it("does not touch files that don't reference the moved note", async () => {
+    await seed("a.md", "# A");
+    await seed("b.md", "[[a]]");
+    await seed("c.md", "unrelated content");
+    const before = (await fs.stat(path.join(vaultDir, "c.md"))).mtimeMs;
+    await new Promise((r) => setTimeout(r, 10));
+    const result = await moveNote(vaultDir, "a.md", "moved.md");
+    const after = (await fs.stat(path.join(vaultDir, "c.md"))).mtimeMs;
+    expect(after).toBe(before);
+    expect(result.updatedReferrers).toEqual(["b.md"]);
+  });
+
+  it("self-reference inside the moved file is not touched", async () => {
+    await seed("idea.md", "I am [[idea]] myself");
+    await moveNote(vaultDir, "idea.md", "archive/idea.md");
+    expect(await readNote(vaultDir, "archive/idea.md")).toBe(
+      "I am [[idea]] myself",
+    );
+  });
+
+  it("falls back to path form when post-move basename collides", async () => {
+    await seed("inbox/idea.md", "moving");
+    await seed("projects/idea.md", "different note same name");
+    await seed("ref.md", "[[inbox/idea]]");
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    // Two `idea.md` exist post-move (projects + archive). Bare basename would
+    // be ambiguous, so the rewrite must use the path form.
+    expect(await readNote(vaultDir, "ref.md")).toBe("[[archive/idea]]");
+  });
+
+  it("preserves bare-basename form when still unambiguous post-move", async () => {
+    await seed("inbox/idea.md", "x");
+    await seed("ref.md", "[[idea]]");
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    expect(await readNote(vaultDir, "ref.md")).toBe("[[idea]]");
+  });
+
+  it("does not rewrite links that resolved to a different basename match", async () => {
+    // `[[idea]]` from `projects/index.md` resolves to `projects/idea.md` by
+    // proximity, NOT to `inbox/idea.md`. Moving `inbox/idea.md` must leave
+    // that link alone.
+    await seed("inbox/idea.md", "moving");
+    await seed("projects/idea.md", "stays put");
+    await seed("projects/index.md", "[[idea]]");
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    expect(await readNote(vaultDir, "projects/index.md")).toBe("[[idea]]");
+  });
+
+  it("updateLinks: false skips the rewrite pass entirely", async () => {
+    await seed("inbox/idea.md", "x");
+    await seed("ref.md", "[[inbox/idea]]");
+    const result = await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md", {
+      updateLinks: false,
+    });
+    expect(await readNote(vaultDir, "ref.md")).toBe("[[inbox/idea]]");
+    expect(result.updatedReferrers).toEqual([]);
+  });
+
+  it("rewrites canvas nodes[].file references", async () => {
+    await seed("inbox/idea.md", "x");
+    const canvas = {
+      nodes: [
+        {
+          id: "n1",
+          type: "file",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          file: "inbox/idea.md",
+        },
+        {
+          id: "n2",
+          type: "text",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          text: "hello",
+        },
+      ],
+      edges: [],
+    };
+    await seed("board.canvas", JSON.stringify(canvas, null, 2));
+    const result = await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+    const updated = JSON.parse(
+      await fs.readFile(path.join(vaultDir, "board.canvas"), "utf-8"),
+    );
+    expect(updated.nodes[0].file).toBe("archive/idea.md");
+    expect(updated.nodes[1].text).toBe("hello");
+    expect(result.updatedReferrers).toContain("board.canvas");
+  });
+
+  it("rewrites multiple links in a single line", async () => {
+    await seed("a.md", "");
+    await seed("ref.md", "[[a]] and [[a|x]] and [[a#h]] all on one line");
+    await moveNote(vaultDir, "a.md", "moved.md");
+    expect(await readNote(vaultDir, "ref.md")).toBe(
+      "[[moved]] and [[moved|x]] and [[moved#h]] all on one line",
+    );
+  });
+
+  it("returns empty arrays when nothing references the moved file", async () => {
+    await seed("orphan.md", "alone");
+    const result = await moveNote(vaultDir, "orphan.md", "archive/orphan.md");
+    expect(result.updatedReferrers).toEqual([]);
+    expect(result.failedReferrers).toEqual([]);
+  });
+
+  it("respects the existing per-destination existence check", async () => {
+    await seed("a.md", "");
+    await seed("b.md", "");
+    await seed("ref.md", "[[a]]");
+    await expect(moveNote(vaultDir, "a.md", "b.md")).rejects.toThrow(
+      "Destination already exists",
+    );
+    // No referrer should have been mutated since the rename failed.
+    expect(await readNote(vaultDir, "ref.md")).toBe("[[a]]");
+  });
+
+  it("integration: vault-wide reorganization with mixed reference styles", async () => {
+    await seed("topic.md", "# Topic\n\n## Detail ^anchor");
+    await seed(
+      "summary.md",
+      [
+        "Wikilink: [[topic]].",
+        "Path: [[old/topic]].",
+        "Alias: [[topic|the topic]].",
+        "Heading: [[topic#Detail]].",
+        "Block: [[topic#^anchor]].",
+        "Embed: ![[topic]].",
+        "MD: [link](topic.md).",
+        "MD path: [link](topic).",
+      ].join("\n"),
+    );
+    await writeNote(vaultDir, "old/topic.md", "alias resolution probe");
+    // The above seeds two notes both basename-`topic`. Move the root one;
+    // every basename reference in summary.md was resolving to it (closer to
+    // root via the proximity tie-break), so they should all rewrite — falling
+    // back to path form because basename is now ambiguous.
+    await moveNote(vaultDir, "topic.md", "archive/topic.md");
+    const out = await readNote(vaultDir, "summary.md");
+    expect(out).toContain("[[archive/topic]]");
+    expect(out).toContain("[[archive/topic|the topic]]");
+    expect(out).toContain("[[archive/topic#Detail]]");
+    expect(out).toContain("[[archive/topic#^anchor]]");
+    expect(out).toContain("![[archive/topic]]");
+    expect(out).toContain("[link](archive/topic.md)");
+    expect(out).toContain("[link](archive/topic)");
+  });
+});

--- a/src/__tests__/markdown.test.ts
+++ b/src/__tests__/markdown.test.ts
@@ -3,6 +3,9 @@ import {
   parseFrontmatter,
   updateFrontmatter,
   extractWikilinks,
+  extractWikilinkSpans,
+  extractMarkdownLinkSpans,
+  formatWikilinkTarget,
   extractTags,
   extractAliases,
   resolveWikilink,
@@ -388,5 +391,150 @@ Body.`;
     const content = "No frontmatter, plain body.";
     const meta = buildNoteMetadata("/vault", "notes/my-note.md", content, stats);
     expect(meta.title).toBe("my-note");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractWikilinkSpans
+// ---------------------------------------------------------------------------
+describe("extractWikilinkSpans", () => {
+  it("returns offsets covering the full [[...]] match", () => {
+    const c = "see [[foo]] then";
+    const spans = extractWikilinkSpans(c);
+    expect(spans).toHaveLength(1);
+    expect(c.slice(spans[0].start, spans[0].end)).toBe("[[foo]]");
+    expect(spans[0].target).toBe("foo");
+    expect(spans[0].fragment).toBe("");
+    expect(spans[0].alias).toBeUndefined();
+    expect(spans[0].isEmbed).toBe(false);
+  });
+
+  it("captures embed prefix in the span", () => {
+    const c = "img: ![[pic.png]]";
+    const spans = extractWikilinkSpans(c);
+    expect(spans[0].isEmbed).toBe(true);
+    expect(c.slice(spans[0].start, spans[0].end)).toBe("![[pic.png]]");
+  });
+
+  it("splits alias and fragment", () => {
+    const c = "x [[note#Heading|Display]] y";
+    const [span] = extractWikilinkSpans(c);
+    expect(span.target).toBe("note");
+    expect(span.fragment).toBe("#Heading");
+    expect(span.alias).toBe("Display");
+  });
+
+  it("handles block-id fragments", () => {
+    const [span] = extractWikilinkSpans("ref [[note#^abc123]] here");
+    expect(span.target).toBe("note");
+    expect(span.fragment).toBe("#^abc123");
+  });
+
+  it("skips wikilinks inside fenced code blocks", () => {
+    const c = ["before [[real]]", "```", "[[notreal]]", "```", "after"].join("\n");
+    const spans = extractWikilinkSpans(c);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].target).toBe("real");
+  });
+
+  it("skips wikilinks inside inline code", () => {
+    const c = "kept [[hit]] but `[[skip]]` not";
+    const spans = extractWikilinkSpans(c);
+    expect(spans.map((s) => s.target)).toEqual(["hit"]);
+  });
+
+  it("captures multiple links per line with correct offsets", () => {
+    const c = "[[a]] then [[b]] then [[c]]";
+    const spans = extractWikilinkSpans(c);
+    expect(spans.map((s) => c.slice(s.start, s.end))).toEqual([
+      "[[a]]",
+      "[[b]]",
+      "[[c]]",
+    ]);
+  });
+
+  it("offsets account for newlines across lines", () => {
+    const c = "line one\nline two [[target]] here\nthird";
+    const [span] = extractWikilinkSpans(c);
+    expect(c.slice(span.start, span.end)).toBe("[[target]]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractMarkdownLinkSpans
+// ---------------------------------------------------------------------------
+describe("extractMarkdownLinkSpans", () => {
+  it("extracts a basic [text](url) link", () => {
+    const c = "[hello](world.md) yes";
+    const [span] = extractMarkdownLinkSpans(c);
+    expect(c.slice(span.start, span.end)).toBe("[hello](world.md)");
+    expect(span.text).toBe("hello");
+    expect(span.urlPath).toBe("world.md");
+    expect(span.fragment).toBe("");
+    expect(span.isEmbed).toBe(false);
+  });
+
+  it("splits the URL fragment", () => {
+    const [span] = extractMarkdownLinkSpans("[x](a/b.md#Heading)");
+    expect(span.urlPath).toBe("a/b.md");
+    expect(span.fragment).toBe("#Heading");
+  });
+
+  it("captures embed prefix", () => {
+    const [span] = extractMarkdownLinkSpans("![alt](pic.png)");
+    expect(span.isEmbed).toBe(true);
+  });
+
+  it("captures trailing title without losing it", () => {
+    const c = '[a](url.md "the title")';
+    const [span] = extractMarkdownLinkSpans(c);
+    expect(span.urlPath).toBe("url.md");
+    expect(span.title).toBe(' "the title"');
+    expect(c.slice(span.start, span.end)).toBe(c);
+  });
+
+  it("skips markdown links inside fenced code blocks", () => {
+    const c = "[real](r.md)\n```\n[skip](s.md)\n```\n[also-real](r2.md)";
+    const spans = extractMarkdownLinkSpans(c);
+    expect(spans.map((s) => s.urlPath)).toEqual(["r.md", "r2.md"]);
+  });
+
+  it("skips markdown links inside inline code", () => {
+    const c = "[a](b.md) and `[c](d.md)` and [e](f.md)";
+    const spans = extractMarkdownLinkSpans(c);
+    expect(spans.map((s) => s.urlPath)).toEqual(["b.md", "f.md"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatWikilinkTarget
+// ---------------------------------------------------------------------------
+describe("formatWikilinkTarget", () => {
+  it("keeps basename form when post-move basename is unambiguous", () => {
+    const out = formatWikilinkTarget("projects/idea.md", "idea", [
+      "projects/idea.md",
+      "other.md",
+    ]);
+    expect(out).toBe("idea");
+  });
+
+  it("falls back to path form when basename collides", () => {
+    const out = formatWikilinkTarget("archive/idea.md", "idea", [
+      "archive/idea.md",
+      "projects/idea.md",
+    ]);
+    expect(out).toBe("archive/idea");
+  });
+
+  it("preserves path form when original used a path", () => {
+    const out = formatWikilinkTarget("projects/idea.md", "inbox/idea", [
+      "projects/idea.md",
+    ]);
+    expect(out).toBe("projects/idea");
+  });
+
+  it("strips the .md extension on output", () => {
+    const out = formatWikilinkTarget("a/b/c.md", "c", ["a/b/c.md"]);
+    expect(out).toBe("c");
   });
 });

--- a/src/__tests__/markdown.test.ts
+++ b/src/__tests__/markdown.test.ts
@@ -135,6 +135,40 @@ describe("extractWikilinks", () => {
     expect(links).toHaveLength(0);
   });
 
+  it("should ignore links inside double-backtick inline code", () => {
+    // ``code with ` inside`` is a CommonMark code span; the wikilink within
+    // must not be extracted. The single-backtick regex used previously
+    // missed this and rewrote into the code span.
+    const links = extractWikilinks("Use ``with ` and [[skip]]`` outside [[hit]].");
+    expect(links.map((l) => l.target)).toEqual(["hit"]);
+  });
+
+  it("should ignore links inside 4-space indented code blocks", () => {
+    const content = [
+      "Paragraph above.",
+      "",
+      "    [[indented-code]]",
+      "",
+      "After [[hit]].",
+    ].join("\n");
+    const links = extractWikilinks(content);
+    expect(links.map((l) => l.target)).toEqual(["hit"]);
+  });
+
+  it("should ignore links inside tab-indented code blocks", () => {
+    const content = ["Para.", "", "\t[[skip]]", "", "[[hit]]"].join("\n");
+    const links = extractWikilinks(content);
+    expect(links.map((l) => l.target)).toEqual(["hit"]);
+  });
+
+  it("does not treat a 4-space-indented paragraph continuation as code", () => {
+    // No blank line before the indent — it's a paragraph continuation, not
+    // an indented code block, per CommonMark. The link should still be seen.
+    const content = "Paragraph one\n    [[continuation]] still in para";
+    const links = extractWikilinks(content);
+    expect(links.map((l) => l.target)).toEqual(["continuation"]);
+  });
+
   it("should handle [[note#heading]] with anchor", () => {
     const links = extractWikilinks("See [[note#heading]].");
     expect(links).toHaveLength(1);
@@ -443,6 +477,26 @@ describe("extractWikilinkSpans", () => {
     expect(spans.map((s) => s.target)).toEqual(["hit"]);
   });
 
+  it("skips wikilinks inside double-backtick inline code", () => {
+    const c = "outer [[hit]] then ``inside ` and [[skip]]`` end";
+    const spans = extractWikilinkSpans(c);
+    expect(spans.map((s) => s.target)).toEqual(["hit"]);
+  });
+
+  it("skips wikilinks inside triple-backtick inline code on the same line", () => {
+    // CommonMark allows `` ``` ``code with `` inside ``` `` `` as inline code
+    // when the line isn't a fence opener (fences must be at line start).
+    const c = "foo ```text with `` and [[skip]]``` bar [[hit]]";
+    const spans = extractWikilinkSpans(c);
+    expect(spans.map((s) => s.target)).toEqual(["hit"]);
+  });
+
+  it("skips wikilinks inside 4-space indented code blocks", () => {
+    const c = ["before [[real]]", "", "    [[skip-me]]", "", "after"].join("\n");
+    const spans = extractWikilinkSpans(c);
+    expect(spans.map((s) => s.target)).toEqual(["real"]);
+  });
+
   it("captures multiple links per line with correct offsets", () => {
     const c = "[[a]] then [[b]] then [[c]]";
     const spans = extractWikilinkSpans(c);
@@ -503,6 +557,18 @@ describe("extractMarkdownLinkSpans", () => {
     const c = "[a](b.md) and `[c](d.md)` and [e](f.md)";
     const spans = extractMarkdownLinkSpans(c);
     expect(spans.map((s) => s.urlPath)).toEqual(["b.md", "f.md"]);
+  });
+
+  it("skips markdown links inside double-backtick inline code", () => {
+    const c = "[hit](a.md) then ``inline ` [skip](b.md)`` end";
+    const spans = extractMarkdownLinkSpans(c);
+    expect(spans.map((s) => s.urlPath)).toEqual(["a.md"]);
+  });
+
+  it("skips markdown links inside 4-space indented code blocks", () => {
+    const c = "[hit](a.md)\n\n    [skip](b.md)\n\n[also-hit](c.md)";
+    const spans = extractMarkdownLinkSpans(c);
+    expect(spans.map((s) => s.urlPath)).toEqual(["a.md", "c.md"]);
   });
 });
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -51,9 +51,14 @@ export function sanitizeError(err: unknown): string {
  * characters `\` and `n`; other control bytes use `\xHH`. Printable input
  * passes through unchanged.
  *
- * Use on values that are about to be interpolated into MCP tool output but
- * are not themselves an Error (file paths, identifiers); for Errors and raw
- * error strings, prefer `sanitizeError`, which already calls this internally.
+ * Exists as a separate export from `sanitizeError` because that function's
+ * path-stripping step would rewrite a path-shaped value to literal `<path>`
+ * — fine inside an error message that mentions a host path, but it would
+ * erase the value when the value itself is the path you want to display
+ * (e.g. `f.path` from `failedReferrers`). Both functions apply the same
+ * control-char escape, so passing `f.path` here and `f.error` to
+ * `sanitizeError` gives equivalent injection protection through different
+ * doors.
  */
 export function escapeControlChars(s: string): string {
   return s.replace(/[\x00-\x1f\x7f]/g, (c) => {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -26,11 +26,14 @@ interface ErrnoLike {
 
 /**
  * Convert an unknown thrown value into a message safe to return to an MCP
- * client. Strips absolute paths, stack traces, and collapses known errno
- * codes to generic human-readable text.
+ * client. Strips absolute paths, stack traces, collapses known errno
+ * codes to generic human-readable text, and escapes control characters so
+ * an attacker-controlled value (e.g. a filename with `\n` in it embedded
+ * in an error message) can't break out of its line and inject text into
+ * the LLM context.
  */
 export function sanitizeError(err: unknown): string {
-  if (typeof err === "string") return stripPaths(err);
+  if (typeof err === "string") return escapeControlChars(stripPaths(err));
   if (!err || typeof err !== "object") return "Unknown error";
 
   const e = err as ErrnoLike;
@@ -38,7 +41,27 @@ export function sanitizeError(err: unknown): string {
   if (code && FS_ERROR_MESSAGES[code]) return FS_ERROR_MESSAGES[code];
 
   const msg = typeof e.message === "string" ? e.message : String(err);
-  return stripPaths(msg);
+  return escapeControlChars(stripPaths(msg));
+}
+
+/**
+ * Escape ASCII control characters (newlines, carriage returns, tabs, NULs,
+ * etc.) so an attacker-controlled string interpolated into a multi-line tool
+ * response can't break out of its line. `\n` becomes the two literal
+ * characters `\` and `n`; other control bytes use `\xHH`. Printable input
+ * passes through unchanged.
+ *
+ * Use on values that are about to be interpolated into MCP tool output but
+ * are not themselves an Error (file paths, identifiers); for Errors and raw
+ * error strings, prefer `sanitizeError`, which already calls this internally.
+ */
+export function escapeControlChars(s: string): string {
+  return s.replace(/[\x00-\x1f\x7f]/g, (c) => {
+    if (c === "\n") return "\\n";
+    if (c === "\r") return "\\r";
+    if (c === "\t") return "\\t";
+    return `\\x${c.charCodeAt(0).toString(16).padStart(2, "0")}`;
+  });
 }
 
 // Replace anything that looks like an absolute path with `<path>`. Covers:

--- a/src/lib/link-rewriter.ts
+++ b/src/lib/link-rewriter.ts
@@ -23,10 +23,16 @@ import type { CanvasData } from "../types.js";
 const SCAN_CONCURRENCY = 8;
 
 /** A single in-place edit on a referrer file, expressed as a byte-offset slice
- *  to replace. Edits within a file are listed in increasing-offset order. */
+ *  to replace. Edits within a file are listed in increasing-offset order.
+ *
+ *  `expected` captures the exact bytes at `[start, end)` at plan time. The
+ *  apply step compares against current contents so a parallel `write_note`
+ *  that mutated the referrer between plan and apply (offsets shift but
+ *  bounds still pass) doesn't silently splice the wrong bytes. */
 interface SpanEdit {
   start: number;
   end: number;
+  expected: string;
   replacement: string;
 }
 
@@ -126,8 +132,9 @@ export async function planMoveRewrites(
       // note may already be in the right form when the basename stays
       // unambiguous post-move. Reporting these as "updated" would be
       // misleading and would touch mtimes for nothing.
-      if (replacement === content.slice(span.start, span.end)) continue;
-      edits.push({ start: span.start, end: span.end, replacement });
+      const expected = content.slice(span.start, span.end);
+      if (replacement === expected) continue;
+      edits.push({ start: span.start, end: span.end, expected, replacement });
     }
 
     // Markdown `[text](url)` links. Resolve URL paths the same way wikilinks
@@ -150,8 +157,9 @@ export async function planMoveRewrites(
       const newBare = formatWikilinkTarget(newPath, decodedBare, postMoveNotes);
       const newUrl = encodeUrlPath(hadExt ? `${newBare}.md` : newBare);
       const replacement = `${span.isEmbed ? "!" : ""}[${span.text}](${newUrl}${span.fragment}${span.title})`;
-      if (replacement === content.slice(span.start, span.end)) continue;
-      edits.push({ start: span.start, end: span.end, replacement });
+      const expected = content.slice(span.start, span.end);
+      if (replacement === expected) continue;
+      edits.push({ start: span.start, end: span.end, expected, replacement });
     }
 
     if (edits.length > 0) {
@@ -226,15 +234,13 @@ export async function applyRewrites(
         const fullPath = await resolveVaultPathSafe(vaultPath, notePath);
         let didWrite = false;
         await withFileLock(fullPath, async () => {
-          // Re-read inside the lock so we apply edits to current content. Any
-          // change since planning may have shifted offsets — fall back to a
-          // resolver-based re-plan for this single file if a span no longer
-          // matches. Cheap to detect (compare content slice to expected
-          // pre-edit text isn't tracked, so re-extract instead).
+          // Re-read inside the lock so we apply edits to current content.
+          // applyEditsBackToFront verifies each edit's `expected` slice
+          // matches before splicing — a parallel `write_note` that landed
+          // between plan and apply will fail the comparison and we report
+          // the file rather than corrupting it.
           const current = await fs.readFile(fullPath, "utf-8");
-          const next = applyEditsBackToFront(current, edits, () =>
-            replanSingleNote(vaultPath, notePath, current, plan),
-          );
+          const next = applyEditsBackToFront(current, edits);
           if (next === null) {
             failed.push({
               path: notePath,
@@ -293,35 +299,27 @@ export async function applyRewrites(
 }
 
 /** Apply pre-sorted edits back-to-front. Returns `null` if any edit's span
- *  no longer matches the current content (means the file was modified between
- *  plan and apply); caller can decide whether to skip or re-plan. */
+ *  is out of bounds or if the bytes at `[start, end)` don't match the edit's
+ *  `expected` slice — which means the file was modified between plan and
+ *  apply (offsets shifted, or the link itself was rewritten). Caller treats
+ *  `null` as a failed referrer rather than corrupting the file. */
 function applyEditsBackToFront(
   content: string,
   edits: SpanEdit[],
-  _fallbackReplan: () => SpanEdit[] | null,
 ): string | null {
-  // Bounds-check from the back so subsequent edits don't shift offsets.
+  // Walk from the back so earlier offsets stay valid as we splice.
   let out = content;
   for (let i = edits.length - 1; i >= 0; i--) {
     const e = edits[i];
     if (e.start < 0 || e.end > out.length || e.start > e.end) {
       return null;
     }
+    if (out.slice(e.start, e.end) !== e.expected) {
+      return null;
+    }
     out = out.slice(0, e.start) + e.replacement + out.slice(e.end);
   }
   return out;
-}
-
-// Reserved for a future "content changed under us" recovery path. Keeping the
-// hook in `applyEditsBackToFront`'s signature documents the intent without
-// shipping a half-finished re-plan implementation today.
-function replanSingleNote(
-  _vaultPath: string,
-  _notePath: string,
-  _currentContent: string,
-  _plan: RewritePlan,
-): SpanEdit[] | null {
-  return null;
 }
 
 /** Tolerant `decodeURIComponent`: returns the input unchanged on malformed

--- a/src/lib/link-rewriter.ts
+++ b/src/lib/link-rewriter.ts
@@ -1,0 +1,343 @@
+import fs from "fs/promises";
+import path from "path";
+import {
+  listNotes,
+  listCanvasFiles,
+  readNote,
+  readCanvasFile,
+  resolveVaultPathSafe,
+  withFileLock,
+  atomicWriteFile,
+} from "./vault.js";
+import {
+  extractAliases,
+  extractWikilinkSpans,
+  extractMarkdownLinkSpans,
+  formatWikilinkTarget,
+  resolveWikilink,
+} from "./markdown.js";
+import { mapConcurrent } from "./concurrency.js";
+import { log } from "./logger.js";
+import type { CanvasData } from "../types.js";
+
+const SCAN_CONCURRENCY = 8;
+
+/** A single in-place edit on a referrer file, expressed as a byte-offset slice
+ *  to replace. Edits within a file are listed in increasing-offset order. */
+interface SpanEdit {
+  start: number;
+  end: number;
+  replacement: string;
+}
+
+/** A complete plan of edits across all referrer files. Canvas edits are
+ *  represented separately because they're applied via JSON re-serialization
+ *  rather than offset substitution. */
+export interface RewritePlan {
+  /** Markdown file edits keyed by vault-relative path. Empty map = no work. */
+  notes: Map<string, SpanEdit[]>;
+  /** Canvas files that need their `nodes[].file` field updated. */
+  canvases: string[];
+  /** Old vault-relative path being moved (with `.md` extension). */
+  oldPath: string;
+  /** New vault-relative path being moved to (with `.md` extension). */
+  newPath: string;
+}
+
+export interface ApplyResult {
+  /** Vault-relative paths whose contents were rewritten. */
+  updated: string[];
+  /** Per-file failures encountered during apply; rename has already committed
+   *  by the time this runs, so partial failures are surfaced rather than
+   *  rolled back. */
+  failed: Array<{ path: string; error: string }>;
+}
+
+/**
+ * Build an edit plan describing how to update every reference to `oldPath`
+ * across the vault so it points at `newPath` instead. Pure planning — does
+ * not write to disk. Caller is expected to invoke `applyRewrites` after the
+ * rename has committed.
+ *
+ * `preMoveNotes` is the list returned by `listNotes(vaultPath)` *before* the
+ * rename. Resolution is computed against this list so a wikilink that pointed
+ * at the moved file is correctly identified, even if a different note
+ * elsewhere happens to share its basename.
+ */
+export async function planMoveRewrites(
+  vaultPath: string,
+  oldPath: string,
+  newPath: string,
+  preMoveNotes: string[],
+): Promise<RewritePlan> {
+  // Build the post-move note set by substituting old → new. Used for picking
+  // the output form (basename vs path) that matches Obsidian's behavior.
+  const postMoveNotes = preMoveNotes.map((n) => (n === oldPath ? newPath : n));
+
+  // Build an alias map from the pre-move state. Mirrors the logic in
+  // tools/links.ts so resolution behavior is identical.
+  const aliasMap = new Map<string, string>();
+  await mapConcurrent(preMoveNotes, SCAN_CONCURRENCY, async (notePath) => {
+    let content: string;
+    try {
+      content = await readNote(vaultPath, notePath);
+    } catch {
+      return undefined;
+    }
+    for (const alias of extractAliases(content)) {
+      const key = alias.toLowerCase();
+      if (key) aliasMap.set(key, notePath);
+    }
+    return undefined;
+  });
+
+  const notesPlan = new Map<string, SpanEdit[]>();
+
+  // Markdown file pass.
+  await mapConcurrent(preMoveNotes, SCAN_CONCURRENCY, async (notePath) => {
+    let content: string;
+    try {
+      content = await readNote(vaultPath, notePath);
+    } catch (err) {
+      log.warn("link-rewriter: read failed during plan", {
+        note: notePath,
+        err: err as Error,
+      });
+      return undefined;
+    }
+
+    const edits: SpanEdit[] = [];
+
+    // Wikilinks.
+    for (const span of extractWikilinkSpans(content)) {
+      if (!span.target) continue;
+      const resolved = resolveWikilink(span.target, notePath, preMoveNotes, { aliasMap });
+      if (resolved !== oldPath) continue;
+
+      // Don't rewrite a self-reference inside the moved file itself — the
+      // file's path is changing too, so the link's resolution travels with
+      // the new file. Leaving it untouched is the simpler invariant.
+      if (notePath === oldPath) continue;
+
+      const newTarget = formatWikilinkTarget(newPath, span.target, postMoveNotes);
+      const aliasPart = span.alias !== undefined ? `|${span.alias}` : "";
+      const replacement = `${span.isEmbed ? "!" : ""}[[${newTarget}${span.fragment}${aliasPart}]]`;
+      // Skip no-op rewrites: a bare `[[idea]]` that resolves to the moved
+      // note may already be in the right form when the basename stays
+      // unambiguous post-move. Reporting these as "updated" would be
+      // misleading and would touch mtimes for nothing.
+      if (replacement === content.slice(span.start, span.end)) continue;
+      edits.push({ start: span.start, end: span.end, replacement });
+    }
+
+    // Markdown `[text](url)` links. Resolve URL paths the same way wikilinks
+    // resolve, so `[x](inbox/idea.md)` and `[x](inbox/idea)` both rewrite.
+    for (const span of extractMarkdownLinkSpans(content)) {
+      if (notePath === oldPath) continue;
+      const url = span.urlPath;
+      // Skip absolute / external URLs — only intra-vault references rewrite.
+      if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url) || url.startsWith("/")) continue;
+      const decoded = safeDecode(url);
+      const resolved = resolveWikilink(decoded, notePath, preMoveNotes, { aliasMap });
+      if (resolved !== oldPath) continue;
+
+      // Preserve the user's choice of with/without `.md` extension and their
+      // basename-vs-path style. `formatWikilinkTarget` handles the
+      // basename-collision check so a post-move ambiguous basename falls back
+      // to the full path automatically.
+      const hadExt = /\.md$/i.test(decoded);
+      const decodedBare = decoded.replace(/\.md$/i, "");
+      const newBare = formatWikilinkTarget(newPath, decodedBare, postMoveNotes);
+      const newUrl = encodeUrlPath(hadExt ? `${newBare}.md` : newBare);
+      const replacement = `${span.isEmbed ? "!" : ""}[${span.text}](${newUrl}${span.fragment}${span.title})`;
+      if (replacement === content.slice(span.start, span.end)) continue;
+      edits.push({ start: span.start, end: span.end, replacement });
+    }
+
+    if (edits.length > 0) {
+      // Edits within a file may have been produced in interleaved order
+      // (wikilinks then markdown links). Sort ascending so the apply step can
+      // walk back-to-front cleanly.
+      edits.sort((a, b) => a.start - b.start);
+      notesPlan.set(notePath, edits);
+    }
+    return undefined;
+  });
+
+  // Canvas pass — `nodes[].file` is the structured equivalent of a wikilink,
+  // and Obsidian stores the vault-relative path verbatim. Match by exact
+  // (case-insensitive) path equality on the old path.
+  const canvasPaths = await listCanvasFiles(vaultPath);
+  const oldLower = oldPath.toLowerCase();
+  const canvasesToRewrite: string[] = [];
+  await mapConcurrent(canvasPaths, SCAN_CONCURRENCY, async (cp) => {
+    let data: CanvasData;
+    try {
+      data = await readCanvasFile(vaultPath, cp);
+    } catch (err) {
+      log.warn("link-rewriter: canvas read failed during plan", {
+        note: cp,
+        err: err as Error,
+      });
+      return undefined;
+    }
+    for (const node of data.nodes) {
+      if (typeof node.file === "string" && node.file.toLowerCase() === oldLower) {
+        canvasesToRewrite.push(cp);
+        return undefined;
+      }
+    }
+    return undefined;
+  });
+
+  return {
+    notes: notesPlan,
+    canvases: canvasesToRewrite,
+    oldPath,
+    newPath,
+  };
+}
+
+/**
+ * Apply a previously-built `RewritePlan` to the vault. Each file is
+ * serialized through the existing per-file lock so concurrent MCP writes
+ * don't lose updates. Markdown edits are applied back-to-front to keep
+ * earlier offsets valid.
+ *
+ * Failures are accumulated, not thrown — the rename has already committed
+ * by the time we get here, so callers need to know which referrers landed
+ * and which need a manual retry.
+ */
+export async function applyRewrites(
+  vaultPath: string,
+  plan: RewritePlan,
+): Promise<ApplyResult> {
+  const updated: string[] = [];
+  const failed: Array<{ path: string; error: string }> = [];
+
+  // Markdown pass.
+  await mapConcurrent(
+    Array.from(plan.notes.keys()),
+    SCAN_CONCURRENCY,
+    async (notePath) => {
+      const edits = plan.notes.get(notePath);
+      if (!edits || edits.length === 0) return undefined;
+      try {
+        const fullPath = await resolveVaultPathSafe(vaultPath, notePath);
+        let didWrite = false;
+        await withFileLock(fullPath, async () => {
+          // Re-read inside the lock so we apply edits to current content. Any
+          // change since planning may have shifted offsets — fall back to a
+          // resolver-based re-plan for this single file if a span no longer
+          // matches. Cheap to detect (compare content slice to expected
+          // pre-edit text isn't tracked, so re-extract instead).
+          const current = await fs.readFile(fullPath, "utf-8");
+          const next = applyEditsBackToFront(current, edits, () =>
+            replanSingleNote(vaultPath, notePath, current, plan),
+          );
+          if (next === null) {
+            failed.push({
+              path: notePath,
+              error: "content changed during move; references not updated",
+            });
+            return;
+          }
+          if (next !== current) {
+            await atomicWriteFile(fullPath, next);
+            didWrite = true;
+          }
+        });
+        if (didWrite) updated.push(notePath);
+      } catch (err) {
+        failed.push({ path: notePath, error: (err as Error).message });
+      }
+      return undefined;
+    },
+  );
+
+  // Canvas pass.
+  for (const cp of plan.canvases) {
+    try {
+      const fullPath = await resolveVaultPathSafe(vaultPath, cp);
+      let didWrite = false;
+      await withFileLock(fullPath, async () => {
+        const raw = await fs.readFile(fullPath, "utf-8");
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          throw new Error(`Invalid canvas file (malformed JSON): ${cp}`);
+        }
+        const obj = (parsed && typeof parsed === "object" ? parsed : {}) as Record<string, unknown>;
+        const nodes = Array.isArray(obj.nodes) ? (obj.nodes as Array<Record<string, unknown>>) : [];
+        let mutated = false;
+        const oldLower = plan.oldPath.toLowerCase();
+        for (const node of nodes) {
+          if (typeof node.file === "string" && node.file.toLowerCase() === oldLower) {
+            node.file = plan.newPath;
+            mutated = true;
+          }
+        }
+        if (mutated) {
+          await atomicWriteFile(fullPath, JSON.stringify({ ...obj, nodes }, null, 2));
+          didWrite = true;
+        }
+      });
+      if (didWrite) updated.push(cp);
+    } catch (err) {
+      failed.push({ path: cp, error: (err as Error).message });
+    }
+  }
+
+  return { updated, failed };
+}
+
+/** Apply pre-sorted edits back-to-front. Returns `null` if any edit's span
+ *  no longer matches the current content (means the file was modified between
+ *  plan and apply); caller can decide whether to skip or re-plan. */
+function applyEditsBackToFront(
+  content: string,
+  edits: SpanEdit[],
+  _fallbackReplan: () => SpanEdit[] | null,
+): string | null {
+  // Bounds-check from the back so subsequent edits don't shift offsets.
+  let out = content;
+  for (let i = edits.length - 1; i >= 0; i--) {
+    const e = edits[i];
+    if (e.start < 0 || e.end > out.length || e.start > e.end) {
+      return null;
+    }
+    out = out.slice(0, e.start) + e.replacement + out.slice(e.end);
+  }
+  return out;
+}
+
+// Reserved for a future "content changed under us" recovery path. Keeping the
+// hook in `applyEditsBackToFront`'s signature documents the intent without
+// shipping a half-finished re-plan implementation today.
+function replanSingleNote(
+  _vaultPath: string,
+  _notePath: string,
+  _currentContent: string,
+  _plan: RewritePlan,
+): SpanEdit[] | null {
+  return null;
+}
+
+/** Tolerant `decodeURIComponent`: returns the input unchanged on malformed
+ *  percent-escapes rather than throwing. Vault paths sometimes contain raw
+ *  spaces or characters that aren't valid URI components. */
+function safeDecode(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}
+
+/** Encode a vault-relative path for use inside a markdown link URL. Keeps
+ *  forward slashes literal (they're path separators) while escaping spaces
+ *  and other characters that would break the `(...)` parser. */
+function encodeUrlPath(p: string): string {
+  return p.split("/").map(encodeURIComponent).join("/");
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -36,48 +36,90 @@ export function updateFrontmatter(
 }
 
 /**
- * Track whether a line is inside a fenced code block.
- * Returns a function that, given a line, returns true if the line
- * is inside a code block (should be skipped).
+ * Track whether a line is inside a code block. Recognizes both fenced blocks
+ * (triple-backtick / triple-tilde) and CommonMark indented code blocks
+ * (4-space or tab leader, after a blank line). Returns a function that, given
+ * a line, returns true if the line should be skipped.
+ *
+ * Indented-code detection follows the CommonMark rule that an indented code
+ * block cannot interrupt a paragraph, so a line indented by 4 spaces only
+ * counts as code when the previous line was blank (or another indented-code
+ * line, or document start). False positives — e.g. a 4-space-indented list
+ * continuation paragraph — are accepted: the link rewriter would rather miss
+ * a rewrite than corrupt code.
  */
 function createCodeBlockTracker(): (line: string) => boolean {
-  let insideCodeBlock = false;
+  let insideFence = false;
   let fenceChar = "";
   let fenceLength = 0;
+  let insideIndentedCode = false;
+  let prevWasBlank = true; // doc start qualifies for "after blank line" rule
   return (line: string): boolean => {
-    const trimmed = line.trimStart();
-    if (!insideCodeBlock) {
-      const backtickMatch = trimmed.match(/^(`{3,})/);
-      const tildeMatch = trimmed.match(/^(~{3,})/);
-      if (backtickMatch) {
-        insideCodeBlock = true;
-        fenceChar = "`";
-        fenceLength = backtickMatch[1].length;
-        return true;
+    if (insideFence) {
+      const closePattern = new RegExp(
+        `^${fenceChar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}{${fenceLength},}\\s*$`,
+      );
+      if (closePattern.test(line.trimStart())) {
+        insideFence = false;
       }
-      if (tildeMatch) {
-        insideCodeBlock = true;
-        fenceChar = "~";
-        fenceLength = tildeMatch[1].length;
-        return true;
-      }
-      return false;
-    } else {
-      const closePattern = new RegExp(`^${fenceChar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}{${fenceLength},}\\s*$`);
-      if (closePattern.test(trimmed)) {
-        insideCodeBlock = false;
-        return true;
-      }
+      prevWasBlank = false;
       return true;
     }
+    const trimmed = line.trimStart();
+    const backtickMatch = trimmed.match(/^(`{3,})/);
+    const tildeMatch = trimmed.match(/^(~{3,})/);
+    if (backtickMatch) {
+      insideFence = true;
+      fenceChar = "`";
+      fenceLength = backtickMatch[1].length;
+      insideIndentedCode = false;
+      prevWasBlank = false;
+      return true;
+    }
+    if (tildeMatch) {
+      insideFence = true;
+      fenceChar = "~";
+      fenceLength = tildeMatch[1].length;
+      insideIndentedCode = false;
+      prevWasBlank = false;
+      return true;
+    }
+    if (line.trim() === "") {
+      // Blank lines don't carry text to skip but they do permit the next
+      // indented line to start (or continue) an indented code block.
+      prevWasBlank = true;
+      return false;
+    }
+    const indented = /^(    |\t)/.test(line);
+    if (indented && (insideIndentedCode || prevWasBlank)) {
+      insideIndentedCode = true;
+      prevWasBlank = false;
+      return true;
+    }
+    if (!indented) {
+      insideIndentedCode = false;
+    }
+    prevWasBlank = false;
+    return false;
   };
 }
 
 /**
  * Strip inline code spans from a line so patterns inside them are ignored.
+ * Handles N-backtick spans (e.g. `` ``with ` inside`` ``), not just single
+ * backticks.
  */
 function stripInlineCode(line: string): string {
-  return line.replace(/`[^`]*`/g, "");
+  const ranges = findInlineCodeRanges(line);
+  if (ranges.length === 0) return line;
+  let out = "";
+  let cursor = 0;
+  for (const [s, e] of ranges) {
+    out += line.slice(cursor, s);
+    cursor = e;
+  }
+  out += line.slice(cursor);
+  return out;
 }
 
 /**
@@ -124,17 +166,45 @@ export function extractWikilinks(content: string): LinkInfo[] {
 }
 
 /**
- * Locate inline-code spans (delimited by single backticks) within a single
- * line. Returned ranges are half-open `[start, end)` byte offsets into the
- * input. Used by the rewriter to skip matches that fall inside inline code,
- * while preserving original offsets (unlike `stripInlineCode`).
+ * Locate inline-code spans within a single line. Handles N-backtick spans
+ * (CommonMark): an opening run of N backticks pairs with the next run of
+ * exactly N backticks, allowing shorter runs to appear inside (e.g.
+ * `` ``contains ` inside`` ``). Returned ranges are half-open `[start, end)`
+ * byte offsets into the input. Used by the rewriter to skip matches that
+ * fall inside inline code while preserving original offsets.
  */
 function findInlineCodeRanges(line: string): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
-  const re = /`[^`]*`/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(line)) !== null) {
-    ranges.push([m.index, m.index + m[0].length]);
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] !== "`") {
+      i++;
+      continue;
+    }
+    let openLen = 0;
+    while (i + openLen < line.length && line[i + openLen] === "`") openLen++;
+    let j = i + openLen;
+    let matched = false;
+    while (j < line.length) {
+      if (line[j] !== "`") {
+        j++;
+        continue;
+      }
+      let closeLen = 0;
+      while (j + closeLen < line.length && line[j + closeLen] === "`") closeLen++;
+      if (closeLen === openLen) {
+        ranges.push([i, j + closeLen]);
+        i = j + closeLen;
+        matched = true;
+        break;
+      }
+      j += closeLen;
+    }
+    if (!matched) {
+      // Unclosed run: advance past the opener and keep scanning. Rare in
+      // practice; matches the lenient behavior of the previous regex.
+      i += openLen;
+    }
   }
   return ranges;
 }

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -124,6 +124,192 @@ export function extractWikilinks(content: string): LinkInfo[] {
 }
 
 /**
+ * Locate inline-code spans (delimited by single backticks) within a single
+ * line. Returned ranges are half-open `[start, end)` byte offsets into the
+ * input. Used by the rewriter to skip matches that fall inside inline code,
+ * while preserving original offsets (unlike `stripInlineCode`).
+ */
+function findInlineCodeRanges(line: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  const re = /`[^`]*`/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(line)) !== null) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+  return ranges;
+}
+
+function isInRanges(offset: number, ranges: Array<[number, number]>): boolean {
+  for (const [s, e] of ranges) {
+    if (offset >= s && offset < e) return true;
+  }
+  return false;
+}
+
+/**
+ * A wikilink occurrence with original offsets and the inner pieces split out.
+ * Used by the link rewriter to do precise in-place substitution.
+ */
+export interface WikilinkSpan {
+  /** Byte offset where the leading `!` (or `[[`) begins. */
+  start: number;
+  /** Byte offset just past the closing `]]`. */
+  end: number;
+  /** Whether this is an `![[...]]` embed. */
+  isEmbed: boolean;
+  /** Target portion before any `|` or `#` (whitespace trimmed). */
+  target: string;
+  /** Heading or block-id fragment with leading `#`, or `""` if absent. */
+  fragment: string;
+  /** Display text after `|`, or `undefined` if none. */
+  alias?: string;
+}
+
+/**
+ * Extract every wikilink in `content` with original byte offsets, skipping
+ * fenced code blocks and inline code. Use when you need to rewrite a
+ * wikilink in place. For analysis only, prefer `extractWikilinks`.
+ */
+export function extractWikilinkSpans(content: string): WikilinkSpan[] {
+  const out: WikilinkSpan[] = [];
+  const isInsideCodeBlock = createCodeBlockTracker();
+  const wikilinkRegex = /(!)?\[\[([^\]\n]+?)\]\]/g;
+
+  let lineStart = 0;
+  for (const line of content.split("\n")) {
+    if (!isInsideCodeBlock(line)) {
+      const inlineRanges = findInlineCodeRanges(line);
+      wikilinkRegex.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = wikilinkRegex.exec(line)) !== null) {
+        const matchStart = m.index;
+        if (isInRanges(matchStart, inlineRanges)) continue;
+
+        const isEmbed = m[1] === "!";
+        const inner = m[2];
+        const pipeIndex = inner.indexOf("|");
+        const before = pipeIndex >= 0 ? inner.slice(0, pipeIndex) : inner;
+        const alias = pipeIndex >= 0 ? inner.slice(pipeIndex + 1).trim() : undefined;
+        const hashIndex = before.indexOf("#");
+        const target = (hashIndex >= 0 ? before.slice(0, hashIndex) : before).trim();
+        const fragment = hashIndex >= 0 ? before.slice(hashIndex) : "";
+
+        out.push({
+          start: lineStart + matchStart,
+          end: lineStart + matchStart + m[0].length,
+          isEmbed,
+          target,
+          fragment,
+          alias,
+        });
+      }
+    }
+    lineStart += line.length + 1; // +1 for the consumed "\n"
+  }
+  return out;
+}
+
+/**
+ * A markdown link occurrence with original offsets. Matches `[text](url)`
+ * (and the embed variant `![text](url)`). The URL is split into path + fragment
+ * so the rewriter can substitute the path while preserving `#heading` and any
+ * trailing title attribute.
+ */
+export interface MarkdownLinkSpan {
+  start: number;
+  end: number;
+  isEmbed: boolean;
+  /** Display text inside `[...]`. */
+  text: string;
+  /** URL path portion before any `#` fragment. */
+  urlPath: string;
+  /** Fragment beginning with `#`, or `""` if absent. */
+  fragment: string;
+  /** Trailing ` "title"` portion of the link, including leading space, or `""`. */
+  title: string;
+}
+
+/**
+ * Extract every markdown `[text](url)` link in `content` with original byte
+ * offsets. Skips fenced code blocks and inline code. Used by the link
+ * rewriter so vault reorganizations update plain markdown links alongside
+ * wikilinks.
+ */
+export function extractMarkdownLinkSpans(content: string): MarkdownLinkSpan[] {
+  const out: MarkdownLinkSpan[] = [];
+  const isInsideCodeBlock = createCodeBlockTracker();
+  // Permit a `!` embed prefix, then `[text](url)`. URLs without spaces; an
+  // optional ` "title"` suffix is captured separately. Bare `()` aren't
+  // supported in URLs (Obsidian itself encodes them) — keeping the URL char
+  // class strict avoids over-matching paragraph parens.
+  const re = /(!)?\[([^\]\n]*)\]\(([^\s)]+)(\s+"[^"\n]*")?\)/g;
+
+  let lineStart = 0;
+  for (const line of content.split("\n")) {
+    if (!isInsideCodeBlock(line)) {
+      const inlineRanges = findInlineCodeRanges(line);
+      re.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(line)) !== null) {
+        const matchStart = m.index;
+        if (isInRanges(matchStart, inlineRanges)) continue;
+
+        const isEmbed = m[1] === "!";
+        const text = m[2];
+        const url = m[3];
+        const title = m[4] ?? "";
+        const hashIndex = url.indexOf("#");
+        const urlPath = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+        const fragment = hashIndex >= 0 ? url.slice(hashIndex) : "";
+
+        out.push({
+          start: lineStart + matchStart,
+          end: lineStart + matchStart + m[0].length,
+          isEmbed,
+          text,
+          urlPath,
+          fragment,
+          title,
+        });
+      }
+    }
+    lineStart += line.length + 1;
+  }
+  return out;
+}
+
+/**
+ * Pick the wikilink target string for `newPath` that best preserves the
+ * `originalForm` the author wrote. If they used a basename and that basename
+ * is still unambiguous after the move, keep the basename; otherwise fall back
+ * to the path-without-extension form. Path-form originals always become
+ * the new path-without-extension.
+ *
+ * `allNotes` is the post-move list (must contain `newPath`).
+ */
+export function formatWikilinkTarget(
+  newPath: string,
+  originalForm: string,
+  allNotes: readonly string[],
+): string {
+  const newWithoutExt = newPath.replace(/\.md$/i, "");
+  const originalUsedPath = originalForm.includes("/");
+  if (originalUsedPath) return newWithoutExt;
+
+  const newBasename = path.basename(newWithoutExt);
+  const newBasenameLower = newBasename.toLowerCase();
+  let collisions = 0;
+  for (const np of allNotes) {
+    const base = path.basename(np, path.extname(np)).toLowerCase();
+    if (base === newBasenameLower) {
+      collisions++;
+      if (collisions > 1) break;
+    }
+  }
+  return collisions <= 1 ? newBasename : newWithoutExt;
+}
+
+/**
  * Extract inline tags and frontmatter tags from markdown content.
  * Returns deduplicated tags without the `#` prefix.
  * Ignores tags inside code blocks and inline code.

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -85,7 +85,7 @@ async function renameWithRetry(from: string, to: string): Promise<void> {
   }
 }
 
-async function atomicWriteFile(fullPath: string, content: string): Promise<void> {
+export async function atomicWriteFile(fullPath: string, content: string): Promise<void> {
   const dir = path.dirname(fullPath);
   const base = path.basename(fullPath);
   const tmp = path.join(dir, `.${base}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`);
@@ -102,7 +102,7 @@ async function atomicWriteFile(fullPath: string, content: string): Promise<void>
   }
 }
 
-async function withFileLock<T>(fullPath: string, fn: () => Promise<T>): Promise<T> {
+export async function withFileLock<T>(fullPath: string, fn: () => Promise<T>): Promise<T> {
   const key = lockKey(fullPath);
   const prev = fileLocks.get(key) ?? Promise.resolve();
   // Swallow the prior holder's rejection (so the chain continues) but still
@@ -454,11 +454,32 @@ export async function deleteNote(
   });
 }
 
+export interface MoveNoteOptions {
+  /** When true (default), rewrite wikilinks and markdown links in every other
+   *  note + canvas to point at the new path. Set false to skip the scan
+   *  entirely (faster on large vaults / for scripted bulk moves where the
+   *  caller is doing its own link bookkeeping). */
+  updateLinks?: boolean;
+}
+
+export interface MoveNoteResult {
+  /** Vault-relative paths of files whose references were rewritten. Empty
+   *  when no other note/canvas referenced the moved file (or `updateLinks`
+   *  was false). */
+  updatedReferrers: string[];
+  /** Per-file failures during the rewrite pass. The rename has already
+   *  committed by the time these are surfaced. Empty when everything landed
+   *  cleanly. */
+  failedReferrers: Array<{ path: string; error: string }>;
+}
+
 export async function moveNote(
   vaultPath: string,
   oldPath: string,
   newPath: string,
-): Promise<void> {
+  options: MoveNoteOptions = {},
+): Promise<MoveNoteResult> {
+  const updateLinks = options.updateLinks !== false;
   const fullOldPath = await resolveVaultPathSafe(vaultPath, oldPath);
   const fullNewPath = await resolveVaultPathSafe(vaultPath, newPath);
   const doRename = async (): Promise<void> => {
@@ -476,18 +497,39 @@ export async function moveNote(
     await fs.mkdir(path.dirname(fullNewPath), { recursive: true });
     await fs.rename(fullOldPath, fullNewPath);
   };
+
+  // Build the rewrite plan from the *pre-move* vault state — resolution must
+  // see the file at its old path so wikilinks pointing at it are matched.
+  // Importing here (not at module top) breaks an import cycle: link-rewriter
+  // depends on this module's read/list/lock helpers.
+  let plan: import("./link-rewriter.js").RewritePlan | null = null;
+  if (updateLinks) {
+    const { planMoveRewrites } = await import("./link-rewriter.js");
+    const preMoveNotes = await listNotes(vaultPath);
+    plan = await planMoveRewrites(vaultPath, oldPath, newPath, preMoveNotes);
+  }
+
   // Lock in deterministic order to prevent deadlock when two concurrent
   // moves cross-reference the same pair of paths. When both paths share
   // the same lock key (case-only rename on case-insensitive FS), a single
   // lock is sufficient — nesting the same key deadlocks.
   if (lockKey(fullOldPath) === lockKey(fullNewPath)) {
     await withFileLock(fullOldPath, doRename);
-    return;
+  } else {
+    const [first, second] = [fullOldPath, fullNewPath].sort();
+    await withFileLock(first, async () => {
+      await withFileLock(second, doRename);
+    });
   }
-  const [first, second] = [fullOldPath, fullNewPath].sort();
-  await withFileLock(first, async () => {
-    await withFileLock(second, doRename);
-  });
+
+  if (!plan) return { updatedReferrers: [], failedReferrers: [] };
+
+  const { applyRewrites } = await import("./link-rewriter.js");
+  const result = await applyRewrites(vaultPath, plan);
+  return {
+    updatedReferrers: result.updated,
+    failedReferrers: result.failed,
+  };
 }
 
 export async function searchNotes(

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -293,7 +293,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
     {
       title: "Move/Rename Note",
       description:
-        "Move or rename a note within the vault, preserving its full content. Parent folders at the destination are created as needed. By default, wikilinks (`[[old]]`, `![[old]]`, with aliases and heading/block fragments preserved), markdown links (`[text](old.md)`), and canvas `nodes[].file` fields in every other note are rewritten to point at the new path — matching Obsidian's \"Automatically update internal links\" behavior. Pass `updateLinks: false` to skip the rewrite scan (faster on large vaults; pair with `find_broken_links` if you need to audit afterward). A .md extension is added automatically if omitted from either path.",
+        "Move or rename a note within the vault, preserving its full content. Parent folders at the destination are created as needed. By default, wikilinks and file references are updated, matching Obsidian's \"Automatically update internal links\" behavior. Pass `updateLinks: false` to skip the rewrite scan (faster on large vaults; pair with `find_broken_links` if you need to audit afterward). A .md extension is added automatically if omitted from either path.",
       annotations: {
         readOnlyHint: false,
         destructiveHint: true,

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -293,7 +293,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
     {
       title: "Move/Rename Note",
       description:
-        "Move or rename a note within the vault, preserving its full content. Parent folders at the destination are created as needed. Note: this does not rewrite wikilinks in other notes that reference the old path — use find_broken_links afterward to spot broken references. A .md extension is added automatically if omitted from either path.",
+        "Move or rename a note within the vault, preserving its full content. Parent folders at the destination are created as needed. By default, wikilinks (`[[old]]`, `![[old]]`, with aliases and heading/block fragments preserved), markdown links (`[text](old.md)`), and canvas `nodes[].file` fields in every other note are rewritten to point at the new path — matching Obsidian's \"Automatically update internal links\" behavior. Pass `updateLinks: false` to skip the rewrite scan (faster on large vaults; pair with `find_broken_links` if you need to audit afterward). A .md extension is added automatically if omitted from either path.",
       annotations: {
         readOnlyHint: false,
         destructiveHint: true,
@@ -309,14 +309,34 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
           .string()
           .min(1)
           .describe("Destination relative path from vault root (e.g., 'projects/idea.md'). Creates intermediate folders as needed."),
+        updateLinks: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe("If true (default), update every wikilink, markdown link, and canvas node reference across the vault to point at the new path. Set false to skip the rewrite pass."),
       },
     },
-    async ({ oldPath, newPath }) => {
+    async ({ oldPath, newPath, updateLinks }) => {
       try {
         const resolvedOld = ensureMdExtension(oldPath);
         const resolvedNew = ensureMdExtension(newPath);
-        await moveNote(vaultPath, resolvedOld, resolvedNew);
-        return textResult(`Moved note from '${resolvedOld}' to '${resolvedNew}'.`);
+        const result = await moveNote(vaultPath, resolvedOld, resolvedNew, { updateLinks });
+        const lines: string[] = [`Moved note from '${resolvedOld}' to '${resolvedNew}'.`];
+        if (updateLinks !== false) {
+          const updated = result.updatedReferrers.length;
+          lines.push(
+            updated === 0
+              ? "No other notes referenced this file — nothing to rewrite."
+              : `Updated references in ${updated} file(s).`,
+          );
+          if (result.failedReferrers.length > 0) {
+            lines.push(`Warning: ${result.failedReferrers.length} file(s) could not be updated:`);
+            for (const f of result.failedReferrers) {
+              lines.push(`  - ${f.path}: ${f.error}`);
+            }
+          }
+        }
+        return textResult(lines.join("\n"));
       } catch (err) {
         log.error("move_note failed", { tool: "move_note", err: err as Error });
         return errorResult(`Error moving note: ${sanitizeError(err)}`);

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -12,7 +12,7 @@ import {
 } from "../lib/vault.js";
 import { updateFrontmatter } from "../lib/markdown.js";
 import { getDailyNoteConfig } from "../config.js";
-import { sanitizeError } from "../lib/errors.js";
+import { sanitizeError, escapeControlChars } from "../lib/errors.js";
 import { formatMomentDate } from "../lib/dates.js";
 import { log } from "../lib/logger.js";
 
@@ -330,9 +330,19 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
               : `Updated references in ${updated} file(s).`,
           );
           if (result.failedReferrers.length > 0) {
+            // Cap at 5 so a vault with hundreds of failures (e.g. a perms
+            // glitch under a big folder) doesn't blow up the response.
+            // Filenames are attacker-controllable, so escape control chars
+            // in `path` and route `error` through `sanitizeError` to prevent
+            // a `\n`-bearing name from injecting text into LLM context.
+            const MAX_DISPLAY = 5;
             lines.push(`Warning: ${result.failedReferrers.length} file(s) could not be updated:`);
-            for (const f of result.failedReferrers) {
-              lines.push(`  - ${f.path}: ${f.error}`);
+            for (const f of result.failedReferrers.slice(0, MAX_DISPLAY)) {
+              lines.push(`  - ${escapeControlChars(f.path)}: ${sanitizeError(f.error)}`);
+            }
+            const remaining = result.failedReferrers.length - MAX_DISPLAY;
+            if (remaining > 0) {
+              lines.push(`  ...and ${remaining} more`);
             }
           }
         }


### PR DESCRIPTION
Addresses the `move_note` half of #3. The `delete_note` half is deliberately left for a separate change — see "Out of scope" below.

## Summary

`move_note` now follows the rename with a vault-wide rewrite of every reference that pointed at the moved file. Matches the behavior an Obsidian user gets from `Vault → Rename` with "Automatically update internal links" enabled.

Covers:
- Wikilinks: `[[old]]`, `![[old]]`, with `|alias`, `#heading`, and `#^block-id` fragments preserved.
- Markdown links: `[text](old.md)` and the extension-less form, with `#fragment` and trailing `"title"` preserved.
- Canvas `.canvas` files: `nodes[].file` fields.

Default `updateLinks: true`. Pass `false` to skip the rewrite scan (useful for huge vaults or scripted bulk moves).

## How discovery works

Reference detection is **resolver-based, not string-based**: for every link in every note, the planner asks the existing `resolveWikilink` whether the link currently points at the file being moved. A link is rewritten only when `resolved === oldPath`.

```ts
for (const span of extractWikilinkSpans(content)) {
  const resolved = resolveWikilink(span.target, notePath, preMoveNotes, { aliasMap });
  if (resolved !== oldPath) continue;
  // ...build edit
}
```

This reuses the resolver every other tool already uses (`find_broken_links`, `get_backlinks`, `get_outlinks`) so resolution semantics stay in sync — including basename collision handling, the proximity tie-break, and frontmatter alias fallback. A `[[idea]]` link that resolves to `projects/idea.md` (not the moved `inbox/idea.md`) is correctly left alone.

The `preMoveNotes` snapshot is taken from `listNotes(vaultPath)` *before* the rename, so the resolver sees the file at its old path and identifies references correctly. The new path enters only at the output stage, where `formatWikilinkTarget` picks the rendered form.

## Output form preservation

A bare `[[idea]]` whose post-move basename is still unambiguous stays bare — no rewrite, no mtime touch. When the basename collides post-move, the link falls back to the path form (`[[archive/idea]]`). Path-form originals always become the new path-without-extension. This matches what Obsidian itself does and avoids gratuitous diffs in unaffected files.

## Sequencing

1. Snapshot pre-move notes + build the edit plan.
2. Execute the rename (existing logic, unchanged).
3. Apply edits per file under the existing `withFileLock`, with `SCAN_CONCURRENCY=8` fan-out and back-to-front offset application.

I deliberately inverted the order from the issue's "rewrite first, then rename" suggestion. If the rename fails, "rewrite first" leaves dozens of unrelated files mutated for no reason. With "rename first, rewrite second," the worst-case partial-failure state is "rename committed, some links not yet rewritten" — which is the exact state the codebase has been in for every move since v1.0, just now visible via `MoveNoteResult.failedReferrers` instead of silently. Recoverable, surfaced in the tool response, and doesn't compound on rename failures.

## Result type

```ts
interface MoveNoteResult {
  updatedReferrers: string[];        // files actually rewritten
  failedReferrers: { path; error }[]; // per-file rewrite failures (rename committed)
}
```

`updatedReferrers` reports files that were *actually written*, not files merely considered — no-op edits (basename preserved when still unambiguous) are filtered at plan time so unchanged files keep their mtime.

## Out of scope — `delete_note`

Issue #3 also covers `delete_note` reference handling. I left it out because the right behavior is genuinely different and warrants its own discussion:

- `delete_note` with `permanent: false` (the default — moves to `.trash`): the file is recoverable, so silently stripping references would destroy information the user can't easily get back. Probably should leave references alone.
- `delete_note` with `permanent: true`: stripping is defensible but has multiple flavors — remove the wrapping but keep visible text, delete the link entirely, leave a `<!-- broken: ... -->` marker, etc. Worth opening the design conversation in its own issue / PR rather than picking one in this change.

I'd suggest splitting the issue (or leaving it open after this PR merges) and tackling `delete_note` separately. Happy to draft that follow-up if useful.

## Tests

- `src/__tests__/markdown.test.ts`: 17 new cases for `extractWikilinkSpans`, `extractMarkdownLinkSpans`, and `formatWikilinkTarget` (offset preservation, code-block / inline-code skipping, fragment splitting, basename-vs-path output picking).
- `src/__tests__/link-rewriter.test.ts` (new file): 21 cases covering every reference shape from the issue — basename, path, alias, heading fragment, block-id fragment, embed, markdown link with and without extension, canvas — plus self-reference, basename collision, no-op preservation, `updateLinks: false`, partial-failure reporting, and a vault-wide integration scenario with mixed reference styles.
- `src/__tests__/handlers/write.test.ts`: 2 new cases covering the `updateLinks` default and the opt-out path through the MCP tool surface (canvas reference rewrite via `boards/test.canvas`).

Full suite: `294 passing, 4 skipped, 1 pre-existing failure`. The single failure is the existing Windows-only `..\..\Windows` path-traversal test that runs on macOS — same baseline as `master`, unrelated to this change. `tsc --noEmit` clean.


## Open questions

1. **`updateLinks: true` default** — this is a behavior change for anyone scripting against v1.5.3. Defensible because Obsidian's own UI default is on, the prior tool description explicitly told users to chain `find_broken_links` (which an LLM may or may not do), and `MoveNoteResult` exposes the count.
2. **Canvas rewrite scope.** We only rewrite `nodes[].file` (the documented `file`-node target field). Two adjacent cases are not covered by this PR: (a) wikilinks / markdown links inside `type: "text"` node body content, and (b) any `type: "link"` node whose `url` happens to point at a vault file. If either matters in practice, I could extend.
3. **Partial-failure UX** — currently the tool response lists each failed referrer inline. If you'd rather the response be terser and a `tool_call` log entry hold the detail, easy to swap.
4. **Honoring Obsidian's `alwaysUpdateLinks` setting** — the library can't read this (it never imports `obsidian` and runs identically under `npx`), but the plugin (`obsidian-mcp-pro-plugin`) can via `app.vault.getConfig("alwaysUpdateLinks")` and could wire it through to a per-server `updateLinks` default. Out of scope for this PR, but mentioning in case this is worth adding in the future. A toggle in the UI settings could be added, that is similar to Obsidian's "Automatically update internal links" setting, potentially falling back to "prompt before updating" — although that sounds like a tedious exercise to me, apparently Obsidian thought it was a good idea.