### PR TITLE
fix: escape recent notes output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `search_by_tag` now escapes control characters in displayed tag labels, note paths, and content previews before returning them to MCP clients.
 - `search_notes` now escapes control characters in displayed query labels, result paths, and matched line snippets before returning them to MCP clients.
 - `search_by_frontmatter` now escapes control characters in displayed property labels, value labels, result paths, and frontmatter rows before returning them to MCP clients.
+- `get_recent_notes` now escapes control characters in displayed `since` labels and note paths before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -334,6 +334,17 @@ describe("read handlers — get_recent_notes", () => {
     expect(isError(result)).toBe(true);
     expect(textContent(result)).toMatch(/Invalid 'since' value/i);
   });
+
+  it("escapes control characters in invalid since values", async () => {
+    const result = await env.client.callTool({
+      name: "get_recent_notes",
+      arguments: { since: "bad\nsince" },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain('Invalid \'since\' value: "bad\\nsince"');
+    expect(text).not.toContain("bad\nsince");
+  });
 });
 
 describe("read handlers — get_vault_stats", () => {

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -511,7 +511,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
       try {
         const sinceMs = since ? parseSince(since) : null;
         if (since && sinceMs === null) {
-          return errorResult(`Invalid 'since' value: "${since}". Use ISO date or relative span like '7d', '24h', '2w'.`);
+          return errorResult(`Invalid 'since' value: "${displayReadValue(since)}". Use ISO date or relative span like '7d', '24h', '2w'.`);
         }
         const notes = await listNotes(vaultPath, folder);
 
@@ -542,16 +542,16 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         const top = rows.slice(0, limit);
 
         if (top.length === 0) {
-          return { content: [{ type: "text" as const, text: since ? `No notes modified since ${since}.` : "No notes in the vault." }] };
+          return { content: [{ type: "text" as const, text: since ? `No notes modified since ${displayReadValue(since)}.` : "No notes in the vault." }] };
         }
 
         const lines: string[] = [
-          `${rows.length} note(s)${since ? ` modified since ${since}` : ""}${rows.length > limit ? ` (showing first ${limit})` : ""}:`,
+          `${rows.length} note(s)${since ? ` modified since ${displayReadValue(since)}` : ""}${rows.length > limit ? ` (showing first ${limit})` : ""}:`,
           "",
         ];
         for (const r of top) {
           const iso = new Date(r.mtimeMs).toISOString();
-          lines.push(`- ${r.path}  (${iso})`);
+          lines.push(`- ${displayReadValue(r.path)}  (${iso})`);
         }
         return { content: [{ type: "text" as const, text: lines.join("\n") }] };
       } catch (err) {


### PR DESCRIPTION
Escapes control characters in `get_recent_notes` display values before returning them to MCP clients. Date filtering is unchanged; only the displayed `since` label and note paths are escaped.

Score: 2 severity x 3 reach / 1 effort = 6.
Risk: low; display-only escaping in a read tool.
Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Applies the same `displayReadValue()` / `escapeControlChars()` pattern — already in use for `search_notes`, `search_by_tag`, and `search_by_frontmatter` — to the three output sites in `get_recent_notes`: the invalid-`since` error message, the zero-results message, and the per-note path lines in the success listing.

- `src/tools/read.ts`: `displayReadValue()` is now called around `since` in all three message branches and around `r.path` in the note-listing loop; date filtering uses the original unescaped value, so behaviour is unchanged.
- `src/__tests__/handlers/read.test.ts`: adds a test asserting that a newline in `since` is rendered as `\
` in the error response and does not appear as a literal newline; escaping of paths in the success output is not yet tested.
- `CHANGELOG.md`: entry added under the current unreleased section, consistent with prior escaping entries.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is display-only, date filtering is untouched, and the escaping logic is reused from an already-tested utility.

The three production call-sites in read.ts are each a straightforward, correct substitution. The one gap is that the new test only exercises the error path (bad since), leaving the success path's path-escaping without a regression guard — a minor but real coverage hole given the PR explicitly calls out path escaping as part of the fix.

src/__tests__/handlers/read.test.ts — the success-path branch where note paths are escaped has no corresponding test.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/read.ts | Wraps `since` and `r.path` display values with `displayReadValue()` in all three output branches of `get_recent_notes`, consistently applying the same escaping pattern already used by other tools in this file. |
| src/__tests__/handlers/read.test.ts | Adds a test for the invalid-since error path confirming control chars in `since` are escaped. The success path where a note path itself contains control characters is not covered. |
| CHANGELOG.md | Adds a changelog entry for `get_recent_notes` escaping, consistent in style with the preceding entries for other tools. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Handler as get_recent_notes handler
    participant parseSince
    participant listNotes
    participant fs as fs.stat
    participant displayReadValue

    Client->>Handler: call(since, limit, folder)
    Handler->>parseSince: parseSince(since)
    alt since is invalid
        parseSince-->>Handler: null
        Handler->>displayReadValue: displayReadValue(since)
        displayReadValue-->>Handler: escaped string
        Handler-->>Client: errorResult(Invalid since value escaped)
    else since is valid or absent
        parseSince-->>Handler: "sinceMs (number | null)"
        Handler->>listNotes: listNotes(vaultPath, folder)
        listNotes-->>Handler: note paths[]
        loop each note path
            Handler->>fs: stat(fullPath)
            fs-->>Handler: mtimeMs
        end
        Handler->>Handler: filter by sinceMs, sort, slice(limit)
        alt "top.length === 0"
            Handler->>displayReadValue: displayReadValue(since)
            displayReadValue-->>Handler: escaped since
            Handler-->>Client: No notes modified since escaped.
        else "top.length > 0"
            loop each note row
                Handler->>displayReadValue: displayReadValue(r.path)
                displayReadValue-->>Handler: escaped path
            end
            Handler-->>Client: note listing with escaped paths
        end
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape recent notes output"](https://github.com/rps321321/obsidian-mcp-pro/commit/0b6a019006b651fd6e87c19c7cc7b177c9071612) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35502108)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->