### PR TITLE
fix: escape canvas response values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Note moves and trash deletes now reuse the Windows rename retry path, reducing transient `EPERM`/`EBUSY` failures when another process briefly has the file open.
 - Index and embedding cache snapshot writes now share the same Windows rename retry path, avoiding avoidable cold-cache rebuilds after brief file-handle conflicts.
 - Failure summaries for tag renames and semantic indexing now escape control characters in vault-relative paths before returning them to MCP clients.
+- Canvas responses now escape control characters in displayed node ids, edge labels, previews, and rejected input before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/canvas.test.ts
+++ b/src/__tests__/handlers/canvas.test.ts
@@ -55,6 +55,55 @@ describe("canvas handlers — read_canvas", () => {
     expect(isError(result)).toBe(true);
     expect(textContent(result)).toMatch(/malformed JSON/i);
   });
+
+  it("escapes control characters in vault-authored canvas output", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, "dirty.canvas"),
+      JSON.stringify({
+        nodes: [
+          {
+            id: "bad\nnode",
+            type: "text",
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 80,
+            text: "first\nsecond",
+          },
+          {
+            id: "clean",
+            type: "text",
+            x: 300,
+            y: 0,
+            width: 200,
+            height: 80,
+            text: "clean",
+          },
+        ],
+        edges: [
+          {
+            id: "edge-1",
+            fromNode: "bad\nnode",
+            toNode: "clean",
+            label: "label\nspoof",
+          },
+        ],
+      }),
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "read_canvas",
+      arguments: { path: "dirty.canvas" },
+    });
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain("[bad\\nnode] type=text");
+    expect(text).toContain("content: first\\nsecond");
+    expect(text).toContain("bad\\nnode -> clean [label\\nspoof]");
+    expect(text).not.toContain("bad\nnode");
+    expect(text).not.toContain("label\nspoof");
+  });
 });
 
 describe("canvas handlers — add_canvas_node", () => {
@@ -176,5 +225,36 @@ describe("canvas handlers — add_canvas_edge", () => {
     });
     expect(isError(result)).toBe(true);
     expect(textContent(result)).toMatch(/target node.*ghost.*not found/i);
+  });
+
+  it("escapes control characters in missing-node errors", async () => {
+    const result = await env.client.callTool({
+      name: "add_canvas_edge",
+      arguments: {
+        canvasPath: "boards/test.canvas",
+        fromNode: "ghost\nnode",
+        toNode: "n2",
+      },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain("source node 'ghost\\nnode' not found");
+    expect(text).not.toContain("ghost\nnode");
+  });
+
+  it("escapes control characters in the success message label", async () => {
+    const result = await env.client.callTool({
+      name: "add_canvas_edge",
+      arguments: {
+        canvasPath: "boards/test.canvas",
+        fromNode: "n2",
+        toNode: "n1",
+        label: "safe\nlabel",
+      },
+    });
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain("Label: safe\\nlabel");
+    expect(text).not.toContain("safe\nlabel");
   });
 });

--- a/src/tools/canvas.ts
+++ b/src/tools/canvas.ts
@@ -1,13 +1,17 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { listCanvasFiles, readCanvasFile, updateCanvasFile, resolveVaultPathSafe } from "../lib/vault.js";
-import { sanitizeError } from "../lib/errors.js";
+import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { log } from "../lib/logger.js";
 import type { CanvasNode, CanvasData } from "../types.js";
 import { randomUUID } from "crypto";
 
 function errorResult(text: string) {
   return { content: [{ type: "text" as const, text }], isError: true as const };
+}
+
+function displayCanvasValue(value: string): string {
+  return escapeControlChars(value);
 }
 
 export function registerCanvasTools(server: McpServer, vaultPath: string): void {
@@ -32,7 +36,7 @@ export function registerCanvasTools(server: McpServer, vaultPath: string): void 
           return { content: [{ type: "text" as const, text: "No canvas files found in the vault." }] };
         }
 
-        const formatted = files.map((f, i) => `${i + 1}. ${f}`).join("\n");
+        const formatted = files.map((f, i) => `${i + 1}. ${displayCanvasValue(f)}`).join("\n");
         return {
           content: [{ type: "text" as const, text: `Found ${files.length} canvas file(s):\n\n${formatted}` }],
         };
@@ -68,7 +72,7 @@ export function registerCanvasTools(server: McpServer, vaultPath: string): void 
         const data = await readCanvasFile(vaultPath, canvasPath);
         const lines: string[] = [];
 
-        lines.push(`Canvas: ${canvasPath}`);
+        lines.push(`Canvas: ${displayCanvasValue(canvasPath)}`);
         lines.push(`Nodes: ${data.nodes.length} | Edges: ${data.edges.length}`);
         lines.push("");
 
@@ -91,12 +95,14 @@ export function registerCanvasTools(server: McpServer, vaultPath: string): void 
               preview = `Group: ${node.label}`;
             }
 
-            lines.push(`  [${node.id}] type=${node.type} pos=${pos} size=${size}`);
+            lines.push(
+              `  [${displayCanvasValue(node.id)}] type=${displayCanvasValue(node.type)} pos=${pos} size=${size}`,
+            );
             if (preview) {
-              lines.push(`    content: ${preview}`);
+              lines.push(`    content: ${displayCanvasValue(preview)}`);
             }
             if (node.color) {
-              lines.push(`    color: ${node.color}`);
+              lines.push(`    color: ${displayCanvasValue(node.color)}`);
             }
           }
           lines.push("");
@@ -105,13 +111,15 @@ export function registerCanvasTools(server: McpServer, vaultPath: string): void 
         if (data.edges.length > 0) {
           lines.push("--- Edges ---");
           for (const edge of data.edges) {
-            const label = edge.label ? ` [${edge.label}]` : "";
+            const label = edge.label ? ` [${displayCanvasValue(edge.label)}]` : "";
             const sides = [
-              edge.fromSide ? `from-side=${edge.fromSide}` : "",
-              edge.toSide ? `to-side=${edge.toSide}` : "",
+              edge.fromSide ? `from-side=${displayCanvasValue(edge.fromSide)}` : "",
+              edge.toSide ? `to-side=${displayCanvasValue(edge.toSide)}` : "",
             ].filter(Boolean).join(" ");
             const sideInfo = sides ? ` (${sides})` : "";
-            lines.push(`  ${edge.fromNode} -> ${edge.toNode}${label}${sideInfo}`);
+            lines.push(
+              `  ${displayCanvasValue(edge.fromNode)} -> ${displayCanvasValue(edge.toNode)}${label}${sideInfo}`,
+            );
           }
         }
 
@@ -211,7 +219,7 @@ export function registerCanvasTools(server: McpServer, vaultPath: string): void 
             await resolveVaultPathSafe(vaultPath, content);
           } catch {
             return errorResult(
-              `Invalid file reference: "${content}" must be a relative path inside the vault.`,
+              `Invalid file reference: "${displayCanvasValue(content)}" must be a relative path inside the vault.`,
             );
           }
         }
@@ -221,7 +229,7 @@ export function registerCanvasTools(server: McpServer, vaultPath: string): void 
           // canvas is opened in Obsidian or exported to HTML.
           if (/^(javascript|data|vbscript):/i.test(content)) {
             return errorResult(
-              `Invalid URL scheme in "${content}". javascript:, data:, and vbscript: URIs are not allowed.`,
+              `Invalid URL scheme in "${displayCanvasValue(content)}". javascript:, data:, and vbscript: URIs are not allowed.`,
             );
           }
         }
@@ -327,7 +335,7 @@ export function registerCanvasTools(server: McpServer, vaultPath: string): void 
         // BUG-15: Reject self-loops early before touching the canvas file.
         if (fromNode === toNode) {
           return errorResult(
-            `Self-loop rejected: fromNode and toNode are the same ('${fromNode}'). Edges must connect two different nodes.`,
+            `Self-loop rejected: fromNode and toNode are the same ('${displayCanvasValue(fromNode)}'). Edges must connect two different nodes.`,
           );
         }
 
@@ -336,12 +344,14 @@ export function registerCanvasTools(server: McpServer, vaultPath: string): void 
         // deletion from sneaking in between the check and the write.
         class MissingNodeError extends Error {
           constructor(public side: "source" | "target", public nodeId: string) {
-            super(`${side} node '${nodeId}' not found in canvas.`);
+            super(`${side} node '${displayCanvasValue(nodeId)}' not found in canvas.`);
           }
         }
         class DuplicateEdgeError extends Error {
           constructor(public from: string, public to: string) {
-            super(`An edge from '${from}' to '${to}' already exists on the canvas.`);
+            super(
+              `An edge from '${displayCanvasValue(from)}' to '${displayCanvasValue(to)}' already exists on the canvas.`,
+            );
           }
         }
         try {
@@ -377,7 +387,10 @@ export function registerCanvasTools(server: McpServer, vaultPath: string): void 
         }
 
         return {
-          content: [{ type: "text" as const, text: `Edge added successfully.\nID: ${id}\nFrom: ${fromNode} -> To: ${toNode}${label ? `\nLabel: ${label}` : ""}` }],
+          content: [{
+            type: "text" as const,
+            text: `Edge added successfully.\nID: ${id}\nFrom: ${displayCanvasValue(fromNode)} -> To: ${displayCanvasValue(toNode)}${label ? `\nLabel: ${displayCanvasValue(label)}` : ""}`,
+          }],
         };
       } catch (err) {
         log.error("add_canvas_edge failed", { tool: "add_canvas_edge", err: err as Error });


### PR DESCRIPTION
Escapes control characters before canvas responses echo node ids, edge labels, previews, paths, or rejected input. Raw canvas JSON is unchanged; only client-facing text is escaped so malicious newlines cannot shape the MCP response.

Score: 3 severity x 3 reach / 1 effort = 9.
Risk: low; display-only escaping for canvas tool output.
Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds control-character escaping to all client-facing canvas tool responses, preventing malicious newlines or other ASCII control characters embedded in canvas node ids, edge labels, content previews, file paths, and rejected input from shaping MCP response text. The raw canvas JSON written to disk is unchanged; only the human-readable summary returned to the client is affected.

- `displayCanvasValue` (a thin wrapper over the existing `escapeControlChars` helper) is applied to every vault-authored or user-supplied string interpolated into `read_canvas`, `list_canvases`, and `add_canvas_edge` responses, as well as all error messages that echo back user input.
- Three integration tests are added covering `read_canvas` with malicious node ids/edge labels, `add_canvas_edge` missing-node errors, and `add_canvas_edge` success labels; `list_canvases` escaping remains untested.
- `MissingNodeError` and `DuplicateEdgeError` store the raw un-escaped node ids as public properties alongside the correctly escaped `message`; this is benign today but is a latent footgun if those fields are ever used for display.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is display-only and the raw canvas JSON is never mutated.

The escaping logic itself is correct and well-exercised for read_canvas and add_canvas_edge. The gap is a missing integration test for list_canvases and a latent footgun in the public error-object fields — neither affects current behavior.

src/__tests__/handlers/canvas.test.ts — list_canvases escaping is not covered by any new test. src/tools/canvas.ts — the raw nodeId/from/to properties on the inner error classes warrant a second look if those fields are ever used downstream.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/tools/canvas.ts | Adds displayCanvasValue wrapper and applies escaping to all user-visible canvas fields (node ids, types, previews, colors, edge labels, sides, node references, and rejected input). Coverage is comprehensive across read, list, and edge-creation paths. |
| src/__tests__/handlers/canvas.test.ts | Adds three escaping tests: read_canvas with malicious node ids/edge labels, add_canvas_edge missing-node error, and add_canvas_edge success label. list_canvases escaping has no corresponding test. |
| CHANGELOG.md | Adds changelog entry for the canvas control-character escaping fix. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Tool as canvas.ts handler
    participant FS as readCanvasFile / listCanvasFiles
    participant Escape as escapeControlChars

    Client->>Tool: read_canvas / list_canvases / add_canvas_edge
    Tool->>FS: read canvas JSON from vault
    FS-->>Tool: raw CanvasData (unvalidated string fields)
    Note over Tool: Build human-readable response lines
    Tool->>Escape: displayCanvasValue(node.id / edge.label / path / …)
    Escape-->>Tool: control chars replaced with \\n, \\r, \\xHH …
    Tool-->>Client: Safe, escaped text response
    Note over FS: Canvas JSON on disk is never modified
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/__tests__/handlers/canvas.test.ts`, line 16-26 ([link](https://github.com/rps321321/obsidian-mcp-pro/blob/00e4d4eb6a0bbee3624e28738b2d1cb4bc24f85d/src/__tests__/handlers/canvas.test.ts#L16-L26)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing escaping test for `list_canvases`**

   Three of the four tools now have explicit escaping integration tests, but `list_canvases` has no test for a file whose path contains a control character (e.g. a newline embedded in the vault-relative canvas path). If `listCanvasFiles` ever returns such a path, `displayCanvasValue` is the only guard and its correctness is currently untested for this code path.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: escape canvas response values"](https://github.com/rps321321/obsidian-mcp-pro/commit/00e4d4eb6a0bbee3624e28738b2d1cb4bc24f85d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35495483)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->