### PR TITLE
fix: escape outlinks output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_note` now escapes control characters in missing section and block error labels before returning them to MCP clients.
 - `resolve_alias` now escapes control characters in displayed alias labels and result paths before returning them to MCP clients.
 - `get_daily_note` now escapes control characters in displayed configured daily-note paths before returning them to MCP clients.
+- `get_outlinks` now escapes control characters in displayed note paths and wikilink targets before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/links.test.ts
+++ b/src/__tests__/handlers/links.test.ts
@@ -82,6 +82,36 @@ describe("link handlers — get_outlinks", () => {
     });
     expect(textContent(result)).toMatch(/No outgoing links/i);
   });
+
+  it("escapes control characters in missing source paths", async () => {
+    const result = await env.client.callTool({
+      name: "get_outlinks",
+      arguments: { path: "missing\nnote" },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain("No note found matching path: missing\\nnote");
+    expect(text).not.toContain("missing\nnote");
+  });
+
+  it("escapes control characters in displayed broken link targets", async () => {
+    const created = await env.client.callTool({
+      name: "create_note",
+      arguments: {
+        path: "tab-outlink.md",
+        content: "# Tab outlink\n\nThis points at [[bad\ttarget]].",
+      },
+    });
+    expect(isError(created)).toBe(false);
+
+    const result = await env.client.callTool({
+      name: "get_outlinks",
+      arguments: { path: "tab-outlink.md" },
+    });
+    const text = textContent(result);
+    expect(text).toContain("[[bad\\ttarget]]");
+    expect(text).not.toContain("bad\ttarget");
+  });
 });
 
 describe("link handlers — find_orphans", () => {

--- a/src/tools/links.ts
+++ b/src/tools/links.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { listNotes, getNoteStats } from "../lib/vault.js";
 import { readAllCached } from "../lib/index-cache.js";
 import { extractWikilinks, resolveWikilink, extractAliases } from "../lib/markdown.js";
-import { sanitizeError } from "../lib/errors.js";
+import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { log } from "../lib/logger.js";
 import type { LinkInfo, BrokenLink, OrphanNote, GraphNeighbor } from "../types.js";
 
@@ -33,6 +33,10 @@ interface CachedGraph {
 }
 const GRAPH_CACHE_TTL_MS = 30_000;
 const GRAPH_CACHE_MAX_ENTRIES = 32;
+
+function displayLinkValue(value: string): string {
+  return escapeControlChars(value);
+}
 const graphCache = new Map<string, CachedGraph>();
 
 // Map iteration order = insertion order; delete+set to refresh recency.
@@ -399,7 +403,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
           }
         }
         if (!resolvedSource) {
-          return errorResult(`No note found matching path: ${notePath}`);
+          return errorResult(`No note found matching path: ${displayLinkValue(notePath)}`);
         }
 
         const links = graph.rawLinks.get(resolvedSource) ?? [];
@@ -425,7 +429,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
             content: [
               {
                 type: "text" as const,
-                text: `No outgoing links found in: ${resolvedSource}`,
+                text: `No outgoing links found in: ${displayLinkValue(resolvedSource)}`,
               },
             ],
           };
@@ -435,7 +439,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
         const broken = results.filter((r) => !r.isValid);
 
         const lines: string[] = [
-          `Outgoing links from: ${resolvedSource}`,
+          `Outgoing links from: ${displayLinkValue(resolvedSource)}`,
           `Total: ${results.length} (${valid.length} valid, ${broken.length} broken)\n`,
         ];
 
@@ -443,7 +447,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
           lines.push("Valid links:");
           for (const r of valid) {
             const embedPrefix = r.isEmbed ? "📎 " : "";
-            lines.push(`  ${embedPrefix}[[${r.target}]] → ${r.resolvedPath}`);
+            lines.push(`  ${embedPrefix}[[${displayLinkValue(r.target)}]] → ${displayLinkValue(r.resolvedPath ?? "")}`);
           }
         }
 
@@ -451,7 +455,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
           lines.push("\nBroken links:");
           for (const r of broken) {
             const embedPrefix = r.isEmbed ? "📎 " : "";
-            lines.push(`  ${embedPrefix}[[${r.target}]] → (not found)`);
+            lines.push(`  ${embedPrefix}[[${displayLinkValue(r.target)}]] → (not found)`);
           }
         }
 


### PR DESCRIPTION
Escapes control characters in `get_outlinks` display values before returning them to MCP clients. Link parsing and resolution are unchanged; only displayed source paths, resolved paths, and wikilink targets are escaped. Score: 2 severity x 3 reach / 1 effort = 6. Risk: low; display-only escaping in a read tool. Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the existing control-character escaping pattern to the `get_outlinks` tool, mirroring identical fixes already applied to `get_note`, `resolve_alias`, and `get_daily_note`. It introduces a thin `displayLinkValue` wrapper and applies it to every display string returned by `get_outlinks`.

- **`src/tools/links.ts`**: Adds `displayLinkValue(value)` (delegates to `escapeControlChars`) and wraps the four display sites in `get_outlinks` — missing source path, resolved source, wikilink targets, and resolved paths — ensuring control characters cannot appear in tool output.
- **`src/__tests__/handlers/links.test.ts`**: Adds two tests: one for a newline in the source path (error path) and one for a tab in a wikilink target (broken-link path); the broken-link test is missing an `isError` guard that would make it self-validating if the wikilink parser drops tab-containing targets.
- **`CHANGELOG.md`**: Entry added under the current unreleased section.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The escaping logic is straightforward and mirrors the same pattern used in three other tools; display output only, no data mutation.

The implementation is correct and low-risk. The only notable gap is in the test for broken-link target escaping, which lacks an `isError` assertion to confirm the tool actually returned link output before checking the escaped text. The wrapper function adds a layer of indirection with no real distinction from calling `escapeControlChars` directly.

src/__tests__/handlers/links.test.ts — the broken-link-target test could use a guard assertion to make failure modes unambiguous.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/links.ts | Adds `displayLinkValue` wrapper calling `escapeControlChars` and applies it to all display strings in `get_outlinks`: source path, resolved source, wikilink targets, and resolved paths. Logic is correct; `resolvedPath ?? ""` is safe because TypeScript can't narrow the type through the filter. |
| src/__tests__/handlers/links.test.ts | Adds two new tests for control-char escaping. The broken-link-target test does not assert the tool succeeded before checking output text, so the positive assertion could silently pass vacuously if the wikilink parser drops tab-containing targets or the tool returns an error. |
| CHANGELOG.md | Adds changelog entry for the `get_outlinks` escaping fix. No issues. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["get_outlinks called\n(path: notePath)"] --> B["Build/fetch link graph"]
    B --> C["Resolve notePath → resolvedSource"]
    C --> D{resolvedSource\nfound?}
    D -- No --> E["errorResult\n'No note found matching path:\n' + displayLinkValue(notePath)"]
    D -- Yes --> F["Fetch rawLinks for resolvedSource"]
    F --> G{Any links?}
    G -- No --> H["Return:\n'No outgoing links found in:\n' + displayLinkValue(resolvedSource)"]
    G -- Yes --> I["Resolve each wikilink target"]
    I --> J["Partition into valid / broken"]
    J --> K["Build output lines\ndisplayLinkValue applied to:\n• resolvedSource\n• r.target\n• r.resolvedPath"]
    K --> L["Return formatted text"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape outlinks output"](https://github.com/rps321321/obsidian-mcp-pro/commit/31592d3c22a34a449207c756b3055999d7772dfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35507864)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->