### PR TITLE
fix: retry transient note renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - MCP-forwarded log payloads now redact vault-relative path-like fields such as `note`, `relPath`, and nested `path`, preventing read-scan failures from exposing private note names to connected clients.
 - MCP log redaction now recognizes compound path field names such as `sourcePath` and `target_path`, and duplicate-alias logs group note paths under a redacted `notes` field.
+- Note moves and trash deletes now reuse the Windows rename retry path, reducing transient `EPERM`/`EBUSY` failures when another process briefly has the file open.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
@@ -17,12 +17,14 @@ import {
 } from "../lib/vault.js";
 
 let vaultDir: string;
+const itWin32 = process.platform === "win32" ? it : it.skip;
 
 beforeEach(async () => {
   vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-test-"));
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await fs.rm(vaultDir, { recursive: true, force: true });
 });
 
@@ -296,6 +298,21 @@ describe("deleteNote", () => {
     expect(collisionCopy).toBeDefined();
     expect(await fs.readFile(path.join(trashDir, collisionCopy!), "utf-8")).toBe("second");
   });
+
+  itWin32("retries transient Windows rename failures while moving to trash", async () => {
+    await writeNote(vaultDir, "doomed.md", "bye");
+    const realRename = fs.rename.bind(fs);
+    const renameSpy = vi.spyOn(fs, "rename");
+    renameSpy
+      .mockRejectedValueOnce(Object.assign(new Error("simulated EPERM"), { code: "EPERM" }))
+      .mockImplementation(realRename);
+
+    await deleteNote(vaultDir, "doomed.md");
+
+    expect(renameSpy).toHaveBeenCalledTimes(2);
+    await expect(fs.access(path.join(vaultDir, "doomed.md"))).rejects.toThrow();
+    await expect(fs.access(path.join(vaultDir, ".trash", "doomed.md"))).resolves.toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -326,6 +343,21 @@ describe("moveNote", () => {
     await expect(moveNote(vaultDir, "a.md", "b.md")).rejects.toThrow(
       "Destination already exists: b.md",
     );
+  });
+
+  itWin32("retries transient Windows rename failures while moving notes", async () => {
+    await writeNote(vaultDir, "old.md", "moving");
+    const realRename = fs.rename.bind(fs);
+    const renameSpy = vi.spyOn(fs, "rename");
+    renameSpy
+      .mockRejectedValueOnce(Object.assign(new Error("simulated EBUSY"), { code: "EBUSY" }))
+      .mockImplementation(realRename);
+
+    await moveNote(vaultDir, "old.md", "new.md");
+
+    expect(renameSpy).toHaveBeenCalledTimes(2);
+    await expect(fs.access(path.join(vaultDir, "old.md"))).rejects.toThrow();
+    await expect(fs.access(path.join(vaultDir, "new.md"))).resolves.toBeUndefined();
   });
 });
 

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -730,7 +730,7 @@ export async function deleteNote(
         // `.trash` (or any intermediate dir) that resolves outside the vault.
         await assertRealPathWithinVault(trashFullPath, vaultPath);
         const finalTrashPath = await chooseTrashPath(trashFullPath);
-        await fs.rename(fullPath, finalTrashPath);
+        await renameWithRetry(fullPath, finalTrashPath);
       } else {
         await fs.unlink(fullPath);
       }
@@ -816,7 +816,7 @@ export async function moveNote(
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
     }
     await fs.mkdir(path.dirname(fullNewPath), { recursive: true });
-    await fs.rename(fullOldPath, fullNewPath);
+    await renameWithRetry(fullOldPath, fullNewPath);
   };
 
   const performMove = async (): Promise<MoveNoteResult> => {


### PR DESCRIPTION
Reuse the existing Windows rename retry helper for note moves and recoverable trash deletes. Atomic writes already wait out transient `EPERM` / `EBUSY` from short-lived file handles; move_note and delete_note now take the same path for their direct renames.

Root cause: `moveNote` and the non-permanent branch of `deleteNote` still called `fs.rename` directly, so a brief handle held by Obsidian, a sync client, or antivirus could fail the operation even though the existing retry helper covered atomic writes.

Risk: low. The retry helper only retries transient rename codes on Windows; POSIX behavior stays fail-fast. Permanent deletes still use `unlink` and are unchanged.

Score: 3 severity x 3 reach / 1 effort = 9. Common write workflows on Windows become less brittle without changing public tool parameters or return shapes.

Tested: `npm run verify`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires two previously unprotected `fs.rename` call sites — the trash move in `deleteNote` and the note rename in `moveNote` — through the existing `renameWithRetry` helper, which already covered atomic writes. On POSIX the behavior is identical (empty retry set); on Windows it adds the same backoff retry loop for transient `EPERM`/`EBUSY`/`EACCES` errors that the atomic-write path has had for a while.

- `src/lib/vault.ts`: two one-line replacements, no interface or return-value changes.
- `src/__tests__/vault.test.ts`: two new `itWin32`-gated retry tests injecting a single transient failure via `vi.spyOn`, plus `vi.restoreAllMocks()` added to the global `afterEach` for proper spy cleanup.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is a strict superset of the existing behavior and cannot regress POSIX callers.

The two changed lines are straightforward substitutions of a helper that has been in production for the atomic-write path. The only open question is whether the new retry tests will ever run in CI — they are skipped on non-Windows runners because the retry set is empty on POSIX. The implementation itself is correct and low-risk.

The test file is worth a second look to decide whether cross-platform coverage of the retry logic matters for this project's CI setup.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/vault.ts | Two direct `fs.rename` calls replaced with the pre-existing `renameWithRetry` helper in `deleteNote` (trash path) and `moveNote`; semantics are identical on POSIX and add retry-with-backoff for EPERM/EBUSY/EACCES on Windows only. |
| src/__tests__/vault.test.ts | Adds two `itWin32`-gated retry tests using `vi.spyOn` to inject a single transient failure; also adds `vi.restoreAllMocks()` to `afterEach` for proper cleanup. Tests will be skipped on Linux/macOS CI because the retry codes are an empty set on those platforms. |
| CHANGELOG.md | Changelog entry added for the retry fix; format and placement are consistent with existing entries. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[deleteNote / moveNote called] --> B[renameWithRetry]
    B --> C{fs.rename}
    C -->|success| D[Done]
    C -->|EPERM / EBUSY / EACCES| E{Windows?}
    E -->|No — POSIX| F[Throw immediately]
    E -->|Yes and attempt < 6| G[Wait backoff delay\n5→10→20→40→80→160 ms]
    G --> C
    E -->|Yes and attempt >= 6| H[Throw after max retries]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: retry transient note renames"](https://github.com/rps321321/obsidian-mcp-pro/commit/6ce97a64dc14d62d2951344b86db1dbfdaac3868) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35489933)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->