### PR TITLE
fix: escape failure paths in tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP log redaction now recognizes compound path field names such as `sourcePath` and `target_path`, and duplicate-alias logs group note paths under a redacted `notes` field.
 - Note moves and trash deletes now reuse the Windows rename retry path, reducing transient `EPERM`/`EBUSY` failures when another process briefly has the file open.
 - Index and embedding cache snapshot writes now share the same Windows rename retry path, avoiding avoidable cold-cache rebuilds after brief file-handle conflicts.
+- Failure summaries for tag renames and semantic indexing now escape control characters in vault-relative paths before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/tool-output.test.ts
+++ b/src/__tests__/tool-output.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { formatFailedPath } from "../lib/tool-output.js";
+
+describe("tool output helpers", () => {
+  it("escapes control characters in failure paths and sanitizes errors", () => {
+    const line = formatFailedPath(
+      "notes/bad\nname.md",
+      new Error("failed while reading /tmp/private-vault/secret.md"),
+      "    ",
+    );
+
+    expect(line).toBe("    - notes/bad\\nname.md: failed while reading <path>");
+  });
+});

--- a/src/lib/tool-output.ts
+++ b/src/lib/tool-output.ts
@@ -1,0 +1,5 @@
+import { escapeControlChars, sanitizeError } from "./errors.js";
+
+export function formatFailedPath(path: string, error: unknown, indent = "  "): string {
+  return `${indent}- ${escapeControlChars(path)}: ${sanitizeError(error)}`;
+}

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -19,6 +19,7 @@ import {
 } from "../lib/embedding-store.js";
 import { makeProgressReporter } from "../lib/progress.js";
 import { sanitizeError } from "../lib/errors.js";
+import { formatFailedPath } from "../lib/tool-output.js";
 import { log } from "../lib/logger.js";
 import { mapConcurrent } from "../lib/concurrency.js";
 
@@ -240,7 +241,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         if (stats.notesPruned > 0) lines.push(`  Notes pruned:    ${stats.notesPruned}`);
         if (stats.failed.length > 0) {
           lines.push(`  Failures:        ${stats.failed.length}`);
-          for (const f of stats.failed.slice(0, 5)) lines.push(`    - ${f.path}: ${sanitizeError(f.error)}`);
+          for (const f of stats.failed.slice(0, 5)) lines.push(formatFailedPath(f.path, f.error, "    "));
           if (stats.failed.length > 5) lines.push(`    ...and ${stats.failed.length - 5} more`);
         }
         return textResult(lines.join("\n"));

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -6,6 +6,7 @@ import { isValidTagName, rewriteAllTags } from "../lib/tag-rewriter.js";
 import { readAllCached } from "../lib/index-cache.js";
 import { makeProgressReporter } from "../lib/progress.js";
 import { sanitizeError } from "../lib/errors.js";
+import { formatFailedPath } from "../lib/tool-output.js";
 import { mapConcurrent } from "../lib/concurrency.js";
 import { log } from "../lib/logger.js";
 
@@ -308,7 +309,7 @@ export function registerTagTools(server: McpServer, vaultPath: string): void {
         ];
         if (failed.length > 0) {
           lines.push(`  Skipped due to errors: ${failed.length}`);
-          for (const f of failed.slice(0, 5)) lines.push(`    - ${f.path}: ${sanitizeError(f.error)}`);
+          for (const f of failed.slice(0, 5)) lines.push(formatFailedPath(f.path, f.error, "    "));
           if (failed.length > 5) lines.push(`    ...and ${failed.length - 5} more`);
         }
         return { content: [{ type: "text" as const, text: lines.join("\n") }] };

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -11,7 +11,8 @@ import {
 } from "../lib/vault.js";
 import { updateFrontmatter } from "../lib/markdown.js";
 import { getDailyNoteConfig } from "../config.js";
-import { sanitizeError, escapeControlChars } from "../lib/errors.js";
+import { sanitizeError } from "../lib/errors.js";
+import { formatFailedPath } from "../lib/tool-output.js";
 import { formatMomentDate, parseLocalDateOnly } from "../lib/dates.js";
 import { log } from "../lib/logger.js";
 
@@ -385,7 +386,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
             const MAX_DISPLAY = 5;
             lines.push(`Warning: ${result.failedReferrers.length} file(s) could not be updated:`);
             for (const f of result.failedReferrers.slice(0, MAX_DISPLAY)) {
-              lines.push(`  - ${escapeControlChars(f.path)}: ${sanitizeError(f.error)}`);
+              lines.push(formatFailedPath(f.path, f.error));
             }
             const remaining = result.failedReferrers.length - MAX_DISPLAY;
             if (remaining > 0) {
@@ -526,7 +527,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
             const MAX_DISPLAY = 5;
             lines.push(`Warning: ${result.failedReferrers.length} file(s) could not be updated:`);
             for (const f of result.failedReferrers.slice(0, MAX_DISPLAY)) {
-              lines.push(`  - ${escapeControlChars(f.path)}: ${sanitizeError(f.error)}`);
+              lines.push(formatFailedPath(f.path, f.error));
             }
             const remaining = result.failedReferrers.length - MAX_DISPLAY;
             if (remaining > 0) {


### PR DESCRIPTION
Escape vault-relative paths in failure summaries before returning them to MCP clients. `rename_tag` and `index_vault` now use the same shared formatter as move/delete failure summaries, so control characters in filenames cannot break the response shape.

Root cause: those summaries printed `f.path` directly while only sanitizing the error text. Vault filenames are user-controlled text, so POSIX filenames containing newlines or other control characters could be reflected into tool output.

Risk: low. This only changes formatting for failure lines; ordinary paths render the same, while control bytes are escaped with the existing error helper behavior.

Score: 3 severity x 3 reach / 1 effort = 9. Tool responses feed MCP clients and model context, and this closes a known injection-hardening pattern across multiple tools.

Tested: `npm run verify`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts a shared `formatFailedPath` helper into `src/lib/tool-output.ts` and applies it to the failure-summary blocks in `tags.ts` and `semantic.ts`, where `f.path` was previously interpolated raw into tool output without control-character escaping.

- **Bug fix (`tags.ts`, `semantic.ts`)**: failure lines now pass `f.path` through `escapeControlChars` before inserting it into the MCP response, closing a path where a vault filename containing `\n` or other control bytes could inject text into model context.
- **Refactor (`write.ts`)**: both `move_note` and `delete_note` failure blocks were already correct (they used `escapeControlChars` inline); they are replaced with the shared helper for consistency, with no functional change.
- **New test** (`src/__tests__/tool-output.test.ts`): covers the combined path-escape + error-sanitize behavior end-to-end for the 4-space indent variant.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is a straightforward extraction of an existing inline pattern into a shared helper, and the two tool files that were actually missing the escape are now fixed.

The core fix is correct and the underlying helpers are thoroughly tested in errors.test.ts. The new test file covers the primary scenario but leaves the default-indent code path and additional control character variants untested.

src/__tests__/tool-output.test.ts — the single test case does not exercise the default 2-space indent or control characters other than newline.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/tool-output.ts | New shared helper that combines escapeControlChars(path) + sanitizeError(error) into a single, consistently-formatted failure line. |
| src/__tests__/tool-output.test.ts | Single test covering newline-in-path and absolute-path-in-error; doesn't exercise the default 2-space indent path used by write.ts, or other control characters like \r and \t. |
| src/tools/tags.ts | Replaced direct f.path interpolation with formatFailedPath; was the primary bug site (paths were not escaped before this change). |
| src/tools/semantic.ts | Replaced direct f.path interpolation with formatFailedPath; same primary bug fix as tags.ts. |
| src/tools/write.ts | Refactored two failure-summary blocks to use formatFailedPath; was already correct (escapeControlChars was applied) but now uses the shared helper consistently. |
| CHANGELOG.md | Entry added to the in-progress release block describing the path-escaping fix. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User-controlled vault path] -->|f.path| B[formatFailedPath]
    C[Error object] -->|f.error| B
    B --> D[escapeControlChars path]
    B --> E[sanitizeError error]
    D -->|\\n → \\\\n etc.| F[Safe path string]
    E -->|strip abs paths + escape ctrl chars| G[Safe error string]
    F --> H["indent- path: error"]
    G --> H
    H --> I[MCP tool response / LLM context]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape failure paths in tool output"](https://github.com/rps321321/obsidian-mcp-pro/commit/10c15b60e69323a550f956948fcec3700d048b6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35493467)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->