### PR TITLE
fix: escape frontmatter search output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP resources now register through the current SDK `registerResource` API, with regression coverage for resource listing and reads.
 - `search_by_tag` now escapes control characters in displayed tag labels, note paths, and content previews before returning them to MCP clients.
 - `search_notes` now escapes control characters in displayed query labels, result paths, and matched line snippets before returning them to MCP clients.
+- `search_by_frontmatter` now escapes control characters in displayed property labels, value labels, result paths, and frontmatter rows before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -243,6 +243,36 @@ describe("read handlers — search_by_frontmatter", () => {
     expect(textContent(result)).toMatch(/No notes found/i);
   });
 
+  it("escapes control characters in no-match property and value labels", async () => {
+    const result = await env.client.callTool({
+      name: "search_by_frontmatter",
+      arguments: { property: "status\nfield", value: "cancelled\nvalue" },
+    });
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain('frontmatter "status\\nfield" matching "cancelled\\nvalue"');
+    expect(text).not.toContain("status\nfield");
+    expect(text).not.toContain("cancelled\nvalue");
+  });
+
+  it("escapes control characters in matched frontmatter output", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, "frontmatter-dirty.md"),
+      "---\nstatus: \"tab\\tvalue\"\n---\n# Dirty frontmatter\n",
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "search_by_frontmatter",
+      arguments: { property: "status", value: "tab\tvalue" },
+    });
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain('"status" matches "tab\\tvalue"');
+    expect(text).toContain('status: "tab\\tvalue"');
+    expect(text).not.toContain("tab\tvalue");
+  });
+
   it("scopes to a folder when requested", async () => {
     const result = await env.client.callTool({
       name: "search_by_frontmatter",

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -438,7 +438,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
             content: [
               {
                 type: "text" as const,
-                text: `No notes found with frontmatter "${property}" matching "${value}"`,
+                text: `No notes found with frontmatter "${displayReadValue(property)}" matching "${displayReadValue(value)}"`,
               },
             ],
           };
@@ -449,14 +449,14 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         const matches = truncated ? allMatches.slice(0, maxResults) : allMatches;
 
         const lines: string[] = [
-          `Found ${totalMatches} note(s) where "${property}" matches "${value}"${truncated ? ` (showing first ${maxResults})` : ""}:`,
+          `Found ${totalMatches} note(s) where "${displayReadValue(property)}" matches "${displayReadValue(value)}"${truncated ? ` (showing first ${maxResults})` : ""}:`,
           "",
         ];
 
         for (const match of matches) {
-          lines.push(`## ${match.path}`);
+          lines.push(`## ${displayReadValue(match.path)}`);
           for (const [key, val] of Object.entries(match.frontmatter)) {
-            lines.push(`  ${key}: ${JSON.stringify(val)}`);
+            lines.push(`  ${displayReadValue(key)}: ${displayReadValue(JSON.stringify(val) ?? "")}`);
           }
           lines.push("");
         }


### PR DESCRIPTION
Escapes control characters in `search_by_frontmatter` display values before returning them to MCP clients. Matching still uses the raw property and value; only response labels, result paths, and rendered frontmatter rows are escaped.

Score: 3 severity x 3 reach / 1 effort = 9.
Risk: low; display-only escaping in a read tool.
Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the existing `displayReadValue` / `escapeControlChars` escaping pattern — already applied to `search_by_tag` and `search_notes` — to the `search_by_frontmatter` handler. All user-visible strings in the response (property label, value label, note paths, frontmatter key–value rows) are escaped before being returned to MCP clients; the matching logic itself is untouched.

- Display strings in both the no-match path and the match path now go through `escapeControlChars`, preventing raw newlines, tabs, and other control characters from reaching MCP clients.
- `JSON.stringify(val) ?? ""` serialises each frontmatter value before escaping; the `?? ""` guard is a sensible defensive measure since `val` is typed `unknown` and `JSON.stringify` returns `undefined` for `undefined` inputs.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is display-only escaping on a read tool with no effect on matching, persistence, or any write path.

All four display sites in the search_by_frontmatter response are covered. The escaping function is already well-tested in isolation and is applied consistently with the pattern used by search_by_tag and search_notes. The two new integration tests verify both the no-match and match code paths. No regressions are apparent.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/read.ts | Applies displayReadValue (wrapping escapeControlChars) to all display strings in search_by_frontmatter: property/value labels, note paths, frontmatter keys, and JSON-serialised frontmatter values. Matching logic is unchanged. |
| src/__tests__/handlers/read.test.ts | Adds two integration tests for the new escaping: one for the no-match path (property/value labels with embedded newlines) and one for the match path (tab character inside a YAML double-quoted string). Test fixture, search argument, and assertions are internally consistent. |
| CHANGELOG.md | Adds a changelog entry for search_by_frontmatter control-character escaping, consistent with the existing pattern used for search_by_tag and search_notes. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["MCP client calls search_by_frontmatter\n(raw property, raw value)"] --> B["Match notes using raw values\n(unchanged logic)"]
    B --> C{Any matches?}
    C -- No --> D["Format no-match message\ndisplayReadValue(property)\ndisplayReadValue(value)"]
    C -- Yes --> E["Format match header\ndisplayReadValue(property)\ndisplayReadValue(value)"]
    E --> F["For each matched note\ndisplayReadValue(match.path)"]
    F --> G["For each frontmatter key/value\ndisplayReadValue(key)\ndisplayReadValue(JSON.stringify(val))"]
    D --> H["Return escaped text to MCP client"]
    G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape frontmatter search output"](https://github.com/rps321321/obsidian-mcp-pro/commit/b87a07b3f5784ee64ff51aed990d966b910f4ea2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35500832)</sub>

<!-- /greptile_comment -->