### PR TITLE
fix: escape daily note output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_recent_notes` now escapes control characters in displayed `since` labels and note paths before returning them to MCP clients.
 - `get_note` now escapes control characters in missing section and block error labels before returning them to MCP clients.
 - `resolve_alias` now escapes control characters in displayed alias labels and result paths before returning them to MCP clients.
+- `get_daily_note` now escapes control characters in displayed configured daily-note paths before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -215,6 +215,23 @@ describe("read handlers — get_daily_note", () => {
     expect(textContent(result)).toMatch(/not found/i);
   });
 
+  it("escapes control characters in configured missing daily-note paths", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "daily\nnotes", format: "YYYY-MM-DD" }),
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "get_daily_note",
+      arguments: { date: "1999-01-01" },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain('expected at "daily\\nnotes/1999-01-01.md"');
+    expect(text).not.toContain("daily\nnotes");
+  });
+
   it("rejects malformed dates at the schema layer", async () => {
     const result = await env.client.callTool({
       name: "get_daily_note",

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -326,13 +326,13 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         try {
           content = await readNote(vaultPath, notePath);
         } catch {
-          return errorResult(`Daily note not found for ${targetDate} (expected at "${notePath}")`);
+          return errorResult(`Daily note not found for ${displayReadValue(targetDate)} (expected at "${displayReadValue(notePath)}")`);
         }
 
         const { data: dailyFrontmatter, content: dailyBody } = parseFrontmatter(content);
         const header: string[] = [
-          `Daily Note: ${targetDate}`,
-          `Path: ${notePath}`,
+          `Daily Note: ${displayReadValue(targetDate)}`,
+          `Path: ${displayReadValue(notePath)}`,
           "",
         ];
 


### PR DESCRIPTION
Escapes control characters in `get_daily_note` display values derived from the vault daily-note config before returning them to MCP clients. Date parsing and note lookup behavior are unchanged. Score: 2 severity x 2 reach / 1 effort = 4. Risk: low; display-only escaping in a read tool. Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Applies `displayReadValue` (`escapeControlChars`) to `targetDate` and `notePath` in the `get_daily_note` handler, covering both the "note not found" error message and the success-path header lines. This mirrors the same escaping already present in every other read handler in the file.

- `src/tools/read.ts`: four interpolation sites in `get_daily_note` (error message + `Daily Note:`/`Path:` header) are now wrapped in `displayReadValue`, consistent with the project-wide pattern.
- `src/__tests__/handlers/read.test.ts`: a new test injects a `\
` into the vault's `daily-notes.json` folder name and asserts the escaped form appears in the error output; the success path with a malicious folder name is not yet tested.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a narrow, display-only escaping fix applied consistently across both code paths in get_daily_note.

The implementation is correct and follows the established pattern used by every other handler in the file. The only gap is that the new test covers only the error branch; the success-path header escaping (Daily Note: / Path: lines) lacks a parallel test, so a future regression there would not be caught automatically.

src/__tests__/handlers/read.test.ts — consider adding a success-path test with a control-character folder name.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/read.ts | Wraps targetDate and notePath in displayReadValue (escapeControlChars) in the get_daily_note handler — both the error and success paths are covered. Change is consistent with the escaping pattern used across all other handlers in the file. |
| src/__tests__/handlers/read.test.ts | Adds a test that injects a newline into the vault's configured daily-note folder name and asserts the error output contains the escaped form. The success path (note found with a malicious folder name) is not tested. |
| CHANGELOG.md | Adds a changelog entry for the new escaping behavior in get_daily_note, consistent with adjacent entries. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["get_daily_note(date?)"] --> B["Read vault daily-notes.json\n(folder, format)"]
    B --> C["Build notePath\nfolder/filename.md"]
    C --> D{"readNote succeeds?"}
    D -- "No (catch)" --> E["errorResult:\n'Daily note not found for displayReadValue(targetDate)\n(expected at displayReadValue(notePath))'"]
    D -- "Yes" --> F["Build header:\nDaily Note: displayReadValue(targetDate)\nPath: displayReadValue(notePath)"]
    F --> G["Return header + body"]
    E --> H["Return isError result"]

    style E fill:#ffd6d6
    style F fill:#d6ffd6
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape daily note output"](https://github.com/rps321321/obsidian-mcp-pro/commit/8410f8a82cda53868e170f1708400412eca4daf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35507039)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->