### PR TITLE
fix: refine client log path redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- MCP-forwarded log payloads now redact vault-relative path fields such as `note`, `relPath`, and nested `path`, preventing read-scan failures from exposing private note names to connected clients.
+- MCP-forwarded log payloads now redact vault-relative path-like fields such as `note`, `relPath`, and nested `path`, preventing read-scan failures from exposing private note names to connected clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -123,12 +123,14 @@ describe("logger", () => {
     log.warn("search_notes: note read failed", {
       note: "private/therapy.md",
       relPath: "finance/taxes-2026.md",
+      notes: ["daily.md"],
       nested: { path: "projects/acquisition.md" },
     });
 
     const stderrOut = captured.join("");
     expect(stderrOut).toContain("private/therapy.md");
     expect(stderrOut).toContain("finance/taxes-2026.md");
+    expect(stderrOut).toContain("daily.md");
     expect(stderrOut).toContain("projects/acquisition.md");
 
     expect(sendLoggingMessage).toHaveBeenCalledTimes(1);
@@ -136,8 +138,28 @@ describe("logger", () => {
     const dataStr = JSON.stringify(params.data);
     expect(dataStr).not.toContain("therapy");
     expect(dataStr).not.toContain("taxes");
+    expect(dataStr).not.toContain("daily.md");
     expect(dataStr).not.toContain("acquisition");
     expect(dataStr).toContain("<vault path>");
+  });
+
+  it("keeps non-path diagnostics under path-like field names", () => {
+    const sendLoggingMessage = vi.fn().mockResolvedValue(undefined);
+    const fakeServer = { server: { sendLoggingMessage } } as unknown as McpServer;
+    configureLogger({ level: "info", format: "text", mcpServer: fakeServer });
+
+    log.info("retry scheduled", {
+      note: "retrying after transient error",
+      file: "index.ts",
+      nested: { path: "transport label" },
+    });
+
+    const [params] = sendLoggingMessage.mock.calls[0];
+    expect(params.data).toMatchObject({
+      note: "retrying after transient error",
+      file: "index.ts",
+      nested: { path: "transport label" },
+    });
   });
 
   it("strips paths recursively from nested objects (e.g. serialized errors)", () => {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -170,6 +170,9 @@ function isVaultPathField(key: string): boolean {
   return VAULT_PATH_FIELD_KEYS.has(key.toLowerCase());
 }
 
+// Treat path-shaped values as vault-local paths, but leave bare labels alone.
+// A note title like "therapy" can still pass through; redacting every string
+// under `note` or `file` made MCP-visible diagnostics too vague.
 function looksLikeVaultPath(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -72,6 +72,28 @@ const VAULT_PATH_FIELD_KEYS = new Set([
   "vaultpath",
 ]);
 
+const VAULT_PATH_EXTENSIONS = new Set([
+  ".avif",
+  ".base",
+  ".canvas",
+  ".gif",
+  ".heic",
+  ".heif",
+  ".jpeg",
+  ".jpg",
+  ".m4a",
+  ".md",
+  ".mov",
+  ".mp3",
+  ".mp4",
+  ".pdf",
+  ".png",
+  ".svg",
+  ".wav",
+  ".webm",
+  ".webp",
+]);
+
 export function configureLogger(opts: {
   level?: LogLevel;
   format?: LogFormat;
@@ -148,12 +170,21 @@ function isVaultPathField(key: string): boolean {
   return VAULT_PATH_FIELD_KEYS.has(key.toLowerCase());
 }
 
+function looksLikeVaultPath(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (trimmed.includes("/") || trimmed.includes("\\")) return true;
+  const dot = trimmed.lastIndexOf(".");
+  if (dot <= 0) return false;
+  return VAULT_PATH_EXTENSIONS.has(trimmed.slice(dot).toLowerCase());
+}
+
 function sanitizeValue(key: string, v: unknown, redactVaultPath = false): unknown {
   const shouldRedactVaultPath = redactVaultPath || isVaultPathField(key);
   if (typeof v === "string") {
     const stripped = stripPaths(v);
     if (stripped !== v) return stripped;
-    return shouldRedactVaultPath ? "<vault path>" : stripped;
+    return shouldRedactVaultPath && looksLikeVaultPath(stripped) ? "<vault path>" : stripped;
   }
   if (Array.isArray(v)) {
     return v.map((inner) => sanitizeValue(key, inner, shouldRedactVaultPath));

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -170,9 +170,10 @@ function isVaultPathField(key: string): boolean {
   return VAULT_PATH_FIELD_KEYS.has(key.toLowerCase());
 }
 
-// Treat path-shaped values as vault-local paths, but leave bare labels alone.
-// A note title like "therapy" can still pass through; redacting every string
-// under `note` or `file` made MCP-visible diagnostics too vague.
+// Returns true when a string looks like a vault-relative file path: it contains
+// a path separator, or ends with one of the extensions Obsidian files can carry.
+// Trade-off: bare note names without an extension or slash (e.g. "therapy") are
+// not considered vault paths and will be forwarded as-is to MCP clients.
 function looksLikeVaultPath(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;


### PR DESCRIPTION
Refines the MCP log-forwarding redaction from PR #9 so path-like fields only redact when the value looks like a vault path. Plain diagnostic strings under keys such as `note`, `file`, or nested `path` now stay readable.

Root cause: the first pass keyed only on field names, which could hide non-path context in MCP-visible logs.

Risk: low. This keeps the privacy behavior for slash/backslash paths and common vault file extensions while preserving local stderr as-is.

Score: 2 severity x 3 reach / 1 effort = 6. Follow-up to Greptile P2 on PR #9.

Tested: `npm run verify`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refines the MCP log-forwarding redaction introduced in PR #9 by adding a `looksLikeVaultPath` predicate that gates vault-path redaction on content shape (path separator present, or value ends with a recognised Obsidian file extension) rather than field name alone. Plain diagnostic strings under keys such as `note`, `file`, or `path` now pass through to MCP clients unchanged.

- **`src/lib/logger.ts`**: Adds `VAULT_PATH_EXTENSIONS` (20 Obsidian-native extensions) and `looksLikeVaultPath(value)`, which short-circuits on slash/backslash presence and then checks the extension set. `sanitizeValue` is updated to require both a path-like field key *and* a path-shaped value before redacting.
- **`src/__tests__/logger.test.ts`**: Adds a new test covering non-path diagnostics under path-like keys, and extends the existing vault-path redaction test with a `notes` array containing `\"daily.md\"`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change narrows redaction to genuinely path-shaped values, the documented bare-name trade-off is intentional, and the new predicate logic is correct for all exercised cases.

The predicate is straightforward and deterministic: slash/backslash check first, then a closed extension allowlist. No absolute-path stripping path is bypassed. Tests cover the redact-fires, redact-suppressed, and array-element cases. No data-loss or privacy regression was found.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/logger.ts | Adds VAULT_PATH_EXTENSIONS set and looksLikeVaultPath predicate; gates vault-path redaction on content shape rather than field name alone. Logic is correct and the trade-off for bare note names is documented in the function comment. |
| src/__tests__/logger.test.ts | Adds a new test covering non-path diagnostics under path-like keys, and extends the existing vault-path redaction test with a notes array case; coverage is well-matched to the new predicate's behaviour. |
| CHANGELOG.md | Wording updated from 'path fields' to 'path-like fields' to reflect the refined predicate; no functional change. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: clarify log redaction tradeoff"](https://github.com/rps321321/obsidian-mcp-pro/commit/adb2d1ed13f8dde3c3cea4ff30d069f08780afde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35483213)</sub>

<!-- /greptile_comment -->