### PR TITLE
fix: escape note search output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Canvas responses now escape control characters in displayed node ids, edge labels, previews, and rejected input before returning them to MCP clients.
 - MCP resources now register through the current SDK `registerResource` API, with regression coverage for resource listing and reads.
 - `search_by_tag` now escapes control characters in displayed tag labels, note paths, and content previews before returning them to MCP clients.
+- `search_notes` now escapes control characters in displayed query labels, result paths, and matched line snippets before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
 import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
 
 let env: TestEnv;
@@ -64,6 +66,30 @@ describe("read handlers — search_notes", () => {
     });
     expect(isError(result)).toBe(false);
     expect(textContent(result)).toMatch(/No results found/);
+  });
+
+  it("escapes control characters in the zero-result query label", async () => {
+    const result = await env.client.callTool({
+      name: "search_notes",
+      arguments: { query: "missing\nphrase" },
+    });
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain('No results found for "missing\\nphrase"');
+    expect(text).not.toContain("missing\nphrase");
+  });
+
+  it("escapes control characters in matched line snippets", async () => {
+    await fs.writeFile(path.join(env.vaultDir, "dirty.md"), "needle\tvalue\n", "utf-8");
+
+    const result = await env.client.callTool({
+      name: "search_notes",
+      arguments: { query: "needle" },
+    });
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain("Line 1: needle\\tvalue");
+    expect(text).not.toContain("needle\tvalue");
   });
 
   it("rejects empty query via zod validation (tool-level isError)", async () => {

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -4,7 +4,7 @@ import fs from "fs/promises";
 import path from "path";
 import { searchInContents, readNote, listNotes, resolveVaultPathSafe } from "../lib/vault.js";
 import { readAllCached } from "../lib/index-cache.js";
-import { sanitizeError } from "../lib/errors.js";
+import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { log } from "../lib/logger.js";
 import { mapConcurrent } from "../lib/concurrency.js";
 import { formatLocalDateOnly, formatMomentDate, parseLocalDateOnly } from "../lib/dates.js";
@@ -14,6 +14,10 @@ import { getDailyNoteConfig } from "../config.js";
 
 /** Maximum number of concurrent file I/O operations for parallel vault scans. */
 const MAX_CONCURRENT_OPS = 16;
+
+function displayReadValue(value: string): string {
+  return escapeControlChars(value);
+}
 
 export function registerReadTools(server: McpServer, vaultPath: string): void {
   function errorResult(text: string) {
@@ -76,21 +80,21 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
             content: [
               {
                 type: "text" as const,
-                text: `No results found for "${query}"`,
+                text: `No results found for "${displayReadValue(query)}"`,
               },
             ],
           };
         }
 
         const lines: string[] = [
-          `Found ${results.length} result(s) for "${query}":`,
+          `Found ${results.length} result(s) for "${displayReadValue(query)}":`,
           "",
         ];
 
         for (const result of results) {
-          lines.push(`## ${result.relativePath}`);
+          lines.push(`## ${displayReadValue(result.relativePath)}`);
           for (const match of result.matches) {
-            lines.push(`  Line ${match.line}: ${match.content}`);
+            lines.push(`  Line ${match.line}: ${displayReadValue(match.content)}`);
           }
           lines.push("");
         }


### PR DESCRIPTION
Escapes control characters in `search_notes` display values before returning them to MCP clients. Literal matching is unchanged; only the query label, result path, and matched line snippets are escaped in the response.

Score: 3 severity x 3 reach / 1 effort = 9.
Risk: low; display-only escaping in a read tool.
Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR applies `escapeControlChars` to the three user-facing display fields in `search_notes` — the query label, result paths, and matched-line snippets — mirroring the same treatment already applied to `search_by_tag` and canvas responses. Two targeted tests cover the zero-result query label and tab-embedded line snippets.

- Adds a `displayReadValue` helper in `read.ts` that wraps `escapeControlChars` and applies it to query labels, `result.relativePath`, and `match.content` before they reach MCP clients.
- Two new integration tests verify the zero-result query label escaping and matched-line snippet escaping; the tests create a temporary `dirty.md` file in the vault and rely on `afterEach` cleanup.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are display-only escaping in a read-only tool with no mutations or side effects.

The escaping is applied correctly to all three display fields in search_notes, escapeControlChars is well-tested in the errors module, and the two new tests confirm the key injection scenarios. The only gap is that result.relativePath escaping is not covered by a test with an actually dirty path — a regression there would be silent.

The relativePath escaping in src/tools/read.ts (line 95) has no test exercising a control-char-bearing path; all other changed lines are covered.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/read.ts | Adds displayReadValue helper and applies it to search_notes outputs; logic is correct, helper is a trivial one-liner with no added behaviour over calling escapeControlChars directly |
| src/__tests__/handlers/read.test.ts | Adds two well-scoped integration tests for control-char escaping; imports and file-creation are valid and temp files are cleaned up by afterEach |
| CHANGELOG.md | Adds accurate changelog entry for search_notes escaping under the correct unreleased section |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[search_notes called] --> B[listNotes + readAllCached]
    B --> C[searchInContents]
    C --> D{results.length === 0?}
    D -- yes --> E["displayReadValue(query)\n→ escapeControlChars"]
    E --> F["No results found for {escaped query}"]
    D -- no --> G["displayReadValue(query) for header"]
    G --> H[For each result]
    H --> I["displayReadValue(result.relativePath)\n→ escapeControlChars"]
    I --> J[For each match]
    J --> K["displayReadValue(match.content)\n→ escapeControlChars"]
    K --> L[Append escaped line snippet]
    L --> M[Return joined text to MCP client]
    F --> M
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape note search output"](https://github.com/rps321321/obsidian-mcp-pro/commit/ef3c5191dddbe9d4a34eb8b5f591f85e561b6a1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35499674)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->