### PR TITLE
fix: escape base output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_outlinks` now escapes control characters in displayed note paths and wikilink targets before returning them to MCP clients.
 - `get_backlinks`, `find_orphans`, `find_broken_links`, and `get_graph_neighbors` now escape control characters in displayed note paths, wikilink targets, and context lines before returning them to MCP clients.
 - Attachment tools now escape control characters in displayed extension filters, attachment paths, filenames, and blocked/rejected paths before returning them to MCP clients.
+- Base tools now escape control characters in displayed Base paths, property labels, view labels, warnings, result paths, and frontmatter keys before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/bases.test.ts
+++ b/src/__tests__/handlers/bases.test.ts
@@ -8,6 +8,41 @@ afterEach(async () => {
   env = undefined;
 });
 
+describe("base handlers — read_base", () => {
+  it("escapes control characters in parsed display fields", async () => {
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "dirty.base": [
+          "properties:",
+          "  \"bad\\tkey\":",
+          "    displayName: \"Display\\nName\"",
+          "views:",
+          "  - type: \"table\\tview\"",
+          "    name: \"Main\\nView\"",
+          "",
+        ].join("\n"),
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "read_base",
+      arguments: { path: "dirty.base" },
+    });
+
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain("bad\\tkey");
+    expect(text).toContain("Display\\nName");
+    expect(text).toContain("Main\\nView");
+    expect(text).toContain("table\\tview");
+    expect(text).not.toContain("bad\tkey");
+    expect(text).not.toContain("Display\nName");
+    expect(text).not.toContain("Main\nView");
+    expect(text).not.toContain("table\tview");
+  });
+});
+
 describe("base handlers — query_base", () => {
   it("populates file.size/ctime/mtime for Base filters", async () => {
     env = await createTestEnv({
@@ -32,5 +67,44 @@ describe("base handlers — query_base", () => {
 
     expect(isError(result)).toBe(false);
     expect(textContent(result)).toContain("- note.md");
+  });
+
+  it("escapes control characters in view labels, warnings, and frontmatter keys", async () => {
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "note.md": [
+          "---",
+          "\"bad\\tkey\": \"dirty\\nvalue\"",
+          "---",
+          "# Note",
+          "",
+        ].join("\n"),
+        "query.base": [
+          "views:",
+          "  - type: table",
+          "    name: clean",
+          "",
+        ].join("\n"),
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "query_base",
+      arguments: {
+        path: "query.base",
+        view: "missing\nview",
+        includeFrontmatter: true,
+      },
+    });
+
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain("Base: query.base (view: missing\\nview)");
+    expect(text).toContain('View not found: "missing\\nview";');
+    expect(text).toContain('    bad\\tkey: "dirty\\nvalue"');
+    expect(text).not.toContain("missing\nview");
+    expect(text).not.toContain("bad\tkey");
+    expect(text).not.toContain("dirty\nvalue");
   });
 });

--- a/src/tools/bases.ts
+++ b/src/tools/bases.ts
@@ -6,7 +6,7 @@ import { parseBaseFile, queryBase, buildRow } from "../lib/bases.js";
 import { readAllCached } from "../lib/index-cache.js";
 import { extractWikilinks } from "../lib/markdown.js";
 import { mapConcurrent } from "../lib/concurrency.js";
-import { sanitizeError } from "../lib/errors.js";
+import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { log } from "../lib/logger.js";
 
 const MAX_CONCURRENT_STATS = 16;
@@ -18,6 +18,9 @@ function textResult(text: string) {
 function errorResult(text: string) {
   return { content: [{ type: "text" as const, text }], isError: true as const };
 }
+
+/** Escape control characters before embedding values in Base tool display text. */
+const displayBaseValue = escapeControlChars;
 
 export function registerBaseTools(server: McpServer, vaultPath: string): void {
   server.registerTool(
@@ -37,7 +40,7 @@ export function registerBaseTools(server: McpServer, vaultPath: string): void {
       try {
         const bases = await listBaseFiles(vaultPath);
         if (bases.length === 0) return textResult("No .base files in this vault.");
-        const lines = [`Found ${bases.length} Base file(s):`, "", ...bases];
+        const lines = [`Found ${bases.length} Base file(s):`, "", ...bases.map(displayBaseValue)];
         return textResult(lines.join("\n"));
       } catch (err) {
         log.error("list_bases failed", { tool: "list_bases", err: err as Error });
@@ -69,10 +72,10 @@ export function registerBaseTools(server: McpServer, vaultPath: string): void {
       try {
         const raw = await readBaseFile(vaultPath, basePath);
         const { doc, warnings } = parseBaseFile(raw);
-        const lines: string[] = [`Base: ${basePath}`, ""];
+        const lines: string[] = [`Base: ${displayBaseValue(basePath)}`, ""];
         if (warnings.length > 0) {
           lines.push("Parse warnings:");
-          for (const w of warnings) lines.push(`  - ${w}`);
+          for (const w of warnings) lines.push(`  - ${displayBaseValue(w)}`);
           lines.push("");
         }
         lines.push("Filters:");
@@ -81,7 +84,9 @@ export function registerBaseTools(server: McpServer, vaultPath: string): void {
         if (doc.properties) {
           lines.push(`Properties (${Object.keys(doc.properties).length}):`);
           for (const [key, spec] of Object.entries(doc.properties)) {
-            lines.push(`  - ${key}${spec.displayName ? ` (display: ${spec.displayName})` : ""}`);
+            lines.push(
+              `  - ${displayBaseValue(key)}${spec.displayName ? ` (display: ${displayBaseValue(spec.displayName)})` : ""}`,
+            );
           }
           lines.push("");
         }
@@ -89,7 +94,7 @@ export function registerBaseTools(server: McpServer, vaultPath: string): void {
           lines.push(`Views (${doc.views.length}):`);
           for (const v of doc.views) {
             const nm = v.name ?? "(unnamed)";
-            lines.push(`  - ${nm} [type: ${v.type}]`);
+            lines.push(`  - ${displayBaseValue(nm)} [type: ${displayBaseValue(v.type)}]`);
           }
         }
         return textResult(lines.join("\n"));
@@ -220,21 +225,21 @@ export function registerBaseTools(server: McpServer, vaultPath: string): void {
         const truncated = result.rows.slice(0, limit);
 
         const lines: string[] = [];
-        lines.push(`Base: ${basePath}${view ? ` (view: ${view})` : ""}`);
+        lines.push(`Base: ${displayBaseValue(basePath)}${view ? ` (view: ${displayBaseValue(view)})` : ""}`);
         lines.push(
           `Matched ${result.rows.length} note(s)${result.rows.length > limit ? ` (showing first ${limit})` : ""}`,
         );
         if (allWarnings.length > 0) {
           lines.push("");
           lines.push("Warnings:");
-          for (const w of allWarnings) lines.push(`  - ${w}`);
+          for (const w of allWarnings) lines.push(`  - ${displayBaseValue(w)}`);
         }
         lines.push("");
         for (const row of truncated) {
-          lines.push(`- ${row.path}`);
+          lines.push(`- ${displayBaseValue(row.path)}`);
           if (includeFrontmatter && Object.keys(row.frontmatter).length > 0) {
             for (const [k, v] of Object.entries(row.frontmatter)) {
-              lines.push(`    ${k}: ${JSON.stringify(v)}`);
+              lines.push(`    ${displayBaseValue(k)}: ${JSON.stringify(v)}`);
             }
           }
         }


### PR DESCRIPTION
Escapes control characters in Base-tool display values before returning them to MCP clients. Base parsing, filtering, and frontmatter values are unchanged; displayed labels, warnings, paths, and keys are made line-safe.

Score: 2 severity x 3 reach / 1 effort = 6.
Risk: low; display-only escaping in read tools.
Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR applies `escapeControlChars` to all user-visible display fields in the three Base tools (`list_bases`, `read_base`, `query_base`), following the same pattern already applied to links, attachments, and backlink tools in recent changelog entries. Frontmatter values intentionally remain serialized via `JSON.stringify`, which also escapes control characters in strings.

- `displayBaseValue` alias is introduced for `escapeControlChars` and applied to base paths, parse warnings, property keys/displayNames, view names/types, row paths, and frontmatter keys.
- Two new integration tests exercise the escaping through actual YAML files with embedded tab and newline characters in keys, display names, and view labels.
- No logic, filtering, or parsing changes are made; this is purely a display-output safety fix.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is display-only and does not touch parsing, filtering, or data logic.

The escaping is applied consistently to every user-visible field across all three Base tools. Frontmatter values go through JSON.stringify, which correctly escapes control characters in strings — intentionally not changed. The two new integration tests use real YAML files with embedded tab and newline characters and cover property keys, displayNames, view labels, warnings, and frontmatter keys. The only minor gap is that no test exercises a basePath containing a control character in the success path of read_base or query_base, though such a path would normally be rejected by the filesystem before reaching the display code.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/bases.ts | Adds displayBaseValue alias for escapeControlChars and applies it consistently to all display fields (paths, warnings, property keys/displayNames, view names/types, frontmatter keys, row paths); frontmatter values are serialized via JSON.stringify which also escapes control chars in strings. |
| src/__tests__/handlers/bases.test.ts | Adds two new test cases covering control-char escaping in read_base (property keys, displayNames, view name/type) and query_base (view label, View not found warning, frontmatter keys/values); test for read_base does not exercise path escaping since the fixture path dirty.base itself is clean. |
| CHANGELOG.md | Adds one changelog entry for the Base tools escaping fix in the Unreleased section, consistent with the other escaping entries already there. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP Client sends tool call] --> B{Tool}
    B --> LB[list_bases]
    B --> RB[read_base]
    B --> QB[query_base]
    LB --> LB1[listBaseFiles - paths]
    LB1 --> LBD[displayBaseValue each path]
    LBD --> LBO[textResult output]
    RB --> RB1[readBaseFile + parseBaseFile]
    RB1 --> RB2[basePath, warnings, property keys/displayNames, view names/types]
    RB2 --> RBD[displayBaseValue each field]
    RBD --> RBO[textResult output]
    QB --> QB1[readBaseFile + parseBaseFile + queryBase]
    QB1 --> QB2[basePath, view, warnings, row paths, frontmatter keys]
    QB2 --> QBD[displayBaseValue each field]
    QB1 --> QB3[frontmatter values]
    QB3 --> QBJ[JSON.stringify - also escapes control chars]
    QBD --> QBO[textResult output]
    QBJ --> QBO
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape base output"](https://github.com/rps321321/obsidian-mcp-pro/commit/23881c88678eda7173acea065437fc38a781f67c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35518306)</sub>

<!-- /greptile_comment -->