### PR TITLE
fix: retry cache snapshot renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP-forwarded log payloads now redact vault-relative path-like fields such as `note`, `relPath`, and nested `path`, preventing read-scan failures from exposing private note names to connected clients.
 - MCP log redaction now recognizes compound path field names such as `sourcePath` and `target_path`, and duplicate-alias logs group note paths under a redacted `notes` field.
 - Note moves and trash deletes now reuse the Windows rename retry path, reducing transient `EPERM`/`EBUSY` failures when another process briefly has the file open.
+- Index and embedding cache snapshot writes now share the same Windows rename retry path, avoiding avoidable cold-cache rebuilds after brief file-handle conflicts.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/regression-cache-flush.test.ts
+++ b/src/__tests__/regression-cache-flush.test.ts
@@ -16,6 +16,7 @@ import { readAllCached, clearCache, flushNow } from "../lib/index-cache.js";
 //         the file became readable again.
 
 let vaultDir: string;
+const itWin32 = process.platform === "win32" ? it : it.skip;
 
 beforeEach(async () => {
   vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "cache-flush-test-"));
@@ -34,6 +35,24 @@ async function writeFile(rel: string, content: string): Promise<void> {
 }
 
 describe("flushVaultCache concurrent dirty-flag handling (C2)", () => {
+  itWin32("retries transient Windows rename failures while persisting snapshots", async () => {
+    await writeFile("a.md", "alpha");
+    await readAllCached(vaultDir, ["a.md"]);
+
+    const realRename = fs.rename.bind(fs);
+    const renameSpy = vi.spyOn(fs, "rename");
+    renameSpy
+      .mockRejectedValueOnce(Object.assign(new Error("simulated EBUSY"), { code: "EBUSY" }))
+      .mockImplementation(realRename);
+
+    await flushNow(vaultDir);
+
+    expect(renameSpy).toHaveBeenCalledTimes(2);
+    const snap = path.join(vaultDir, ".obsidian", "cache", "mcp-pro-index-cache.json");
+    const parsed = JSON.parse(await fs.readFile(snap, "utf-8"));
+    expect(parsed.entries["a.md"]?.content).toBe("alpha");
+  });
+
   it("persists writes that arrive while an earlier flush is mid-write", async () => {
     // Stage: warm the cache with one entry so the first flush has data.
     await writeFile("a.md", "alpha");

--- a/src/__tests__/regression-embedding-fixes.test.ts
+++ b/src/__tests__/regression-embedding-fixes.test.ts
@@ -27,12 +27,14 @@ import {
 //          cheaply.
 
 let vaultDir: string;
+const itWin32 = process.platform === "win32" ? it : it.skip;
 
 beforeEach(async () => {
   vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "embed-regression-"));
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await clearStore(vaultDir, { removeSnapshot: true });
   await fs.rm(vaultDir, { recursive: true, force: true });
 });
@@ -86,6 +88,32 @@ describe("saveStore tmp hygiene (H10)", () => {
     expect(entries.filter((e) => e.endsWith(".tmp"))).toEqual([]);
   });
 
+  itWin32("retries transient Windows rename failures while saving", async () => {
+    await loadStore(vaultDir);
+    setNoteChunks(
+      vaultDir,
+      "a.md",
+      "h",
+      [{ notePath: "a.md", chunkIndex: 1, headingPath: [], text: "x", hash: "th", vector: [1, 2, 3] }],
+      "test",
+      "m",
+    );
+
+    const realRename = fs.rename.bind(fs);
+    const renameSpy = vi.spyOn(fs, "rename");
+    renameSpy
+      .mockRejectedValueOnce(Object.assign(new Error("simulated EPERM"), { code: "EPERM" }))
+      .mockImplementation(realRename);
+
+    await saveStore(vaultDir);
+
+    expect(renameSpy).toHaveBeenCalledTimes(2);
+    const cacheDir = path.join(vaultDir, ".obsidian", "cache");
+    const entries = await fs.readdir(cacheDir);
+    expect(entries.filter((e) => e.endsWith(".tmp"))).toEqual([]);
+    expect(entries).toContain("mcp-pro-embeddings.json");
+  });
+
   it("cleans up the tmp file when rename fails", async () => {
     await loadStore(vaultDir);
     setNoteChunks(
@@ -97,12 +125,12 @@ describe("saveStore tmp hygiene (H10)", () => {
       "m",
     );
 
-    // Make rename fail. The saveStore catch should unlink the tmp so we
-    // don't accumulate orphan files on a flaky disk / EXDEV / antivirus
-    // lock scenario.
+    // Make rename fail with a non-retriable code. The saveStore catch should
+    // unlink the tmp so we don't accumulate orphan files on a flaky disk or
+    // cross-device rename scenario.
     const renameSpy = vi
       .spyOn(fs, "rename")
-      .mockRejectedValueOnce(Object.assign(new Error("simulated EPERM"), { code: "EPERM" }));
+      .mockRejectedValueOnce(Object.assign(new Error("simulated EXDEV"), { code: "EXDEV" }));
 
     await saveStore(vaultDir);
 

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -4,6 +4,7 @@ import { createHash, randomBytes } from "crypto";
 import { log } from "./logger.js";
 import { isPersistenceEnabled } from "./index-cache.js";
 import { resolveVaultInternalPathSafe } from "./vault.js";
+import { renameWithRetry } from "./fs-ops.js";
 
 /**
  * Persistent embedding store.
@@ -301,7 +302,7 @@ async function doSave(vaultPath: string, state: StoreState): Promise<void> {
     await fs.mkdir(path.dirname(file), { recursive: true });
     try {
       await fs.writeFile(tmp, serialized, { encoding: "utf-8", mode: 0o600 });
-      await fs.rename(tmp, file);
+      await renameWithRetry(tmp, file);
     } catch (innerErr) {
       // Best-effort cleanup: if writeFile succeeded but rename failed, the
       // tmp file is still on disk. ENOENT (writeFile never created it) is

--- a/src/lib/fs-ops.ts
+++ b/src/lib/fs-ops.ts
@@ -1,0 +1,27 @@
+import fs from "fs/promises";
+
+// Windows raises EPERM/EBUSY/EACCES from fs.rename when another process has
+// either endpoint open. Obsidian, sync clients, and antivirus scanners usually
+// release those handles within a few milliseconds, so retry the transient
+// class before surfacing a failure. POSIX EACCES is normally structural, not a
+// timing issue, so non-Windows platforms stay fail-fast.
+const RENAME_RETRY_CODES: ReadonlySet<string> = process.platform === "win32"
+  ? new Set(["EPERM", "EBUSY", "EACCES"])
+  : new Set();
+
+const RENAME_RETRY_DELAYS_MS = [5, 10, 20, 40, 80, 160];
+
+export async function renameWithRetry(from: string, to: string): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await fs.rename(from, to);
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code ?? "";
+      if (!RENAME_RETRY_CODES.has(code) || attempt >= RENAME_RETRY_DELAYS_MS.length) {
+        throw err;
+      }
+      await new Promise((r) => setTimeout(r, RENAME_RETRY_DELAYS_MS[attempt]));
+    }
+  }
+}

--- a/src/lib/index-cache.ts
+++ b/src/lib/index-cache.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { resolveVaultInternalPathSafe, resolveVaultPathSafe } from "./vault.js";
 import { mapConcurrent } from "./concurrency.js";
 import { log } from "./logger.js";
+import { renameWithRetry } from "./fs-ops.js";
 
 /**
  * mtime-keyed content cache (in-memory + persistent).
@@ -265,7 +266,7 @@ async function doFlush(vaultPath: string, state: VaultCacheState): Promise<void>
     await fs.mkdir(dir, { recursive: true });
     const tmp = `${file}.${process.pid}-${Date.now()}-${crypto.randomUUID().slice(0, 8)}.tmp`;
     await fs.writeFile(tmp, JSON.stringify(snapshot), "utf-8");
-    await fs.rename(tmp, file);
+    await renameWithRetry(tmp, file);
   } catch (err) {
     // Write failed - re-mark dirty so the next flush retries this data.
     state.dirty = true;

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { randomBytes } from "crypto";
 import { mapConcurrent } from "./concurrency.js";
 import { assertAllowed, type AccessKind } from "./permissions.js";
+import { renameWithRetry } from "./fs-ops.js";
 import type { SearchResult, SearchMatch, CanvasData } from "../types.js";
 
 // Bounded fan-out for vault-wide scans. Higher values saturate the event loop
@@ -69,32 +70,6 @@ export function vaultRewriteLockKey(vaultPath: string): string {
  * against concurrent writers to the *same* target path still requires the
  * per-path lock (otherwise two concurrent renames race on the final name).
  */
-// Windows raises EPERM/EBUSY/EACCES from `fs.rename` when another handle has
-// the target open for read (Win32's default share mode is stricter than
-// POSIX). Readers typically release within a few ms — retry with linear
-// backoff before surfacing the error. POSIX renames never hit this transient
-// class: on POSIX, EACCES from rename(2) means the caller structurally lacks
-// write permission on a containing directory, which will not clear by
-// waiting — so we only retry these codes on Windows.
-const RENAME_RETRY_CODES: ReadonlySet<string> = process.platform === "win32"
-  ? new Set(["EPERM", "EBUSY", "EACCES"])
-  : new Set();
-const RENAME_RETRY_DELAYS_MS = [5, 10, 20, 40, 80, 160];
-async function renameWithRetry(from: string, to: string): Promise<void> {
-  for (let attempt = 0; ; attempt++) {
-    try {
-      await fs.rename(from, to);
-      return;
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code ?? "";
-      if (!RENAME_RETRY_CODES.has(code) || attempt >= RENAME_RETRY_DELAYS_MS.length) {
-        throw err;
-      }
-      await new Promise((r) => setTimeout(r, RENAME_RETRY_DELAYS_MS[attempt]));
-    }
-  }
-}
-
 export async function atomicWriteFile(fullPath: string, content: string): Promise<void> {
   const dir = path.dirname(fullPath);
   const base = path.basename(fullPath);


### PR DESCRIPTION
Move the Windows rename retry policy into a shared internal helper and use it for the remaining cache snapshot renames. Index-cache and embedding-store persistence now wait out transient `EPERM` / `EBUSY` handle conflicts the same way note writes, moves, and trash deletes do.

Root cause: snapshot writes still called `fs.rename` directly, so a short-lived Windows file handle could fail persistence and force avoidable cold-cache rebuilds or re-embedding later.

Risk: low. The helper still retries only the Windows transient rename codes; non-Windows behavior stays fail-fast, and non-retriable failures still preserve existing tmp cleanup / dirty retry behavior.

Score: 2 severity x 3 reach / 1 effort = 6. Cache persistence is not as user-visible as note writes, but it affects broad repeated workflows on Windows.

Tested: `npm run verify`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts the Windows rename-retry policy from `vault.ts` into a new shared helper (`fs-ops.ts`) and applies it to the index-cache and embedding-store persistence paths that were still calling `fs.rename` directly, closing the gap that caused transient `EPERM`/`EBUSY` failures to force cold-cache rebuilds on Windows.

- **`fs-ops.ts`** (new): shared `renameWithRetry` helper, identical logic to what was removed from `vault.ts`; all three callers now import from a single source.
- **`index-cache.ts` / `embedding-store.ts`**: single-line swap of `fs.rename` → `renameWithRetry`; embedding-store's existing inner-try/unlink cleanup is preserved correctly.
- **Tests**: two new `itWin32`-guarded regression tests (one per cache); the embedding-store suite also adds `vi.restoreAllMocks()` to `afterEach` and correctly changes the non-retriable cleanup test from `EPERM` (now retriable on Windows) to `EXDEV`.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is a straightforward extraction of an already-proven helper with no behavioural difference on POSIX systems.

The `doFlush` path in index-cache still does not unlink its tmp file when rename exhausts all retries, unlike the embedding-store path which handles this correctly. The orphaned file will accumulate on Windows under sustained disk pressure but won't cause data loss or incorrect cache state — dirty is re-marked so the next flush tries again. Everything else in the PR is clean.

src/lib/index-cache.ts — the outer catch in doFlush could benefit from a best-effort fs.unlink(tmp) to match the embedding-store pattern.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/fs-ops.ts | New shared helper that extracts the Windows rename-retry logic from vault.ts. Implementation is identical to the original; correctly exported and typed. |
| src/lib/vault.ts | Removes the now-duplicate local renameWithRetry function and imports it from fs-ops.ts; no behavioural change. |
| src/lib/index-cache.ts | Swaps bare fs.rename for renameWithRetry in doFlush; the outer catch block still does not unlink the tmp file on exhausted retries, unlike the embedding-store pattern. |
| src/lib/embedding-store.ts | Swaps bare fs.rename for renameWithRetry in doSave; the existing inner try/catch with fs.unlink cleanup is preserved and still covers the exhausted-retry case correctly. |
| src/__tests__/regression-cache-flush.test.ts | Adds an itWin32-guarded test that injects a one-shot EBUSY rejection and verifies flushNow retries and succeeds; vi.restoreAllMocks() is already in afterEach. |
| src/__tests__/regression-embedding-fixes.test.ts | Adds itWin32 retry test (EPERM), adds vi.restoreAllMocks() to afterEach, and correctly changes the non-retriable cleanup test from EPERM (now retriable on Windows) to EXDEV. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant IC as index-cache / embedding-store
    participant FO as fs-ops (renameWithRetry)
    participant FS as fs.rename (OS)

    IC->>FO: renameWithRetry(tmp, file)
    loop attempt 0..5
        FO->>FS: fs.rename(tmp, file)
        alt success
            FS-->>FO: resolved
            FO-->>IC: return
        else EPERM / EBUSY / EACCES (Windows only)
            FS-->>FO: throws
            FO->>FO: wait RENAME_RETRY_DELAYS_MS[attempt]
        else non-retriable / retries exhausted
            FS-->>FO: throws
            FO-->>IC: re-throw
        end
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/index-cache.ts`, line 265-274 ([link](https://github.com/rps321321/obsidian-mcp-pro/blob/4c2a7b2088bfb8a72b2ebb77911f5782dddafefb/src/lib/index-cache.ts#L265-L274)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Orphaned tmp file on exhausted rename retries**

   `embedding-store.ts` wraps `renameWithRetry` in an inner try/catch that calls `fs.unlink(tmp)` before re-throwing, but `doFlush` here has no equivalent cleanup. If `renameWithRetry` ultimately exhausts all six retries and throws, `writeFile` has already written the tmp file to disk and it will remain there indefinitely — the outer catch only re-marks `state.dirty` and logs. Because the tmp name embeds a random UUID, no future flush will overwrite or reuse it. The same catch pattern existed before this PR with the bare `fs.rename`, so this isn't a regression, but now that both persistence paths share the same retry helper it is more visible next to the correct embedding-store pattern.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: retry cache snapshot renames"](https://github.com/rps321321/obsidian-mcp-pro/commit/4c2a7b2088bfb8a72b2ebb77911f5782dddafefb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35491932)</sub>

<!-- /greptile_comment -->