### PR TITLE
fix: escape link tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `resolve_alias` now escapes control characters in displayed alias labels and result paths before returning them to MCP clients.
 - `get_daily_note` now escapes control characters in displayed configured daily-note paths before returning them to MCP clients.
 - `get_outlinks` now escapes control characters in displayed note paths and wikilink targets before returning them to MCP clients.
-- `get_backlinks` now escapes control characters in displayed note paths and backlink context lines before returning them to MCP clients.
+- `get_backlinks`, `find_orphans`, `find_broken_links`, and `get_graph_neighbors` now escape control characters in displayed note paths, wikilink targets, and context lines before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `resolve_alias` now escapes control characters in displayed alias labels and result paths before returning them to MCP clients.
 - `get_daily_note` now escapes control characters in displayed configured daily-note paths before returning them to MCP clients.
 - `get_outlinks` now escapes control characters in displayed note paths and wikilink targets before returning them to MCP clients.
+- `get_backlinks` now escapes control characters in displayed note paths and backlink context lines before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/links.test.ts
+++ b/src/__tests__/handlers/links.test.ts
@@ -52,6 +52,36 @@ describe("link handlers — get_backlinks", () => {
     });
     expect(textContent(withExt)).toEqual(textContent(withoutExt));
   });
+
+  it("escapes control characters in missing target paths", async () => {
+    const result = await env.client.callTool({
+      name: "get_backlinks",
+      arguments: { path: "missing\nnote" },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain("No note found matching path: missing\\nnote");
+    expect(text).not.toContain("missing\nnote");
+  });
+
+  it("escapes control characters in backlink context lines", async () => {
+    const created = await env.client.callTool({
+      name: "create_note",
+      arguments: {
+        path: "tab-backlink.md",
+        content: "# Tab backlink\n\nLinks to [[note-a]]\twith tab.",
+      },
+    });
+    expect(isError(created)).toBe(false);
+
+    const result = await env.client.callTool({
+      name: "get_backlinks",
+      arguments: { path: "note-a.md" },
+    });
+    const text = textContent(result);
+    expect(text).toContain("Links to [[note-a]]\\twith tab.");
+    expect(text).not.toContain("note-a]]\twith tab");
+  });
 });
 
 describe("link handlers — get_outlinks", () => {

--- a/src/__tests__/handlers/links.test.ts
+++ b/src/__tests__/handlers/links.test.ts
@@ -187,6 +187,25 @@ describe("link handlers — find_broken_links", () => {
     });
     expect(textContent(result)).toMatch(/No broken links/i);
   });
+
+  it("escapes control characters in broken link targets", async () => {
+    const created = await env.client.callTool({
+      name: "create_note",
+      arguments: {
+        path: "tab-broken-report.md",
+        content: "# Tab broken report\n\nThis points at [[bad\ttarget]].",
+      },
+    });
+    expect(isError(created)).toBe(false);
+
+    const result = await env.client.callTool({
+      name: "find_broken_links",
+      arguments: {},
+    });
+    const text = textContent(result);
+    expect(text).toContain("[[bad\\ttarget]]");
+    expect(text).not.toContain("bad\ttarget");
+  });
 });
 
 describe("link handlers — get_graph_neighbors", () => {
@@ -229,5 +248,16 @@ describe("link handlers — get_graph_neighbors", () => {
       arguments: { path: "does-not-exist", depth: 1 },
     });
     expect(isError(result)).toBe(true);
+  });
+
+  it("escapes control characters in unresolvable start paths", async () => {
+    const result = await env.client.callTool({
+      name: "get_graph_neighbors",
+      arguments: { path: "missing\nstart", depth: 1 },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain("No note found matching path: missing\\nstart");
+    expect(text).not.toContain("missing\nstart");
   });
 });

--- a/src/tools/links.ts
+++ b/src/tools/links.ts
@@ -278,7 +278,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
         }
 
         if (!resolvedTarget) {
-          return errorResult(`No note found matching path: ${targetPath}`);
+          return errorResult(`No note found matching path: ${displayLinkValue(targetPath)}`);
         }
 
         const backlinkSources = graph.backlinks.get(resolvedTarget);
@@ -287,7 +287,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
             content: [
               {
                 type: "text" as const,
-                text: `No backlinks found for: ${resolvedTarget}`,
+                text: `No backlinks found for: ${displayLinkValue(resolvedTarget)}`,
               },
             ],
           };
@@ -336,12 +336,12 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
         });
 
         const output = [
-          `Backlinks to: ${resolvedTarget}`,
+          `Backlinks to: ${displayLinkValue(resolvedTarget)}`,
           `Found: ${deduped.length} backlink(s)\n`,
           ...deduped.map((r) => {
             const lineStr = r.line > 0 ? `:${r.line}` : "";
-            const contextStr = r.context ? `  → ${r.context}` : "";
-            return `- ${r.source}${lineStr}${contextStr}`;
+            const contextStr = r.context ? `  → ${displayLinkValue(r.context)}` : "";
+            return `- ${displayLinkValue(r.source)}${lineStr}${contextStr}`;
           }),
         ].join("\n");
 

--- a/src/tools/links.ts
+++ b/src/tools/links.ts
@@ -531,7 +531,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
 
         lines.push(`Fully isolated (no links in or out): ${fullyIsolated.length}`);
         for (const note of cappedIsolated) {
-          lines.push(`  - ${note.path}`);
+          lines.push(`  - ${displayLinkValue(note.path)}`);
         }
         if (cappedIsolated.length < fullyIsolated.length) {
           lines.push(`  ... and ${fullyIsolated.length - cappedIsolated.length} more`);
@@ -539,7 +539,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
 
         lines.push(`\nNo backlinks (not linked by any note): ${noBacklinks.length}`);
         for (const note of cappedNoBacklinks) {
-          lines.push(`  - ${note.path}`);
+          lines.push(`  - ${displayLinkValue(note.path)}`);
         }
         if (cappedNoBacklinks.length < noBacklinks.length) {
           lines.push(`  ... and ${noBacklinks.length - cappedNoBacklinks.length} more`);
@@ -548,7 +548,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
         if (includeOutlinksCheck) {
           lines.push(`\nNo outlinks (links to no other notes): ${noOutlinks.length}`);
           for (const note of cappedNoOutlinks) {
-            lines.push(`  - ${note.path}`);
+            lines.push(`  - ${displayLinkValue(note.path)}`);
           }
           if (cappedNoOutlinks.length < noOutlinks.length) {
             lines.push(`  ... and ${noOutlinks.length - cappedNoOutlinks.length} more`);
@@ -657,7 +657,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
         }
 
         if (brokenBySource.size === 0) {
-          const scopeStr = folder ? ` in folder: ${folder}` : "";
+          const scopeStr = folder ? ` in folder: ${displayLinkValue(folder)}` : "";
           return {
             content: [
               {
@@ -674,17 +674,17 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
         }
 
         const lines: string[] = [];
-        const scopeStr = folder ? ` (folder: ${folder})` : "";
+        const scopeStr = folder ? ` (folder: ${displayLinkValue(folder)})` : "";
         lines.push(`Broken links report${scopeStr}\n`);
 
         let shown = 0;
         for (const [sourcePath, brokenLinks] of brokenBySource) {
           if (shown >= maxResults) break;
-          lines.push(`${sourcePath}:`);
+          lines.push(`${displayLinkValue(sourcePath)}:`);
           for (const bl of brokenLinks) {
             if (shown >= maxResults) break;
             const lineStr = bl.line > 0 ? ` (line ${bl.line})` : "";
-            lines.push(`  - [[${bl.targetLink}]]${lineStr}`);
+            lines.push(`  - [[${displayLinkValue(bl.targetLink)}]]${lineStr}`);
             shown++;
           }
           lines.push("");
@@ -777,7 +777,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
         }
 
         if (!resolvedStart) {
-          return errorResult(`No note found matching path: ${startPath}`);
+          return errorResult(`No note found matching path: ${displayLinkValue(startPath)}`);
         }
 
         // BFS traversal with maxResults cap to prevent explosion at higher depths
@@ -845,7 +845,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
             content: [
               {
                 type: "text" as const,
-                text: `No neighbors found for: ${resolvedStart} (depth: ${depth}, direction: ${direction})`,
+                text: `No neighbors found for: ${displayLinkValue(resolvedStart)} (depth: ${depth}, direction: ${direction})`,
               },
             ],
           };
@@ -862,9 +862,9 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
 
         const truncatedStr = truncated ? " (TRUNCATED)" : "";
         const lines: string[] = [
-          `Graph neighbors of: ${resolvedStart}`,
+          `Graph neighbors of: ${displayLinkValue(resolvedStart)}`,
           `Direction: ${direction} | Max depth: ${depth} | Found: ${visited.size} note(s)${truncatedStr}\n`,
-          resolvedStart,
+          displayLinkValue(resolvedStart),
         ];
 
         const sortedDepths = [...byDepth.keys()].sort((a, b) => a - b);
@@ -880,7 +880,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
                 : neighbor.direction === "outbound"
                   ? "→"
                   : "↔";
-            lines.push(`${indent}${arrow} ${neighbor.path} (depth ${d})`);
+            lines.push(`${indent}${arrow} ${displayLinkValue(neighbor.path)} (depth ${d})`);
           }
         }
 


### PR DESCRIPTION
Escapes control characters in link-tool display values before returning them to MCP clients. Link parsing and resolution are unchanged; displayed source paths, resolved paths, wikilink targets, and context lines are escaped.

Score: 2 severity x 3 reach / 1 effort = 6.
Risk: low; display-only escaping in read tools.
Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the control-character escaping pattern (introduced in earlier commits for `get_outlinks`, `resolve_alias`, and `get_daily_note`) to the four remaining link tools: `get_backlinks`, `find_orphans`, `find_broken_links`, and `get_graph_neighbors`. All user-controlled strings that appear in MCP output — source paths, resolved paths, wikilink targets, folder inputs, and context lines — are now wrapped in `displayLinkValue`/`escapeControlChars` before being returned to clients.

- **`src/tools/links.ts`**: Wraps all interpolated vault paths and user inputs in `displayLinkValue` across the four affected handlers; no logic or link-resolution changes.
- **`src/__tests__/handlers/links.test.ts`**: Adds four integration tests verifying escape behavior for `get_backlinks` (missing path and tab in context), `find_broken_links` (tab in link target), and `get_graph_neighbors` (newline in start path). `find_orphans` has no new escape test.
- **`CHANGELOG.md`**: Documents the four newly covered tools alongside the earlier escaping entries.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Display-only escaping applied uniformly to the remaining link tools; no parsing, resolution, or data-mutation paths are touched.

The change is mechanical and consistent — it applies the same displayLinkValue wrapper already present in get_outlinks and other sibling tools, touches only string interpolation in output builders, and is covered by new integration tests for three of the four tools. The single gap (no escape test for find_orphans) does not affect correctness.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/links.ts | Applied displayLinkValue (wrapping escapeControlChars) to all user-controlled output strings in get_backlinks, find_orphans, find_broken_links, and get_graph_neighbors, matching the pattern already established in read.ts, tags.ts, and canvas.ts. No logic or parsing changes. |
| src/__tests__/handlers/links.test.ts | Adds four integration-level escape tests covering get_backlinks (missing path, context lines), find_broken_links (link targets), and get_graph_neighbors (unresolvable start path). find_orphans path escaping has no corresponding new test. |
| CHANGELOG.md | Entry accurately reflects the four tools updated in this PR; grouped with sibling entries from previous escaping PRs. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User-controlled input\ne.g. path, folder] --> B{Resolve to vault path}
    B -- Not found --> C[errorResult\ndisplayLinkValue applied ✓]
    B -- Found --> D[Build output lines]
    D --> E[Interpolate paths / targets / context]
    E --> F[displayLinkValue\nescapeControlChars]
    F --> G[MCP text response]

    subgraph "Tools updated in this PR"
        H[get_backlinks]
        I[find_orphans]
        J[find_broken_links]
        K[get_graph_neighbors]
    end

    H & I & J & K --> D
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: escape sibling link outputs"](https://github.com/rps321321/obsidian-mcp-pro/commit/66f82e7cfc860ba0f2e9329ee5e10b8e131b74ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35508587)</sub>

<!-- /greptile_comment -->