### PR TITLE
fix: escape resolve_alias output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `search_by_frontmatter` now escapes control characters in displayed property labels, value labels, result paths, and frontmatter rows before returning them to MCP clients.
 - `get_recent_notes` now escapes control characters in displayed `since` labels and note paths before returning them to MCP clients.
 - `get_note` now escapes control characters in missing section and block error labels before returning them to MCP clients.
+- `resolve_alias` now escapes control characters in displayed alias labels and result paths before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -441,4 +441,15 @@ describe("read handlers — resolve_alias", () => {
     expect(isError(result)).toBe(false);
     expect(textContent(result)).toMatch(/No alias or basename match/i);
   });
+
+  it("escapes control characters in no-match alias labels", async () => {
+    const result = await env.client.callTool({
+      name: "resolve_alias",
+      arguments: { name: "nope\nalias" },
+    });
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain('No alias or basename match for "nope\\nalias"');
+    expect(text).not.toContain("nope\nalias");
+  });
 });

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -719,18 +719,18 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
 
         const total = aliasMatches.length + basenameMatches.length;
         if (total === 0) {
-          return { content: [{ type: "text" as const, text: `No alias or basename match for "${name}"` }] };
+          return { content: [{ type: "text" as const, text: `No alias or basename match for "${displayReadValue(name)}"` }] };
         }
 
-        const lines: string[] = [`Matches for "${name}":`, ""];
+        const lines: string[] = [`Matches for "${displayReadValue(name)}":`, ""];
         if (aliasMatches.length > 0) {
           lines.push(`Alias matches (${aliasMatches.length}):`);
-          for (const p of aliasMatches) lines.push(`  - ${p}`);
+          for (const p of aliasMatches) lines.push(`  - ${displayReadValue(p)}`);
         }
         if (basenameMatches.length > 0) {
           if (aliasMatches.length > 0) lines.push("");
           lines.push(`Basename matches (${basenameMatches.length}):`);
-          for (const p of basenameMatches) lines.push(`  - ${p}`);
+          for (const p of basenameMatches) lines.push(`  - ${displayReadValue(p)}`);
         }
         return { content: [{ type: "text" as const, text: lines.join("\n") }] };
       } catch (err) {


### PR DESCRIPTION
Escapes control characters in `resolve_alias` display values before returning them to MCP clients. Alias matching is unchanged; only displayed names and result paths are escaped. Score: 2 severity x 2 reach / 1 effort = 4. Risk: low; display-only escaping in a read tool. Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the existing control-character escaping pattern to `resolve_alias`, applying `displayReadValue` (backed by `escapeControlChars`) to user-supplied alias names in labels and to matched vault paths in results. Matching logic is unchanged; only display strings are affected.

- `src/tools/read.ts`: Four display sites in `resolve_alias` — the no-match label, the matches header, alias match paths, and basename match paths — now pass through `displayReadValue` before being returned to MCP clients.
- `src/__tests__/handlers/read.test.ts`: A new test covers the no-match branch with a newline-embedded alias name, asserting the escaped (`\\n`) form is present and the raw newline is absent.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — display-only escaping in a read-only tool with no changes to matching logic or data flow.

The change is narrow and mechanical: four display sites in `resolve_alias` now call `displayReadValue`, identical to what was already done for `search_by_frontmatter`, `get_recent_notes`, and `get_note`. The underlying `escapeControlChars` function is already tested and proven across those other handlers. A new test directly validates the no-match branch with an embedded newline, and alias matching itself is untouched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/read.ts | Applies displayReadValue (escapeControlChars) to the name label and both alias/basename match paths in the resolve_alias handler; matching logic is untouched. |
| src/__tests__/handlers/read.test.ts | Adds one test covering the no-match branch with a newline in the alias name; correctly asserts the escaped form appears and the raw form does not. |
| CHANGELOG.md | Adds a changelog entry for the resolve_alias escaping fix, consistent with surrounding entries for the same feature in other tools. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Tool as resolve_alias handler
    participant Vault as Vault FS
    participant Esc as escapeControlChars

    Client->>Tool: "callTool("resolve_alias", { name })"
    Tool->>Vault: listNotes()
    Vault-->>Tool: notes[]
    Tool->>Vault: readNote(notePath) x N (concurrent)
    Vault-->>Tool: content
    Tool->>Tool: extractAliases(content) — raw match vs target
    alt no matches
        Tool->>Esc: displayReadValue(name)
        Esc-->>Tool: escaped label
        Tool-->>Client: No alias or basename match for escaped
    else matches found
        Tool->>Esc: displayReadValue(name) for header
        loop each matched path
            Tool->>Esc: displayReadValue(path)
        end
        Esc-->>Tool: escaped strings
        Tool-->>Client: formatted list with escaped values
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape resolve\_alias output"](https://github.com/rps321321/obsidian-mcp-pro/commit/532a8d2eb2993d5cc6dba9a88f9aab9508005657) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35505509)</sub>

<!-- /greptile_comment -->