### PR TITLE
fix: escape section output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_backlinks`, `find_orphans`, `find_broken_links`, and `get_graph_neighbors` now escape control characters in displayed note paths, wikilink targets, and context lines before returning them to MCP clients.
 - Attachment tools now escape control characters in displayed extension filters, attachment paths, filenames, and blocked/rejected paths before returning them to MCP clients.
 - Base tools now escape control characters in displayed Base paths, property labels, view labels, warnings, result paths, and frontmatter keys before returning them to MCP clients.
+- Section tools now escape control characters in displayed note paths, headings, block ids, and invalid regex flags before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/regression-tools-sections.test.ts
+++ b/src/__tests__/regression-tools-sections.test.ts
@@ -192,6 +192,89 @@ describe("regression: insert_at_section UTF-8 byte count (H11)", () => {
   });
 });
 
+describe("regression: section tool output escaping", () => {
+  it("escapes control characters in listed heading text", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, "dirty-heading.md"),
+      "# Clean\n\n## Dirty\tHeading\n\nBody\n",
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "list_sections",
+      arguments: { path: "dirty-heading.md" },
+    });
+
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain("## Dirty\\tHeading");
+    expect(text).not.toContain("Dirty\tHeading");
+  });
+
+  it("escapes control characters in update_section success output", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, "update-dirty-heading.md"),
+      "# Dirty\tHeading\n\nold body\n",
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "update_section",
+      arguments: {
+        path: "update-dirty-heading.md",
+        section: "Dirty\tHeading",
+        newBody: "new body",
+      },
+    });
+
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain('Updated section "Dirty\\tHeading" in update-dirty-heading.md');
+    expect(text).not.toContain("Dirty\tHeading");
+  });
+
+  it("escapes control characters in insert_at_section success output", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, "insert-dirty-heading.md"),
+      "# Dirty\tHeading\n\nold body\n",
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "insert_at_section",
+      arguments: {
+        path: "insert-dirty-heading.md",
+        section: "Dirty\tHeading",
+        content: "inserted",
+        position: "append",
+      },
+    });
+
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain('bytes into "Dirty\\tHeading" (append) in insert-dirty-heading.md');
+    expect(text).not.toContain("Dirty\tHeading");
+  });
+
+  it("escapes control characters in invalid regex flag errors", async () => {
+    const result = await env.client.callTool({
+      name: "replace_in_note",
+      arguments: {
+        path: "note-c.md",
+        find: "Standalone",
+        replace: "REPLACED",
+        regex: true,
+        flags: "g\n",
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain("invalid regex flag '\\n'");
+    expect(text).not.toContain("invalid regex flag '\n'");
+  });
+});
+
 describe("regression: edit_block normalizes leading ^ (O8)", () => {
   it("accepts `^myid` and treats it identically to `myid`", async () => {
     const note = "# Note\n\nFirst paragraph. ^myid\n\nOther stuff.\n";

--- a/src/tools/sections.ts
+++ b/src/tools/sections.ts
@@ -8,7 +8,7 @@ import {
   replaceSectionBody,
   insertAfterHeading,
 } from "../lib/sections.js";
-import { sanitizeError } from "../lib/errors.js";
+import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { log } from "../lib/logger.js";
 
 function textResult(text: string) {
@@ -18,6 +18,9 @@ function textResult(text: string) {
 function errorResult(text: string) {
   return { content: [{ type: "text" as const, text }], isError: true as const };
 }
+
+/** Escape control characters before embedding values in section-tool display text. */
+const displaySectionValue = escapeControlChars;
 
 function splitHeadingPath(section: string): string[] {
   return section.split("/").map((s) => s.trim()).filter(Boolean);
@@ -71,7 +74,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
           return updated;
         });
         return textResult(
-          `Updated section "${resolvedHeading}" in ${notePath} (${bodyBytes} bytes of new body)`,
+          `Updated section "${displaySectionValue(resolvedHeading)}" in ${displaySectionValue(notePath)} (${bodyBytes} bytes of new body)`,
         );
       } catch (err) {
         log.error("update_section failed", { tool: "update_section", err: err as Error });
@@ -133,7 +136,9 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
           if (!payload.endsWith("\n")) payload += "\n";
           return before + payload + after;
         });
-        return textResult(`Inserted ${Buffer.byteLength(content, "utf-8")} bytes into "${resolvedHeading}" (${position}) in ${notePath}`);
+        return textResult(
+          `Inserted ${Buffer.byteLength(content, "utf-8")} bytes into "${displaySectionValue(resolvedHeading)}" (${position}) in ${displaySectionValue(notePath)}`,
+        );
       } catch (err) {
         log.error("insert_at_section failed", { tool: "insert_at_section", err: err as Error });
         return errorResult(`Error inserting at section: ${sanitizeError(err)}`);
@@ -161,10 +166,10 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
         const { readNote } = await import("../lib/vault.js");
         const content = await readNote(vaultPath, notePath);
         const headings = parseHeadings(content);
-        if (headings.length === 0) return textResult(`No headings in ${notePath}`);
-        const lines = [`${headings.length} heading(s) in ${notePath}:`, ""];
+        if (headings.length === 0) return textResult(`No headings in ${displaySectionValue(notePath)}`);
+        const lines = [`${headings.length} heading(s) in ${displaySectionValue(notePath)}:`, ""];
         for (const h of headings) {
-          lines.push(`${"  ".repeat(h.level - 1)}${"#".repeat(h.level)} ${h.text}`);
+          lines.push(`${"  ".repeat(h.level - 1)}${"#".repeat(h.level)} ${displaySectionValue(h.text)}`);
         }
         return textResult(lines.join("\n"));
       } catch (err) {
@@ -221,12 +226,12 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
           for (const ch of f) {
             if (!ALLOWED_FLAGS.has(ch)) {
               return errorResult(
-                `Error replacing in note: invalid regex flag '${ch}'. Allowed flags: g, i, m, s, u, y.`,
+                `Error replacing in note: invalid regex flag '${displaySectionValue(ch)}'. Allowed flags: g, i, m, s, u, y.`,
               );
             }
             if (seen.has(ch)) {
               return errorResult(
-                `Error replacing in note: duplicate regex flag '${ch}'.`,
+                `Error replacing in note: duplicate regex flag '${displaySectionValue(ch)}'.`,
               );
             }
             seen.add(ch);
@@ -272,8 +277,8 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
         });
         return textResult(
           count === 0
-            ? `No matches in ${notePath} - file unchanged.`
-            : `Replaced ${count} match(es) in ${notePath}.`,
+            ? `No matches in ${displaySectionValue(notePath)} - file unchanged.`
+            : `Replaced ${count} match(es) in ${displaySectionValue(notePath)}.`,
         );
       } catch (err) {
         log.error("replace_in_note failed", { tool: "replace_in_note", err: err as Error });
@@ -325,7 +330,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
           const replacement = isMultiline ? `${body}\n^${block}\n` : `${body} ^${block}\n`;
           return before + replacement + after;
         });
-        return textResult(`Updated block ^${block} in ${notePath}`);
+        return textResult(`Updated block ^${displaySectionValue(block)} in ${displaySectionValue(notePath)}`);
       } catch (err) {
         log.error("edit_block failed", { tool: "edit_block", err: err as Error });
         return errorResult(`Error editing block: ${sanitizeError(err)}`);


### PR DESCRIPTION
Escapes control characters in section-tool display values before returning them to MCP clients. Section matching, note writes, regex behavior, and block edits are unchanged; displayed note paths, headings, block ids, and invalid regex flags are made line-safe.

Score: 3 severity x 3 reach / 1 effort = 9.
Risk: low; display-only escaping plus invalid-flag message escaping.
Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the existing `escapeControlChars` defense-in-depth pattern to the section tools (`update_section`, `insert_at_section`, `list_sections`, `replace_in_note`, `edit_block`), matching what was already applied to backlink, attachment, and base tools. All user-visible note paths, heading text, block IDs, and flag characters are now passed through `displaySectionValue` (an alias for `escapeControlChars`) before being embedded in MCP response strings.

- **`src/tools/sections.ts`**: Introduces a `displaySectionValue` alias for `escapeControlChars` and applies it to every display-facing interpolation (note paths, heading text, block IDs, flag characters) across the five section tools.
- **`src/__tests__/regression-tools-sections.test.ts`**: Adds four regression tests covering heading-text escaping in `list_sections`, success-message escaping in `update_section` and `insert_at_section`, and invalid-flag escaping in `replace_in_note`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are display-only escaping with no effect on note reads, writes, or matching logic.

The escaping is applied consistently to every user-controlled value that appears in a section-tool response string, matching the pattern already established for other tool families. The only gap is that edit_block and note-path escaping lack regression tests, leaving those call sites without a pin against future accidental removal.

The test file would benefit from a couple of additional cases for edit_block and control characters in note paths.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/sections.ts | Escaping applied consistently to all display-facing values across all five section tools; no logic paths altered. |
| src/__tests__/regression-tools-sections.test.ts | Four regression tests added covering key escaping paths; edit_block and note-path escaping cases are not yet covered by tests. |
| CHANGELOG.md | Changelog entry added for section-tool output escaping under the current unreleased section. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP Tool Call] --> B{Tool}
    B --> C[update_section]
    B --> D[insert_at_section]
    B --> E[list_sections]
    B --> F[replace_in_note]
    B --> G[edit_block]

    C --> C1["resolvedHeading, notePath → displaySectionValue()"]
    D --> D1["resolvedHeading, notePath → displaySectionValue()"]
    E --> E1["notePath, h.text → displaySectionValue()"]
    F --> F1["invalid/duplicate flag ch → displaySectionValue()"]
    F --> F2["notePath (success) → displaySectionValue()"]
    G --> G1["block, notePath → displaySectionValue()"]

    C1 --> R[textResult / errorResult to MCP client]
    D1 --> R
    E1 --> R
    F1 --> R
    F2 --> R
    G1 --> R
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape section output"](https://github.com/rps321321/obsidian-mcp-pro/commit/04b229c9408cf62e1873e4c20fb82d3f085f53e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35519209)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->