### PR TITLE
fix: escape tag search output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Failure summaries for tag renames and semantic indexing now escape control characters in vault-relative paths before returning them to MCP clients.
 - Canvas responses now escape control characters in displayed node ids, edge labels, previews, and rejected input before returning them to MCP clients.
 - MCP resources now register through the current SDK `registerResource` API, with regression coverage for resource listing and reads.
+- `search_by_tag` now escapes control characters in displayed tag labels, note paths, and content previews before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/tags.test.ts
+++ b/src/__tests__/handlers/tags.test.ts
@@ -93,6 +93,17 @@ describe("tag handlers — search_by_tag", () => {
     expect(textContent(result)).toMatch(/No notes found/i);
   });
 
+  it("escapes control characters in the searched tag label", async () => {
+    const result = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "does-not\nexist" },
+    });
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain("No notes found with tag #does-not\\nexist");
+    expect(text).not.toContain("does-not\nexist");
+  });
+
   it("includes a 200-char preview when includeContent=true", async () => {
     const result = await env.client.callTool({
       name: "search_by_tag",
@@ -104,6 +115,8 @@ describe("tag handlers — search_by_tag", () => {
     expect(text).toContain("note-b.md");
     // Frontmatter is now stripped from previews, so verify body content appears instead.
     expect(text).toMatch(/Note A|Note B/);
+    expect(text).toContain("# Note A\\n\\nLinks to [[note-b]]");
+    expect(text).not.toContain("# Note A\n\nLinks to [[note-b]]");
   });
 
   it("honors maxResults cap", async () => {

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -5,7 +5,7 @@ import { extractTags } from "../lib/markdown.js";
 import { isValidTagName, rewriteAllTags } from "../lib/tag-rewriter.js";
 import { readAllCached } from "../lib/index-cache.js";
 import { makeProgressReporter } from "../lib/progress.js";
-import { sanitizeError } from "../lib/errors.js";
+import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { formatFailedPath } from "../lib/tool-output.js";
 import { mapConcurrent } from "../lib/concurrency.js";
 import { log } from "../lib/logger.js";
@@ -14,6 +14,10 @@ import type { TagInfo } from "../types.js";
 
 function errorResult(text: string) {
   return { content: [{ type: "text" as const, text }], isError: true as const };
+}
+
+function displayTagSearchValue(value: string): string {
+  return escapeControlChars(value);
 }
 
 export function registerTagTools(server: McpServer, vaultPath: string): void {
@@ -160,19 +164,21 @@ export function registerTagTools(server: McpServer, vaultPath: string): void {
         if (matchingNotes.length === 0) {
           return {
             content: [
-              { type: "text" as const, text: `No notes found with tag #${searchTag}` },
+              { type: "text" as const, text: `No notes found with tag #${displayTagSearchValue(searchTag)}` },
             ],
           };
         }
 
         const lines: string[] = [];
-        lines.push(`Found ${matchingNotes.length} ${matchingNotes.length === 1 ? "note" : "notes"} with tag #${searchTag}`);
+        lines.push(
+          `Found ${matchingNotes.length} ${matchingNotes.length === 1 ? "note" : "notes"} with tag #${displayTagSearchValue(searchTag)}`,
+        );
         lines.push("");
 
         for (const note of matchingNotes) {
-          lines.push(`- ${note.path}`);
+          lines.push(`- ${displayTagSearchValue(note.path)}`);
           if (note.preview) {
-            lines.push(`  ${note.preview}`);
+            lines.push(`  ${displayTagSearchValue(note.preview)}`);
             lines.push("");
           }
         }


### PR DESCRIPTION
Escapes control characters in `search_by_tag` display values before returning them to MCP clients. Matching still uses the raw normalized tag; only response text for the searched label, matching paths, and previews is escaped.

Score: 3 severity x 3 reach / 1 effort = 9.
Risk: low; display-only escaping in a read tool.
Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR applies `escapeControlChars` to the `search_by_tag` tool's display output — the searched tag label, matching note paths, and content previews — using a new `displayTagSearchValue` helper, and adds two targeted tests to verify the escaping on both the no-match and preview paths.

- `search_by_tag` now escapes all three interpolated display values (`searchTag`, `note.path`, `note.preview`) before they enter the MCP response, preventing control-character injection from vault content or crafted tag inputs.
- The sibling `list_tags` handler in the same file still outputs raw tag names; a parallel fix there would complete the defense-in-depth pattern this PR establishes.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; this is a display-only escaping change on a read-only tool with no writes or schema changes involved.

The escaping logic, helper, and tests are correct. The only gap is that `list_tags` in the same file still outputs raw tag names, leaving a small inconsistency that the same pattern of crafted frontmatter could theoretically exploit — but fixing `search_by_tag` alone is still a strict improvement.

src/tools/tags.ts — the `list_tags` handler at line 90 outputs tag names without escaping, unlike the now-fixed `search_by_tag` paths.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/tools/tags.ts | Adds `displayTagSearchValue` wrapper and applies `escapeControlChars` to `searchTag`, `note.path`, and `note.preview` in `search_by_tag`; `list_tags` in the same file still outputs raw tag names without escaping. |
| src/__tests__/handlers/tags.test.ts | Adds two new assertions: one verifying control characters in the tag label are escaped on a no-match path, and one verifying preview newlines are escaped to literal `\n` sequences. Both tests look correct. |
| CHANGELOG.md | Adds a CHANGELOG entry for the `search_by_tag` escaping fix in the Unreleased section. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Tool as search_by_tag handler
    participant Vault as Vault / Cache
    participant Escape as escapeControlChars

    Client->>Tool: "callTool({ tag, includeContent })"
    Tool->>Tool: "searchTag = tag.replace(/#/, "").toLowerCase()"
    Tool->>Vault: readAllCached(vaultPath, notes)
    Vault-->>Tool: contents map
    loop each note
        Tool->>Tool: extractTags(content)
        alt tag matches
            Tool->>Tool: "push { path, preview? }"
        end
    end
    alt no matches
        Tool->>Escape: displayTagSearchValue(searchTag)
        Escape-->>Tool: escaped label
        Tool-->>Client: "No notes found with tag #escaped"
    else matches found
        Tool->>Escape: displayTagSearchValue(searchTag)
        loop each matching note
            Tool->>Escape: displayTagSearchValue(note.path)
            Tool->>Escape: displayTagSearchValue(note.preview)
        end
        Escape-->>Tool: escaped values
        Tool-->>Client: formatted list with escaped paths and previews
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/tools/tags.ts`, line 89-91 ([link](https://github.com/rps321321/obsidian-mcp-pro/blob/a4f8c29652705be9f94667c1b7cebc4885105ec8/src/tools/tags.ts#L89-L91)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `list_tags` in the same file outputs `info.tag` directly without escaping. While Obsidian's tag parser is unlikely to produce tags with embedded control characters, vault content is attacker-controlled (a crafted frontmatter `tags:` field could contain a raw newline). Applying `escapeControlChars` here keeps `list_tags` consistent with the defense-in-depth posture established by this PR.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: escape tag search output"](https://github.com/rps321321/obsidian-mcp-pro/commit/a4f8c29652705be9f94667c1b7cebc4885105ec8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35498502)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->