### PR TITLE
chore: register resources with current sdk api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Index and embedding cache snapshot writes now share the same Windows rename retry path, avoiding avoidable cold-cache rebuilds after brief file-handle conflicts.
 - Failure summaries for tag renames and semantic indexing now escape control characters in vault-relative paths before returning them to MCP clients.
 - Canvas responses now escape control characters in displayed node ids, edge labels, previews, and rejected input before returning them to MCP clients.
+- MCP resources now register through the current SDK `registerResource` API, with regression coverage for resource listing and reads.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/resources.test.ts
+++ b/src/__tests__/handlers/resources.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createTestEnv, type TestEnv } from "./harness.js";
+
+let env: TestEnv;
+
+beforeEach(async () => {
+  env = await createTestEnv();
+});
+
+afterEach(async () => {
+  await env.cleanup();
+});
+
+function firstText(contents: Array<{ text?: string }>): string {
+  const first = contents[0];
+  expect(first?.text).toBeTypeOf("string");
+  return first.text ?? "";
+}
+
+describe("MCP resources", () => {
+  it("lists static resources and the note template", async () => {
+    const resources = await env.client.listResources();
+    const listed = resources.resources
+      .map((resource) => ({ name: resource.name, uri: resource.uri }))
+      .sort((a, b) => a.uri.localeCompare(b.uri));
+
+    expect(listed).toEqual([
+      { name: "daily", uri: "obsidian://daily" },
+      { name: "tags", uri: "obsidian://tags" },
+    ]);
+
+    const templates = await env.client.listResourceTemplates();
+    expect(templates.resourceTemplates).toEqual([
+      expect.objectContaining({
+        name: "note",
+        uriTemplate: "obsidian://note/{+path}",
+      }),
+    ]);
+  });
+
+  it("reads note resources through the note URI template", async () => {
+    const result = await env.client.readResource({ uri: "obsidian://note/nested/note-d.md" });
+    const content = result.contents[0];
+
+    expect(content).toMatchObject({
+      uri: "obsidian://note/nested/note-d.md",
+      mimeType: "text/markdown",
+    });
+    expect(firstText(result.contents)).toContain("Nested note that references [[note-a]].");
+  });
+
+  it("reads the tag index resource as JSON", async () => {
+    const result = await env.client.readResource({ uri: "obsidian://tags" });
+    const content = result.contents[0];
+
+    expect(content).toMatchObject({
+      uri: "obsidian://tags",
+      mimeType: "application/json",
+    });
+
+    const tags = JSON.parse(firstText(result.contents)) as Record<string, string[]>;
+    expect(tags["#review"]).toEqual(expect.arrayContaining(["note-a.md", "note-b.md"]));
+    expect(tags["#nested/archive"]).toEqual(["nested/note-d.md"]);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,9 +212,10 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
 
   // --- MCP Resources ---
 
-  server.resource(
+  server.registerResource(
     "note",
     new ResourceTemplate("obsidian://note/{+path}", { list: undefined }),
+    {},
     async (uri: URL, params: Variables) => {
       if (!vaultPath) throw new Error(noVaultError);
       const rawPath = params.path;
@@ -242,7 +243,7 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
     }
   );
 
-  server.resource("tags", "obsidian://tags", async (uri) => {
+  server.registerResource("tags", "obsidian://tags", {}, async (uri) => {
     if (!vaultPath) throw new Error(noVaultError);
     const tagIndex: Record<string, string[]> = {};
     const notes = await listNotes(vaultPath);
@@ -275,7 +276,7 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
     };
   });
 
-  server.resource("daily", "obsidian://daily", async (uri) => {
+  server.registerResource("daily", "obsidian://daily", {}, async (uri) => {
     if (!vaultPath) throw new Error(noVaultError);
     const dailyConfig = await getDailyNoteConfig(vaultPath);
     let filename = formatMomentDate(new Date(), dailyConfig.format);


### PR DESCRIPTION
MCP SDK 1.29 marks the `server.resource()` overloads deprecated in `src/server/mcp.ts`; this moves the three resources to `registerResource` while preserving their URI and template behavior. Adds in-memory client coverage for resource listing plus note and tag reads.

Score: 2 severity x 3 reach / 1 effort = 6.
Risk: low; registration API swap with protocol-level resource tests.
Tested: npm run verify.
Source checked: @modelcontextprotocol/sdk 1.29.0 via OpenSrc.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Migrates three MCP resource registrations from the deprecated `server.resource()` overloads to `server.registerResource()` as required by SDK 1.29, and adds a new integration test file that covers resource listing, note template reads, and tag index reads via an in-memory client.

- `src/index.ts`: All three resource registrations (`note`, `tags`, `daily`) are updated to `registerResource` with an empty metadata object `{}`; handler logic is untouched.
- `src/__tests__/handlers/resources.test.ts`: New test file wires a real `Client` to a real `McpServer` over `InMemoryTransport`, asserting on listed resources, template metadata, and content from two of the three handlers; the `daily` read is omitted because the handler throws when today's dated file is absent from the fixture vault.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a straight API rename with identical handler logic and passing integration tests for two of the three resources.

The migration itself is mechanical and the in-memory client tests confirm the two exercised paths behave correctly. The only gap is the daily resource read, which is intentionally absent because the handler would error against the static fixture vault; this leaves the date-formatting and readNote call path in the daily handler untested by the new suite.

The new resources.test.ts would benefit from a small extraFiles-based fixture to close the daily read gap.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/index.ts | Migrates three MCP resource registrations from deprecated server.resource() to server.registerResource(), inserting an empty metadata object {} as the third argument; handler logic is unchanged. |
| src/__tests__/handlers/resources.test.ts | New test file exercising resource listing, note template reads, and tag index reads via in-memory client; the daily resource read is not covered because today's date won't match any static fixture. |
| CHANGELOG.md | Adds a changelog entry for the registerResource migration and regression coverage under the current unreleased section. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildMcpServer] --> B[registerResource: note\nResourceTemplate]
    A --> C[registerResource: tags\nstatic URI]
    A --> D[registerResource: daily\nstatic URI]

    B --> F[resolveVaultPathSafe + readFile]
    F --> G[Return text/markdown content]

    C --> H[listNotes + readAllCached + extractTags]
    H --> I[Return application/json tagIndex]

    D --> J[getDailyNoteConfig + formatMomentDate + readNote]
    J --> K[Return text/markdown daily note]
    J -->|file missing| L[throw Error - no daily note]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: register resources with current s..."](https://github.com/rps321321/obsidian-mcp-pro/commit/f86b1666c9f0e2d323224b2133b31fb4bb34b881) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35497320)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->