### PR TITLE
fix: escape attachment output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_daily_note` now escapes control characters in displayed configured daily-note paths before returning them to MCP clients.
 - `get_outlinks` now escapes control characters in displayed note paths and wikilink targets before returning them to MCP clients.
 - `get_backlinks`, `find_orphans`, `find_broken_links`, and `get_graph_neighbors` now escape control characters in displayed note paths, wikilink targets, and context lines before returning them to MCP clients.
+- Attachment tools now escape control characters in displayed extension filters, attachment paths, filenames, and blocked/rejected paths before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/attachments-display.test.ts
+++ b/src/__tests__/attachments-display.test.ts
@@ -1,0 +1,136 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { isError, textContent } from "./handlers/harness.js";
+
+interface AttachmentMocks {
+  attachments: string[];
+  notes?: string[];
+  resolvedPath?: string;
+  stats?: Map<string, number>;
+}
+
+const tempDirs: string[] = [];
+
+async function createAttachmentClient(mocks: AttachmentMocks): Promise<{
+  client: Client;
+  cleanup: () => Promise<void>;
+}> {
+  vi.resetModules();
+  vi.doMock("../lib/vault.js", () => ({
+    listAttachments: vi.fn(async () => mocks.attachments),
+    listNotes: vi.fn(async () => mocks.notes ?? []),
+    getAttachmentStats: vi.fn(async (_vaultPath: string, relPath: string) => ({
+      size: mocks.stats?.get(relPath) ?? 0,
+    })),
+    resolveVaultPathSafe: vi.fn(async () => {
+      if (!mocks.resolvedPath) {
+        throw new Error("resolveVaultPathSafe mock missing resolvedPath");
+      }
+      return mocks.resolvedPath;
+    }),
+  }));
+  vi.doMock("../lib/index-cache.js", () => ({
+    readAllCached: vi.fn(async () => ({ contents: new Map<string, string>() })),
+  }));
+
+  const { registerAttachmentTools } = await import("../tools/attachments.js");
+  const server = new McpServer({ name: "attachment-display-test", version: "0.0.0" });
+  registerAttachmentTools(server, "mock-vault");
+
+  const client = new Client({ name: "attachment-display-client", version: "0.0.0" });
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverT), client.connect(clientT)]);
+
+  return {
+    client,
+    cleanup: async () => {
+      try {
+        await client.close();
+      } catch {
+        // ignore
+      }
+    },
+  };
+}
+
+afterEach(async () => {
+  vi.doUnmock("../lib/vault.js");
+  vi.doUnmock("../lib/index-cache.js");
+  vi.resetModules();
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()!;
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("attachment display escaping", () => {
+  it("escapes control characters in populated attachment listings", async () => {
+    const env = await createAttachmentClient({
+      attachments: ["assets/bad\nname.png", "assets/tab\tname.jpg"],
+    });
+    try {
+      const result = await env.client.callTool({
+        name: "list_attachments",
+        arguments: {},
+      });
+      expect(isError(result)).toBe(false);
+      const text = textContent(result);
+      expect(text).toContain("- assets/bad\\nname.png");
+      expect(text).toContain("- assets/tab\\tname.jpg");
+      expect(text).not.toContain("assets/bad\nname.png");
+      expect(text).not.toContain("assets/tab\tname.jpg");
+    } finally {
+      await env.cleanup();
+    }
+  });
+
+  it("escapes control characters in unused attachment rows", async () => {
+    const dirtyPath = "assets/orphan\nfile.png";
+    const env = await createAttachmentClient({
+      attachments: [dirtyPath],
+      stats: new Map([[dirtyPath, 7]]),
+    });
+    try {
+      const result = await env.client.callTool({
+        name: "find_unused_attachments",
+        arguments: { includeBytes: true },
+      });
+      expect(isError(result)).toBe(false);
+      const text = textContent(result);
+      expect(text).toContain("- assets/orphan\\nfile.png  (7 bytes)");
+      expect(text).not.toContain("assets/orphan\nfile.png");
+    } finally {
+      await env.cleanup();
+    }
+  });
+
+  it("escapes control characters in maxBytes errors", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "attachment-display-"));
+    tempDirs.push(dir);
+    const fullPath = path.join(dir, "big.png");
+    await fs.writeFile(fullPath, "data", "utf-8");
+
+    const relPath = "assets/big\nfile.png";
+    const env = await createAttachmentClient({
+      attachments: [],
+      resolvedPath: fullPath,
+    });
+    try {
+      const result = await env.client.callTool({
+        name: "get_attachment",
+        arguments: { path: relPath, maxBytes: 1 },
+      });
+      expect(isError(result)).toBe(true);
+      const text = textContent(result);
+      expect(text).toContain('Attachment "assets/big\\nfile.png" is 4 bytes');
+      expect(text).not.toContain("assets/big\nfile.png");
+    } finally {
+      await env.cleanup();
+    }
+  });
+});

--- a/src/__tests__/handlers/attachments.test.ts
+++ b/src/__tests__/handlers/attachments.test.ts
@@ -55,6 +55,17 @@ describe("attachments handlers — list_attachments", () => {
     expect(isError(result)).toBe(false);
     expect(textContent(result)).toMatch(/No attachments with extension/i);
   });
+
+  it("escapes control characters in extension filters", async () => {
+    const result = await env.client.callTool({
+      name: "list_attachments",
+      arguments: { extension: "mp4\nnext" },
+    });
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain('No attachments with extension "mp4\\nnext".');
+    expect(text).not.toContain("mp4\nnext");
+  });
 });
 
 describe("attachments handlers — find_unused_attachments", () => {
@@ -135,6 +146,28 @@ describe("attachments handlers — get_attachment", () => {
     });
     expect(isError(md)).toBe(true);
     expect(textContent(md)).toMatch(/use get_note/i);
+  });
+
+  it("escapes control characters in rejected text-format paths", async () => {
+    const result = await env.client.callTool({
+      name: "get_attachment",
+      arguments: { path: "bad\nnote.md" },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain('Refusing to fetch "bad\\nnote.md"');
+    expect(text).not.toContain("bad\nnote.md");
+  });
+
+  it("escapes control characters in blocked executable paths", async () => {
+    const result = await env.client.callTool({
+      name: "get_attachment",
+      arguments: { path: "tools/bad\tthing.exe" },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain('"tools/bad\\tthing.exe"');
+    expect(text).not.toContain("tools/bad\tthing.exe");
   });
 
   it("enforces the maxBytes cap", async () => {

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -20,7 +20,7 @@ import {
   getBlockedExtension,
   verifyImageMagicBytes,
 } from "../lib/mime.js";
-import { sanitizeError } from "../lib/errors.js";
+import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { log } from "../lib/logger.js";
 
 /** Cap on attachment size returned by `get_attachment` — base64 inflates by
@@ -36,6 +36,10 @@ function textResult(text: string) {
 
 function errorResult(text: string) {
   return { content: [{ type: "text" as const, text }], isError: true as const };
+}
+
+function displayAttachmentValue(value: string): string {
+  return escapeControlChars(value);
 }
 
 /** Group attachments by their lower-cased extension for the summary line. */
@@ -145,23 +149,23 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         if (filtered.length === 0) {
           return textResult(
             extension
-              ? `No attachments with extension "${extension}".`
+              ? `No attachments with extension "${displayAttachmentValue(extension)}".`
               : "No attachments in this vault.",
           );
         }
         const truncated = filtered.slice(0, limit);
         const lines: string[] = [
-          `${filtered.length} attachment(s)${extension ? ` (.${extension.replace(/^\./, "")})` : ""}${filtered.length > limit ? ` (showing first ${limit})` : ""}:`,
+          `${filtered.length} attachment(s)${extension ? ` (.${displayAttachmentValue(extension.replace(/^\./, ""))})` : ""}${filtered.length > limit ? ` (showing first ${limit})` : ""}:`,
           "",
         ];
         const summary = summarizeByExtension(filtered);
         if (summary.size > 1) {
           lines.push("By extension:");
           const entries = Array.from(summary.entries()).sort((a, b) => b[1] - a[1]);
-          for (const [ext, n] of entries) lines.push(`  ${ext}  ${n}`);
+          for (const [ext, n] of entries) lines.push(`  ${displayAttachmentValue(ext)}  ${n}`);
           lines.push("");
         }
-        for (const p of truncated) lines.push(`- ${p}`);
+        for (const p of truncated) lines.push(`- ${displayAttachmentValue(p)}`);
         return textResult(lines.join("\n"));
       } catch (err) {
         log.error("list_attachments failed", { tool: "list_attachments", err: err as Error });
@@ -263,10 +267,11 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
           lines.push("");
           for (const p of truncated) {
             const sz = sizes.get(p);
-            lines.push(sz !== undefined ? `- ${p}  (${sz.toLocaleString()} bytes)` : `- ${p}`);
+            const displayedPath = displayAttachmentValue(p);
+            lines.push(sz !== undefined ? `- ${displayedPath}  (${sz.toLocaleString()} bytes)` : `- ${displayedPath}`);
           }
         } else {
-          for (const p of truncated) lines.push(`- ${p}`);
+          for (const p of truncated) lines.push(`- ${displayAttachmentValue(p)}`);
         }
 
         return textResult(lines.join("\n"));
@@ -312,7 +317,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         const lowerPath = relPath.toLowerCase();
         if (lowerPath.endsWith(".md") || lowerPath.endsWith(".canvas") || lowerPath.endsWith(".base")) {
           return errorResult(
-            `Refusing to fetch "${relPath}" via get_attachment - use get_note / read_canvas / read_base instead.`,
+            `Refusing to fetch "${displayAttachmentValue(relPath)}" via get_attachment - use get_note / read_canvas / read_base instead.`,
           );
         }
 
@@ -320,7 +325,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         const blockedExt = getBlockedExtension(relPath);
         if (blockedExt) {
           return errorResult(
-            `Blocked: "${relPath}" has a dangerous extension (${blockedExt}). ` +
+            `Blocked: "${displayAttachmentValue(relPath)}" has a dangerous extension (${displayAttachmentValue(blockedExt)}). ` +
             `Executable file types are not served as attachments.`,
           );
         }
@@ -330,7 +335,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         const limit = maxBytes ?? DEFAULT_GET_ATTACHMENT_LIMIT;
         if (stat.size > limit) {
           return errorResult(
-            `Attachment "${relPath}" is ${stat.size.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`,
+            `Attachment "${displayAttachmentValue(relPath)}" is ${stat.size.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`,
           );
         }
 
@@ -338,6 +343,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         const mime = detectMimeType(relPath);
         const category = categorizeMimeType(mime);
         const basename = path.basename(relPath);
+        const displayedBasename = displayAttachmentValue(basename);
 
         // SEC-8: SVG files can contain embedded <script> tags and event
         // handlers, making them an XSS vector. Return SVG content as
@@ -348,7 +354,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
             content: [
               {
                 type: "text" as const,
-                text: `Attached: ${basename} (SVG returned as text/plain for security - SVGs may contain embedded scripts)\n` +
+                text: `Attached: ${displayedBasename} (SVG returned as text/plain for security - SVGs may contain embedded scripts)\n` +
                       `Size: ${stat.size.toLocaleString()} bytes`,
               },
               {
@@ -385,7 +391,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         if (category === "image") {
           return {
             content: [
-              { type: "text" as const, text: `Attached: ${basename} (${mime}, ${stat.size.toLocaleString()} bytes)${magicWarning}` },
+              { type: "text" as const, text: `Attached: ${displayedBasename} (${mime}, ${stat.size.toLocaleString()} bytes)${magicWarning}` },
               { type: "image" as const, data, mimeType: mime },
             ],
           };
@@ -393,14 +399,14 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         if (category === "audio") {
           return {
             content: [
-              { type: "text" as const, text: `Attached: ${basename} (${mime}, ${stat.size.toLocaleString()} bytes)` },
+              { type: "text" as const, text: `Attached: ${displayedBasename} (${mime}, ${stat.size.toLocaleString()} bytes)` },
               { type: "audio" as const, data, mimeType: mime },
             ],
           };
         }
         return {
           content: [
-            { type: "text" as const, text: `Attached: ${basename} (${mime}, ${stat.size.toLocaleString()} bytes)` },
+            { type: "text" as const, text: `Attached: ${displayedBasename} (${mime}, ${stat.size.toLocaleString()} bytes)` },
             {
               type: "resource" as const,
               resource: {

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -38,9 +38,8 @@ function errorResult(text: string) {
   return { content: [{ type: "text" as const, text }], isError: true as const };
 }
 
-function displayAttachmentValue(value: string): string {
-  return escapeControlChars(value);
-}
+/** Escape control characters in a value before embedding it in a display string. */
+const displayAttachmentValue = escapeControlChars;
 
 /** Group attachments by their lower-cased extension for the summary line. */
 function summarizeByExtension(paths: readonly string[]): Map<string, number> {


### PR DESCRIPTION
Escapes control characters in attachment-tool display values before returning them to MCP clients. Attachment resolution, returned bytes, and vault resource URIs are unchanged; only text labels and lists are made line-safe.

Score: 2 severity x 3 reach / 1 effort = 6.
Risk: low; display-only escaping in read tools.
Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the existing control-character escaping pattern — already applied to note paths, wikilink targets, and context lines in other tools — to the attachment tools (`list_attachments`, `find_unused_attachments`, `get_attachment`). Vault resource URIs and returned file bytes are intentionally left unchanged; only the human-readable labels embedded in tool responses are sanitised.

- `escapeControlChars` is aliased as `displayAttachmentValue` and applied to extension filters, attachment path rows, the blocked-extension message, the text-format rejection message, maxBytes-exceeded messages, and basename labels in image/audio/resource responses.
- Two test files add coverage for populated listing rows, unused-attachment rows with byte counts, maxBytes-exceeded errors, extension-filter messages, text-format rejection, and blocked-extension rejection — all verifying that raw control characters are absent from output and their escaped representations are present.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are display-only and read-path only, with no modifications to file resolution, bytes returned, or vault URIs.

Every user-visible label in the three attachment tools is now escaped through escapeControlChars, consistent with how the same function is applied elsewhere in the codebase. The vault:// URIs and raw file bytes are correctly left untouched. The new tests directly exercise the escape behaviour in both the empty-results and populated paths across all three tools, leaving no obvious gaps.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/attachments.ts | Applies displayAttachmentValue (alias for escapeControlChars) to every user-visible label — extension filters, path rows, blocked/rejected messages, size-exceeded messages, and basename labels — while intentionally leaving vault:// URIs and returned bytes untouched. |
| src/__tests__/attachments-display.test.ts | New dedicated integration test file covering control-char escaping in populated listing rows, unused-attachment rows with byte counts, and maxBytes-exceeded error messages using module-level mocks. |
| src/__tests__/handlers/attachments.test.ts | Adds three new handler-level tests for control-char escaping in extension-filter messages, text-format path rejection, and blocked executable-extension messages. |
| CHANGELOG.md | Adds a changelog entry for the attachment-tool escaping in the correct Unreleased section, consistent with existing entries for other tools. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP Client sends tool call] --> B{Tool}
    B --> C[list_attachments]
    B --> D[find_unused_attachments]
    B --> E[get_attachment]

    C --> C1[Filter by extension]
    C1 --> C2[displayAttachmentValue: extension label]
    C2 --> C3[displayAttachmentValue: per-ext summary rows]
    C3 --> C4[displayAttachmentValue: path list rows]
    C4 --> C5[textResult returned]

    D --> D1[Collect unreferenced paths]
    D1 --> D2[displayAttachmentValue: path rows]
    D2 --> D3[textResult returned]

    E --> E1{.md / .canvas / .base?}
    E1 -->|Yes| E2[displayAttachmentValue: relPath in error]
    E1 -->|No| E3{Blocked extension?}
    E3 -->|Yes| E4[displayAttachmentValue: relPath + blockedExt in error]
    E3 -->|No| E5{Size > limit?}
    E5 -->|Yes| E6[displayAttachmentValue: relPath in error]
    E5 -->|No| E7[displayAttachmentValue: basename in success label]
    E7 --> E8[vault:// URI — raw relPath preserved]
    E8 --> E9[File bytes returned unchanged]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test: cover attachment display escaping"](https://github.com/rps321321/obsidian-mcp-pro/commit/2b41dba2772a8a8e29e9ec32c42e444d9f971eee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35513577)</sub>

<!-- /greptile_comment -->