### PR TITLE
fix: broaden client log path redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - MCP-forwarded log payloads now redact vault-relative path-like fields such as `note`, `relPath`, and nested `path`, preventing read-scan failures from exposing private note names to connected clients.
+- MCP log redaction now recognizes compound path field names such as `sourcePath` and `target_path`, and duplicate-alias logs group note paths under a redacted `notes` field.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -162,6 +162,30 @@ describe("logger", () => {
     });
   });
 
+  it("redacts path-like values under compound path field names", () => {
+    const sendLoggingMessage = vi.fn().mockResolvedValue(undefined);
+    const fakeServer = { server: { sendLoggingMessage } } as unknown as McpServer;
+    configureLogger({ level: "info", format: "text", mcpServer: fakeServer });
+
+    log.warn("rewrite plan failed", {
+      sourcePath: "private/source.md",
+      target_path: "archive/target.canvas",
+      profile: "daily.md",
+      origin: "https://example.test/path",
+    });
+
+    expect(sendLoggingMessage).toHaveBeenCalledTimes(1);
+    const [params] = sendLoggingMessage.mock.calls[0];
+    const dataStr = JSON.stringify(params.data);
+    expect(dataStr).not.toContain("private/source.md");
+    expect(dataStr).not.toContain("archive/target.canvas");
+    expect(dataStr).toContain("<vault path>");
+    expect(params.data).toMatchObject({
+      profile: "daily.md",
+      origin: "https://example.test/path",
+    });
+  });
+
   it("strips paths recursively from nested objects (e.g. serialized errors)", () => {
     const sendLoggingMessage = vi.fn().mockResolvedValue(undefined);
     const fakeServer = { server: { sendLoggingMessage } } as unknown as McpServer;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -71,6 +71,16 @@ const VAULT_PATH_FIELD_KEYS = new Set([
   "vault",
   "vaultpath",
 ]);
+const VAULT_PATH_FIELD_TOKENS = new Set([
+  "file",
+  "files",
+  "note",
+  "notes",
+  "path",
+  "paths",
+  "root",
+  "roots",
+]);
 
 const VAULT_PATH_EXTENSIONS = new Set([
   ".avif",
@@ -167,7 +177,15 @@ function sanitizeLogData(input: Record<string, unknown>): Record<string, unknown
 }
 
 function isVaultPathField(key: string): boolean {
-  return VAULT_PATH_FIELD_KEYS.has(key.toLowerCase());
+  const lower = key.toLowerCase();
+  if (VAULT_PATH_FIELD_KEYS.has(lower)) return true;
+  const tokens = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+  const last = tokens.at(-1);
+  return last !== undefined && VAULT_PATH_FIELD_TOKENS.has(last);
 }
 
 // Returns true when a string looks like a vault-relative file path: it contains

--- a/src/tools/links.ts
+++ b/src/tools/links.ts
@@ -124,7 +124,7 @@ async function buildLinkGraph(
       if (!key) continue;
       const prior = aliasMap.get(key);
       if (prior && prior !== notePath) {
-        log.warn("Duplicate alias", { alias, a: prior, b: notePath });
+        log.warn("Duplicate alias", { alias, notes: [prior, notePath] });
       }
       aliasMap.set(key, notePath);
     }


### PR DESCRIPTION
Broaden MCP log redaction so compound path-like field names such as `sourcePath` and `target_path` are treated like existing `note` / `relPath` fields. Duplicate alias logs now put both conflicting note paths under `notes`, which the sanitizer redacts before forwarding to MCP clients.

Root cause: the logger only recognized exact field names, and one duplicate-alias log used `a` / `b` for note paths.

Risk: low. This only changes MCP log notifications; local stderr and tool output are unchanged. The key tokenizer checks the final camel/snake token, so labels such as `profile` stay readable.

Score: 3 severity x 3 reach / 1 effort = 9. Privacy issue across forwarded diagnostic logs.

Tested: `npm run verify`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a privacy gap where MCP-forwarded log notifications could expose vault-relative file paths stored under compound field names (`sourcePath`, `target_path`, etc.) or under the opaque single-character fields `a`/`b` used in the duplicate-alias log.

- `isVaultPathField` is extended to tokenize camelCase and snake_case key names and check the final token against a new `VAULT_PATH_FIELD_TOKENS` set, so fields like `sourcePath` and `target_path` now trigger vault-path redaction without requiring explicit registration.
- The duplicate-alias log in `links.ts` is renamed from `{ a, b }` to `{ notes: [prior, notePath] }`, ensuring both conflicting paths are caught by the existing `notes` entry in `VAULT_PATH_FIELD_KEYS`.
- A new test validates that compound path field names are redacted while non-path fields (`profile`, `origin`) pass through unchanged.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are confined to the MCP log sanitizer and a log call site, with no impact on tool behavior or local stderr output.

The tokenizer logic is correct and well-tested. The one open question is whether including "root" and "roots" in VAULT_PATH_FIELD_TOKENS is intentional — those tokens will redact values in any field whose name ends in Root/root, which could suppress non-sensitive diagnostics. This is a minor, easily reversible decision rather than a defect.

The VAULT_PATH_FIELD_TOKENS set in src/lib/logger.ts warrants a quick review of whether "root" and "roots" belong there given the broader match surface they introduce.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/logger.ts | Adds VAULT_PATH_FIELD_TOKENS set and expands isVaultPathField to tokenize compound camelCase/snake_case keys, correctly broadening MCP log redaction |
| src/__tests__/logger.test.ts | Adds test for compound path field names; missing explicit coverage of the array-under-notes case from links.ts, though an existing test covers it |
| src/tools/links.ts | Renames a/b fields in duplicate-alias log to notes array, ensuring both conflicting paths are redacted by the sanitizer |
| CHANGELOG.md | Adds accurate entry for the log redaction fix under [Unreleased] |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[log.warn called with fields] --> B[sanitizeLogData]
    B --> C{for each key/value}
    C --> D[sanitizeValue key v]
    D --> E{isVaultPathField key}
    E -->|YES| F[shouldRedactVaultPath = true]
    E -->|NO| G[shouldRedactVaultPath = false]
    F --> H{typeof v === string}
    G --> H
    H -->|YES| I[stripPaths v]
    I --> J{stripped !== v?}
    J -->|YES - absolute path| K[return stripped value]
    J -->|NO| L{shouldRedactVaultPath AND looksLikeVaultPath?}
    L -->|YES| M[return '<vault path>']
    L -->|NO| N[return value as-is]
    H -->|Array| O[map sanitizeValue with inherited redactVaultPath]
    H -->|Object| P[recurse sanitizeValue per nested key]

    subgraph isVaultPathField
    Q[key.toLowerCase] --> R{in VAULT_PATH_FIELD_KEYS?}
    R -->|YES| S[return true]
    R -->|NO| T[camelCase/snake tokenize]
    T --> U[take last token]
    U --> V{in VAULT_PATH_FIELD_TOKENS?}
    V -->|YES| W[return true]
    V -->|NO| X[return false]
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: broaden client log path redaction"](https://github.com/rps321321/obsidian-mcp-pro/commit/68cd397a99113f2261d2379d84d0455c973ab837) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35487162)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->