### PR TITLE
fix: escape get_note fragment errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `search_notes` now escapes control characters in displayed query labels, result paths, and matched line snippets before returning them to MCP clients.
 - `search_by_frontmatter` now escapes control characters in displayed property labels, value labels, result paths, and frontmatter rows before returning them to MCP clients.
 - `get_recent_notes` now escapes control characters in displayed `since` labels and note paths before returning them to MCP clients.
+- `get_note` now escapes control characters in missing section and block error labels before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -135,6 +135,28 @@ describe("read handlers — get_note", () => {
     });
     expect(isError(result)).toBe(true);
   });
+
+  it("escapes control characters in missing section errors", async () => {
+    const result = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "note-a.md", section: "Missing\nHeading" },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain('Section not found: "Missing\\nHeading" in note-a.md');
+    expect(text).not.toContain("Missing\nHeading");
+  });
+
+  it("escapes control characters in missing block errors", async () => {
+    const result = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "note-a.md", block: "bad\nblock" },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain('Block not found: "^bad\\nblock" in note-a.md');
+    expect(text).not.toContain("bad\nblock");
+  });
 });
 
 describe("read handlers — list_notes", () => {

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -154,7 +154,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
           const headingPath = section.split("/").map((s) => s.trim()).filter(Boolean);
           const found = findSection(content, headingPath);
           if (!found) {
-            return errorResult(`Section not found: "${section}" in ${notePath}`);
+            return errorResult(`Section not found: "${displayReadValue(section)}" in ${displayReadValue(notePath)}`);
           }
           return {
             content: [
@@ -169,7 +169,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         if (block) {
           const found = findBlockById(content, block);
           if (!found) {
-            return errorResult(`Block not found: "^${block}" in ${notePath}`);
+            return errorResult(`Block not found: "^${displayReadValue(block)}" in ${displayReadValue(notePath)}`);
           }
           return {
             content: [


### PR DESCRIPTION
Escapes control characters in `get_note` missing section and block error labels before returning them to MCP clients. Fragment extraction and returned note content are unchanged.

Score: 3 severity x 3 reach / 1 effort = 9.
Risk: low; display-only escaping in fragment miss errors.
Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR applies consistent control-character escaping to the two remaining unescaped error paths in `get_note` — the "section not found" and "block not found" messages — bringing it in line with the pattern already applied to `search_notes`, `search_by_frontmatter`, and `get_recent_notes`.

- Both the user-supplied `section`/`block` value and the `notePath` are now wrapped with `displayReadValue()` (which calls `escapeControlChars`) before being interpolated into the error string.
- Two integration tests verify the new behavior for newline-bearing section and block inputs.
- No fragment-extraction or returned note-content logic is touched.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is two-line, display-only, and has no effect on fragment extraction or returned note content.

The escaping is applied only in the two error-message branches for missing sections and missing blocks. The `displayReadValue` helper is the same one used consistently across every other tool in the file. Tests directly verify both new paths with newline-bearing inputs, and no existing behavior is modified.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/read.ts | Adds `displayReadValue()` wrapping to the section-not-found and block-not-found error messages in `get_note`; consistent with the escaping pattern across the rest of the file. |
| src/__tests__/handlers/read.test.ts | Adds two integration tests that pass control-character-containing section and block values and assert the escaped output; matches the test pattern used for earlier escaping PRs. |
| CHANGELOG.md | Adds a changelog entry for the `get_note` escaping fix; accurate and consistent with prior entries. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP client calls get_note] --> B{fragment mode?}
    B -- section --> C[findSection in content]
    C -- found --> D[return raw section text]
    C -- not found --> E["displayReadValue(section)\ndisplayReadValue(notePath)"]
    E --> F[errorResult: Section not found]
    B -- block --> G[findBlockById in content]
    G -- found --> H[return stripBlockId text]
    G -- not found --> I["displayReadValue(block)\ndisplayReadValue(notePath)"]
    I --> J[errorResult: Block not found]
    B -- lines --> K[slice allLines]
    B -- none --> L[return frontmatter + tags + body]

    style E fill:#d4edda,stroke:#28a745
    style I fill:#d4edda,stroke:#28a745
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape get\_note fragment errors"](https://github.com/rps321321/obsidian-mcp-pro/commit/2974074bafbe5a1bd06ad5dea653d8ebe72f592d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35503115)</sub>

<!-- /greptile_comment -->