### PR TITLE
fix: escape semantic output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Attachment tools now escape control characters in displayed extension filters, attachment paths, filenames, and blocked/rejected paths before returning them to MCP clients.
 - Base tools now escape control characters in displayed Base paths, property labels, view labels, warnings, result paths, and frontmatter keys before returning them to MCP clients.
 - Section tools now escape control characters in displayed note paths, headings, block ids, and invalid regex flags before returning them to MCP clients.
+- Semantic tools now escape control characters in displayed queries, provider labels, note paths, heading paths, and snippets before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/semantic.test.ts
+++ b/src/__tests__/handlers/semantic.test.ts
@@ -80,6 +80,24 @@ describe("semantic handlers — index_vault", () => {
     const text = textContent(forced);
     expect(text).toMatch(/Notes embedded:\s+4/);
   });
+
+  it("escapes configured provider labels in summaries", async () => {
+    class DirtyProvider extends MockProvider {
+      readonly id = "mock\nprovider";
+      readonly model = "topic\tcounter";
+    }
+    setProviderForTests(new DirtyProvider());
+
+    const result = await env.client.callTool({
+      name: "index_vault",
+      arguments: {},
+    });
+
+    const text = textContent(result);
+    expect(text).toContain("via mock\\nprovider/topic\\tcounter");
+    expect(text).not.toContain("mock\nprovider");
+    expect(text).not.toContain("topic\tcounter");
+  });
 });
 
 describe("semantic handlers — search_semantic", () => {
@@ -114,6 +132,43 @@ describe("semantic handlers — search_semantic", () => {
     });
     expect(textContent(result)).toMatch(/No matches/);
   });
+
+  it("escapes query labels when no matches are found", async () => {
+    await env.client.callTool({ name: "index_vault", arguments: {} });
+
+    const result = await env.client.callTool({
+      name: "search_semantic",
+      arguments: { query: "cats\ninjected", folder: "no-such-folder", limit: 5 },
+    });
+
+    const text = textContent(result);
+    expect(text).toContain('No matches for "cats\\ninjected".');
+    expect(text).not.toContain("cats\ninjected");
+  });
+
+  it("escapes indexed headings and snippets in search output", async () => {
+    await env.cleanup();
+    await clearStore(env.vaultDir, { removeSnapshot: true });
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "dirty.md": "# Dirty\tHeading\n\nCats cats cats ring \x07 bells.",
+        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+      },
+    });
+
+    await env.client.callTool({ name: "index_vault", arguments: {} });
+    const result = await env.client.callTool({
+      name: "search_semantic",
+      arguments: { query: "cats", limit: 1 },
+    });
+
+    const text = textContent(result);
+    expect(text).toContain("Dirty\\tHeading");
+    expect(text).toContain("\\x07");
+    expect(text).not.toContain("Dirty\tHeading");
+    expect(text).not.toContain("\x07");
+  });
 });
 
 describe("semantic handlers — find_similar_notes", () => {
@@ -138,6 +193,41 @@ describe("semantic handlers — find_similar_notes", () => {
     });
     expect(isError(result)).toBe(true);
     expect(textContent(result)).toMatch(/index_vault/i);
+  });
+
+  it("escapes caller-supplied missing source paths", async () => {
+    const result = await env.client.callTool({
+      name: "find_similar_notes",
+      arguments: { path: "missing\nnote.md" },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(true);
+    expect(text).toContain('No embeddings found for "missing\\nnote.md"');
+    expect(text).not.toContain("missing\nnote.md");
+  });
+
+  it("escapes indexed headings in similar-note output", async () => {
+    await env.cleanup();
+    await clearStore(env.vaultDir, { removeSnapshot: true });
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "dirty.md": "# Dirty\tHeading\n\nCats cats cats ring bells.",
+        "source.md": "# Source\n\nCats.",
+        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+      },
+    });
+
+    await env.client.callTool({ name: "index_vault", arguments: {} });
+    const result = await env.client.callTool({
+      name: "find_similar_notes",
+      arguments: { path: "source.md", limit: 1 },
+    });
+
+    const text = textContent(result);
+    expect(text).toContain("Dirty\\tHeading");
+    expect(text).not.toContain("Dirty\tHeading");
   });
 });
 

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -18,7 +18,7 @@ import {
   type ChunkEmbedding,
 } from "../lib/embedding-store.js";
 import { makeProgressReporter } from "../lib/progress.js";
-import { sanitizeError } from "../lib/errors.js";
+import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { formatFailedPath } from "../lib/tool-output.js";
 import { log } from "../lib/logger.js";
 import { mapConcurrent } from "../lib/concurrency.js";
@@ -35,6 +35,12 @@ function textResult(text: string) {
 
 function errorResult(text: string) {
   return { content: [{ type: "text" as const, text }], isError: true as const };
+}
+
+const displaySemanticValue = escapeControlChars;
+
+function displayHeadingPath(path: readonly string[]): string {
+  return path.map(displaySemanticValue).join(" / ");
 }
 
 interface IndexProgress {
@@ -102,7 +108,9 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         const reportProgress = makeProgressReporter(progressMeta);
         const notes = await listNotes(vaultPath, folder);
         if (notes.length === 0) {
-          return textResult(folder ? `No notes in "${folder}" to index.` : "Vault is empty — nothing to index.");
+          return textResult(
+            folder ? `No notes in "${displaySemanticValue(folder)}" to index.` : "Vault is empty — nothing to index.",
+          );
         }
 
         const { contents } = await readAllCached(vaultPath, notes, (note, err) => {
@@ -139,7 +147,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
           if (!force && noteIsCurrent(vaultPath, notePath, contentHash)) {
             stats.notesUnchanged++;
             stats.notesScanned++;
-            await reportProgress(stats.notesScanned, notes.length, `Unchanged ${notePath}`);
+            await reportProgress(stats.notesScanned, notes.length, `Unchanged ${displaySemanticValue(notePath)}`);
             continue;
           }
           noteHashByPath.set(notePath, contentHash);
@@ -155,7 +163,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
             });
           }
           stats.notesScanned++;
-          await reportProgress(stats.notesScanned, notes.length, `Chunked ${notePath}`);
+          await reportProgress(stats.notesScanned, notes.length, `Chunked ${displaySemanticValue(notePath)}`);
         }
 
         // Embed pending chunks in batches.
@@ -232,7 +240,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         await saveStore(vaultPath);
 
         const lines = [
-          `Indexed${folder ? ` "${folder}"` : ""} via ${provider.id}/${provider.model}`,
+          `Indexed${folder ? ` "${displaySemanticValue(folder)}"` : ""} via ${displaySemanticValue(provider.id)}/${displaySemanticValue(provider.model)}`,
           `  Notes scanned:   ${stats.notesScanned}`,
           `  Notes embedded:  ${stats.notesEmbedded}`,
           `  Notes unchanged: ${stats.notesUnchanged}`,
@@ -317,16 +325,16 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         }
         const hits = searchEmbeddings(vaultPath, vector, { limit, ...(folder ? { folder } : {}) });
         if (hits.length === 0) {
-          return textResult(`No matches for "${query}".`);
+          return textResult(`No matches for "${displaySemanticValue(query)}".`);
         }
 
-        const lines: string[] = [`${hits.length} match(es) for "${query}":`, ""];
+        const lines: string[] = [`${hits.length} match(es) for "${displaySemanticValue(query)}":`, ""];
         for (const hit of hits) {
-          const heading = hit.headingPath.length > 0 ? ` (${hit.headingPath.join(" / ")})` : "";
-          lines.push(`- ${hit.notePath}${heading}  [score: ${hit.score.toFixed(3)}]`);
+          const heading = hit.headingPath.length > 0 ? ` (${displayHeadingPath(hit.headingPath)})` : "";
+          lines.push(`- ${displaySemanticValue(hit.notePath)}${heading}  [score: ${hit.score.toFixed(3)}]`);
           if (includeSnippet) {
             const snippet = hit.text.replace(/\s+/g, " ").trim().slice(0, 200);
-            lines.push(`    ${snippet}${hit.text.length > 200 ? "…" : ""}`);
+            lines.push(`    ${displaySemanticValue(snippet)}${hit.text.length > 200 ? "…" : ""}`);
           }
         }
         return textResult(lines.join("\n"));
@@ -377,7 +385,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         const ownChunks = getNoteEmbeddings(vaultPath, notePath);
         if (ownChunks.length === 0) {
           return errorResult(
-            `No embeddings found for "${notePath}". Run \`index_vault\` first (or check the path is correct).`,
+            `No embeddings found for "${displaySemanticValue(notePath)}". Run \`index_vault\` first (or check the path is correct).`,
           );
         }
         // Compute a centroid (mean) vector from all of the source note's
@@ -418,12 +426,12 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         }));
 
         if (ranked.length === 0) {
-          return textResult(`No similar notes found for "${notePath}".`);
+          return textResult(`No similar notes found for "${displaySemanticValue(notePath)}".`);
         }
-        const lines: string[] = [`${ranked.length} note(s) similar to ${notePath}:`, ""];
+        const lines: string[] = [`${ranked.length} note(s) similar to ${displaySemanticValue(notePath)}:`, ""];
         for (const r of ranked) {
-          const heading = r.headingPath.length > 0 ? ` (${r.headingPath.join(" / ")})` : "";
-          lines.push(`- ${r.notePath}${heading}  [score: ${r.score.toFixed(3)}]`);
+          const heading = r.headingPath.length > 0 ? ` (${displayHeadingPath(r.headingPath)})` : "";
+          lines.push(`- ${displaySemanticValue(r.notePath)}${heading}  [score: ${r.score.toFixed(3)}]`);
         }
         return textResult(lines.join("\n"));
       } catch (err) {


### PR DESCRIPTION
Escapes control characters in semantic tool display output for queries, provider labels, progress messages, note paths, heading paths, and snippets. This keeps indexed vault text and caller-supplied labels from injecting extra lines into MCP responses without changing embedding or storage semantics.

Risk: low; display-only escaping on existing text payloads.
Score: 3 severity x 3 reach / 1 effort = 9.

Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR completes the control-character escaping work for the semantic tool family, bringing it in line with the attachment, base, and section tools that were hardened in the same release cycle. All caller-supplied and indexed values that appear in MCP display output — queries, folder names, note paths, heading path segments, snippets, and provider id/model labels — are now routed through `escapeControlChars` before being included in response text.

- **`semantic.ts`**: Introduces `displaySemanticValue` (alias for `escapeControlChars`) and `displayHeadingPath` (escapes each segment before joining), then applies them to every display-facing interpolation across `index_vault`, `search_semantic`, and `find_similar_notes`. Embedding storage and retrieval are untouched.
- **`semantic.test.ts`**: Adds five new integration tests covering dirty provider labels, escaped query echo on no-match, embedded headings with tabs, snippets with non-whitespace control bytes (`\x07`), and caller-supplied paths with newlines in error messages.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are display-only, scoped to output formatting, and do not touch embedding logic, storage, or retrieval.

All display interpolations across the three semantic tools are now escaped, formatFailedPath already handled failure entries independently, and five new integration tests exercise the boundaries with dirty provider labels, tab-embedded headings, non-whitespace control bytes in snippets, and newlines in caller-supplied paths. No embedding, storage, or search behaviour is altered.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/semantic.ts | Adds displaySemanticValue/displayHeadingPath display helpers backed by escapeControlChars and applies them consistently to all user-visible string fields: query, folder, notePath, headingPath segments, snippets, and provider id/model. |
| src/__tests__/handlers/semantic.test.ts | Adds five targeted escape tests covering provider labels, query echo, indexed headings, snippets, and caller-supplied paths; uses mid-test env reset pattern correctly and assertions are well-formed. |
| CHANGELOG.md | Adds changelog entry describing the semantic-tool escaping; progress-message escaping is also applied in code but not mentioned here — minor omission, not a functional issue. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP Tool Call] --> B{Tool}
    B --> C[index_vault]
    B --> D[search_semantic]
    B --> E[find_similar_notes]

    C --> C1[folder / notePath in progress\ndisplaySemanticValue]
    C --> C2[provider.id / provider.model\nin summary\ndisplaySemanticValue]
    C --> C3[formatFailedPath\nalready escaped]

    D --> D1[query echo\ndisplaySemanticValue]
    D --> D2[hit.notePath\ndisplaySemanticValue]
    D --> D3[hit.headingPath\ndisplayHeadingPath]
    D --> D4[snippet\ndisplaySemanticValue]

    E --> E1[notePath in error / summary\ndisplaySemanticValue]
    E --> E2[r.notePath in results\ndisplaySemanticValue]
    E --> E3[r.headingPath\ndisplayHeadingPath]

    C1 & C2 & C3 & D1 & D2 & D3 & D4 & E1 & E2 & E3 --> F[escapeControlChars\nASCII 0x00-0x1F 0x7F]
    F --> G[Safe MCP Response Text]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape semantic output"](https://github.com/rps321321/obsidian-mcp-pro/commit/038367cb6bdad68c4a93e116d3e1dc569f2fb8f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35524615)</sub>

<!-- /greptile_comment -->