### PR TITLE
fix: redact vault paths in client logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP-forwarded log payloads now redact vault-relative path fields such as `note`, `relPath`, and nested `path`, preventing read-scan failures from exposing private note names to connected clients.
+
 ## [2.2.0] - 2026-06-03
 
 ### Breaking Changes

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -115,6 +115,31 @@ describe("logger", () => {
     expect(dataStr).toContain("<path>");
   });
 
+  it("redacts vault-relative path fields from forwarded MCP payload", () => {
+    const sendLoggingMessage = vi.fn().mockResolvedValue(undefined);
+    const fakeServer = { server: { sendLoggingMessage } } as unknown as McpServer;
+    configureLogger({ level: "info", format: "text", mcpServer: fakeServer });
+
+    log.warn("search_notes: note read failed", {
+      note: "private/therapy.md",
+      relPath: "finance/taxes-2026.md",
+      nested: { path: "projects/acquisition.md" },
+    });
+
+    const stderrOut = captured.join("");
+    expect(stderrOut).toContain("private/therapy.md");
+    expect(stderrOut).toContain("finance/taxes-2026.md");
+    expect(stderrOut).toContain("projects/acquisition.md");
+
+    expect(sendLoggingMessage).toHaveBeenCalledTimes(1);
+    const [params] = sendLoggingMessage.mock.calls[0];
+    const dataStr = JSON.stringify(params.data);
+    expect(dataStr).not.toContain("therapy");
+    expect(dataStr).not.toContain("taxes");
+    expect(dataStr).not.toContain("acquisition");
+    expect(dataStr).toContain("<vault path>");
+  });
+
   it("strips paths recursively from nested objects (e.g. serialized errors)", () => {
     const sendLoggingMessage = vi.fn().mockResolvedValue(undefined);
     const fakeServer = { server: { sendLoggingMessage } } as unknown as McpServer;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -54,6 +54,24 @@ const MCP_LEVEL: Record<Exclude<LogLevel, "silent">, "debug" | "info" | "warning
   error: "error",
 };
 
+const VAULT_PATH_FIELD_KEYS = new Set([
+  "configpath",
+  "currentroot",
+  "file",
+  "files",
+  "fullpath",
+  "note",
+  "notepath",
+  "notes",
+  "path",
+  "paths",
+  "relativepath",
+  "relpath",
+  "snapshotroot",
+  "vault",
+  "vaultpath",
+]);
+
 export function configureLogger(opts: {
   level?: LogLevel;
   format?: LogFormat;
@@ -121,19 +139,30 @@ function emit(level: LogLevel, msg: string, fields?: Record<string, unknown>): v
 function sanitizeLogData(input: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(input)) {
-    out[k] = sanitizeValue(v);
+    out[k] = sanitizeValue(k, v);
   }
   return out;
 }
 
-function sanitizeValue(v: unknown): unknown {
-  if (typeof v === "string") return stripPaths(v);
-  if (Array.isArray(v)) return v.map(sanitizeValue);
+function isVaultPathField(key: string): boolean {
+  return VAULT_PATH_FIELD_KEYS.has(key.toLowerCase());
+}
+
+function sanitizeValue(key: string, v: unknown, redactVaultPath = false): unknown {
+  const shouldRedactVaultPath = redactVaultPath || isVaultPathField(key);
+  if (typeof v === "string") {
+    const stripped = stripPaths(v);
+    if (stripped !== v) return stripped;
+    return shouldRedactVaultPath ? "<vault path>" : stripped;
+  }
+  if (Array.isArray(v)) {
+    return v.map((inner) => sanitizeValue(key, inner, shouldRedactVaultPath));
+  }
   if (v && typeof v === "object") {
     const obj = v as Record<string, unknown>;
     const out: Record<string, unknown> = {};
     for (const [k, inner] of Object.entries(obj)) {
-      out[k] = sanitizeValue(inner);
+      out[k] = sanitizeValue(k, inner, shouldRedactVaultPath);
     }
     return out;
   }


### PR DESCRIPTION
Redacts vault-relative path-shaped fields from MCP-forwarded logger payloads while leaving local stderr intact for operator diagnostics.

Root cause: scan-failure logs pass fields such as `note`, `relPath`, and nested `path` through logger forwarding. Absolute host paths were scrubbed, but relative private note names were not.

Risk: low. This only changes MCP log notifications, not tool output or local stderr.

Score: 4 severity x 3 reach / 1 effort = 12. Safety/privacy issue across scan tools.

Tested: `npm run verify`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the MCP log-forwarding sanitizer to redact vault-relative path fields (`note`, `relPath`, nested `path`, etc.) that were previously passed through to connected MCP clients verbatim, while keeping full detail on local stderr for operator diagnostics.

- **`src/lib/logger.ts`**: Introduces `VAULT_PATH_FIELD_KEYS` (a set of lowercased field names) and key-aware `sanitizeValue` logic; if a field's key matches the set, its string value is replaced with `\"<vault path>\"` in the MCP payload even when `stripPaths` finds no absolute path to strip.
- **`src/__tests__/logger.test.ts`**: Adds a targeted test covering top-level, sibling, and nested path fields, verifying stderr is untouched and the MCP payload is clean.
- **`CHANGELOG.md`**: Documents the fix under `[Unreleased]`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one minor caveat: key-name matching is broader than strictly necessary and could silently redact non-path strings in MCP logs.

The sanitizer change is deliberately conservative — it errs on the side of over-redacting rather than leaking vault note names. The only realistic downside is that generic keys like `note` or `file` used for human-readable annotations would become `"<vault path>"` in MCP-forwarded logs, silently degrading debuggability for MCP clients. Stderr is unaffected, so operator diagnostics remain intact. The new test covers the core scenarios well.

src/lib/logger.ts — specifically the breadth of VAULT_PATH_FIELD_KEYS; worth confirming that every call site that logs fields named `note`, `file`, or `files` is always supplying a vault path, not a human-readable annotation.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/logger.ts | Adds VAULT_PATH_FIELD_KEYS set and key-aware sanitization to redact vault-relative paths in MCP-forwarded log payloads; logic is sound but some keys (e.g. "note", "file") are generic enough to over-redact non-path strings. |
| src/__tests__/logger.test.ts | Adds a well-structured test verifying vault-relative path redaction in MCP payload while confirming stderr is unchanged; covers note, relPath, and nested path fields. |
| CHANGELOG.md | Adds an Unreleased changelog entry describing the vault-relative path redaction fix; accurate and correctly placed. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["log.warn / log.error / ..."] --> B["emit()"]
    B --> C["serializeFields()"]
    C --> D["Write to stderr\n(full detail, unredacted)"]
    B --> E{mcpServer\nconfigured?}
    E -- No --> F["(dropped)"]
    E -- Yes --> G["sanitizeLogData()"]
    G --> H["sanitizeValue(key, value)"]
    H --> I{isVaultPathField\nkey?}
    I -- Yes --> J{stripPaths changed\nthe value?}
    I -- No --> K{redactVaultPath\ninherited from parent?}
    K -- No --> L{stripPaths changed\nthe value?}
    L -- Yes --> M["Return stripped\n'<path>'"]
    L -- No --> N["Return original value"]
    K -- Yes --> J
    J -- Yes --> O["Return stripped\n'<path>'"]
    J -- No --> P["Return '<vault path>'"]
    H --> Q{Array?}
    Q -- Yes --> R["Recurse each item\n(inherit key + redactVaultPath)"]
    H --> S{Object?}
    S -- Yes --> T["Recurse each child key\n(child key + inherit redactVaultPath)"]
    G --> U["sendLoggingMessage()\nredacted MCP payload"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: redact vault paths in client logs"](https://github.com/rps321321/obsidian-mcp-pro/commit/8d028339bce885eefe54406534ede134d620582f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35479639)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->