### PR TITLE
fix: escape write output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Base tools now escape control characters in displayed Base paths, property labels, view labels, warnings, result paths, and frontmatter keys before returning them to MCP clients.
 - Section tools now escape control characters in displayed note paths, headings, block ids, and invalid regex flags before returning them to MCP clients.
 - Semantic tools now escape control characters in displayed queries, provider labels, note paths, heading paths, and snippets before returning them to MCP clients.
+- Write tools now escape control characters in displayed note paths before returning create, update, move, delete, and daily-note messages to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/write.test.ts
+++ b/src/__tests__/handlers/write.test.ts
@@ -93,6 +93,27 @@ describe("write handlers — create_note", () => {
     expect(textContent(result)).toMatch(/no-extension\.md/);
     await expect(fs.access(path.join(env.vaultDir, "no-extension.md"))).resolves.toBeUndefined();
   });
+
+  it("escapes normalized paths in success and already-exists messages", async () => {
+    const dirtyPath = "dirty\x7fnote.md";
+    const created = await env.client.callTool({
+      name: "create_note",
+      arguments: { path: dirtyPath, content: "Control-char path." },
+    });
+
+    expect(isError(created)).toBe(false);
+    expect(textContent(created)).toContain("dirty\\x7fnote.md");
+    expect(textContent(created)).not.toContain(dirtyPath);
+    await expect(fs.access(path.join(env.vaultDir, dirtyPath))).resolves.toBeUndefined();
+
+    const duplicate = await env.client.callTool({
+      name: "create_note",
+      arguments: { path: dirtyPath, content: "Duplicate." },
+    });
+    expect(isError(duplicate)).toBe(true);
+    expect(textContent(duplicate)).toContain("dirty\\x7fnote.md");
+    expect(textContent(duplicate)).not.toContain(dirtyPath);
+  });
 });
 
 describe("write handlers — append_to_note / prepend_to_note", () => {
@@ -136,6 +157,35 @@ describe("write handlers — append_to_note / prepend_to_note", () => {
     expect(isError(result)).toBe(false);
     const onDisk = await fs.readFile(path.join(env.vaultDir, "note-c.md"), "utf-8");
     expect(onDisk).toMatch(/^HEADER\n/);
+  });
+
+  it("escapes target paths in append, prepend, and frontmatter success messages", async () => {
+    const dirtyPath = "mutate\x7fnote.md";
+    await fs.writeFile(path.join(env.vaultDir, dirtyPath), "Body", "utf-8");
+
+    const appended = await env.client.callTool({
+      name: "append_to_note",
+      arguments: { path: dirtyPath, content: "APPENDED" },
+    });
+    expect(isError(appended)).toBe(false);
+    expect(textContent(appended)).toContain("mutate\\x7fnote.md");
+    expect(textContent(appended)).not.toContain(dirtyPath);
+
+    const prepended = await env.client.callTool({
+      name: "prepend_to_note",
+      arguments: { path: dirtyPath, content: "PREPENDED" },
+    });
+    expect(isError(prepended)).toBe(false);
+    expect(textContent(prepended)).toContain("mutate\\x7fnote.md");
+    expect(textContent(prepended)).not.toContain(dirtyPath);
+
+    const updated = await env.client.callTool({
+      name: "update_frontmatter",
+      arguments: { path: dirtyPath, properties: JSON.stringify({ status: "dirty" }) },
+    });
+    expect(isError(updated)).toBe(false);
+    expect(textContent(updated)).toContain("mutate\\x7fnote.md");
+    expect(textContent(updated)).not.toContain(dirtyPath);
   });
 });
 
@@ -229,6 +279,27 @@ describe("write handlers — create_daily_note", () => {
     expect(isError(result)).toBe(true);
     expect(textContent(result)).toMatch(/Invalid date/);
   });
+
+  it("escapes configured daily-note paths in create output", async () => {
+    const dirtyFolder = "daily\x7fnotes";
+    await fs.writeFile(
+      path.join(env.vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: dirtyFolder, format: "YYYY-MM-DD" }),
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "create_daily_note",
+      arguments: { date: "2026-05-07", content: "May 7 entry." },
+    });
+
+    expect(isError(result)).toBe(false);
+    expect(textContent(result)).toContain("daily\\x7fnotes/2026-05-07.md");
+    expect(textContent(result)).not.toContain(`${dirtyFolder}/2026-05-07.md`);
+    await expect(
+      fs.access(path.join(env.vaultDir, dirtyFolder, "2026-05-07.md")),
+    ).resolves.toBeUndefined();
+  });
 });
 
 describe("write handlers — move_note", () => {
@@ -292,6 +363,25 @@ describe("write handlers — move_note", () => {
     const fileNode = canvas.nodes.find((n: { type: string }) => n.type === "file");
     expect(fileNode.file).toBe("note-a.md");
   });
+
+  it("escapes source and destination paths in move output", async () => {
+    const oldPath = "move\x7fold.md";
+    const newPath = "archive/move\x7fnew.md";
+    await fs.writeFile(path.join(env.vaultDir, oldPath), "Move me.", "utf-8");
+
+    const result = await env.client.callTool({
+      name: "move_note",
+      arguments: { oldPath, newPath, updateLinks: false },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain("move\\x7fold.md");
+    expect(text).toContain("archive/move\\x7fnew.md");
+    expect(text).not.toContain(oldPath);
+    expect(text).not.toContain(newPath);
+    await expect(fs.access(path.join(env.vaultDir, newPath))).resolves.toBeUndefined();
+  });
 });
 
 describe("write handlers — delete_note", () => {
@@ -317,5 +407,33 @@ describe("write handlers — delete_note", () => {
 
     await expect(fs.access(path.join(env.vaultDir, "note-c.md"))).rejects.toThrow();
     await expect(fs.access(path.join(env.vaultDir, ".trash/note-c.md"))).rejects.toThrow();
+  });
+
+  it("escapes note paths in trash-delete output", async () => {
+    const dirtyPath = "delete\x7fnote.md";
+    await fs.writeFile(path.join(env.vaultDir, dirtyPath), "Delete me.", "utf-8");
+
+    const result = await env.client.callTool({
+      name: "delete_note",
+      arguments: { path: dirtyPath },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain("delete\\x7fnote.md");
+    expect(text).not.toContain(dirtyPath);
+    await expect(fs.access(path.join(env.vaultDir, ".trash", dirtyPath))).resolves.toBeUndefined();
+  });
+
+  it("escapes note paths before permanent-delete confirmation", async () => {
+    const result = await env.client.callTool({
+      name: "delete_note",
+      arguments: { path: "line\nbreak", permanent: true },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(true);
+    expect(text).toContain('Permanent deletion of "line\\nbreak.md" requires confirm=true');
+    expect(text).not.toContain("line\nbreak.md");
   });
 });

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -11,7 +11,7 @@ import {
 } from "../lib/vault.js";
 import { updateFrontmatter } from "../lib/markdown.js";
 import { getDailyNoteConfig } from "../config.js";
-import { sanitizeError } from "../lib/errors.js";
+import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { formatFailedPath } from "../lib/tool-output.js";
 import { formatMomentDate, parseLocalDateOnly } from "../lib/dates.js";
 import { log } from "../lib/logger.js";
@@ -23,6 +23,8 @@ function textResult(text: string) {
 function errorResult(text: string) {
   return { content: [{ type: "text" as const, text }], isError: true as const };
 }
+
+const displayWriteValue = escapeControlChars;
 
 function ensureMdExtension(filePath: string): string {
   return /\.md$/i.test(filePath) ? filePath : `${filePath}.md`;
@@ -74,6 +76,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
     async ({ path: notePath, content, frontmatter }) => {
       try {
         const resolvedPath = ensureMdExtension(notePath);
+        const displayedPath = displayWriteValue(resolvedPath);
 
         let finalContent: string;
 
@@ -98,11 +101,11 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
           await writeNote(vaultPath, resolvedPath, finalContent, { exclusive: true });
         } catch (err) {
           if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-            return errorResult(`Error: Note already exists at '${resolvedPath}'. Use append or update tools instead.`);
+            return errorResult(`Error: Note already exists at '${displayedPath}'. Use append or update tools instead.`);
           }
           throw err;
         }
-        return textResult(`Created note at '${resolvedPath}'.`);
+        return textResult(`Created note at '${displayedPath}'.`);
       } catch (err) {
         log.error("create_note failed", { tool: "create_note", err: err as Error });
         return errorResult(`Error creating note: ${sanitizeError(err)}`);
@@ -139,7 +142,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
       try {
         const resolvedPath = ensureMdExtension(notePath);
         await appendToNote(vaultPath, resolvedPath, content);
-        return textResult(`Appended content to '${resolvedPath}'.`);
+        return textResult(`Appended content to '${displayWriteValue(resolvedPath)}'.`);
       } catch (err) {
         log.error("append_to_note failed", { tool: "append_to_note", err: err as Error });
         return errorResult(`Error appending to note: ${sanitizeError(err)}`);
@@ -176,7 +179,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
       try {
         const resolvedPath = ensureMdExtension(notePath);
         await prependToNote(vaultPath, resolvedPath, content);
-        return textResult(`Prepended content to '${resolvedPath}'.`);
+        return textResult(`Prepended content to '${displayWriteValue(resolvedPath)}'.`);
       } catch (err) {
         log.error("prepend_to_note failed", { tool: "prepend_to_note", err: err as Error });
         return errorResult(`Error prepending to note: ${sanitizeError(err)}`);
@@ -230,7 +233,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
           updateFrontmatter(existing, props),
         );
 
-        return textResult(`Updated frontmatter of '${resolvedPath}' with ${Object.keys(props).length} properties.`);
+        return textResult(`Updated frontmatter of '${displayWriteValue(resolvedPath)}' with ${Object.keys(props).length} properties.`);
       } catch (err) {
         log.error("update_frontmatter failed", { tool: "update_frontmatter", err: err as Error });
         return errorResult(`Error updating frontmatter: ${sanitizeError(err)}`);
@@ -321,11 +324,11 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
           await writeNote(vaultPath, notePath, finalContent, { exclusive: true });
         } catch (err) {
           if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-            return errorResult(`Error: Daily note already exists at '${notePath}'.`);
+            return errorResult(`Error: Daily note already exists at '${displayWriteValue(notePath)}'.`);
           }
           throw err;
         }
-        return textResult(`Created daily note at '${notePath}'.`);
+        return textResult(`Created daily note at '${displayWriteValue(notePath)}'.`);
       } catch (err) {
         log.error("create_daily_note failed", { tool: "create_daily_note", err: err as Error });
         return errorResult(`Error creating daily note: ${sanitizeError(err)}`);
@@ -369,7 +372,9 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
         const resolvedOld = ensureMdExtension(oldPath);
         const resolvedNew = ensureMdExtension(newPath);
         const result = await moveNote(vaultPath, resolvedOld, resolvedNew, { updateLinks });
-        const lines: string[] = [`Moved note from '${resolvedOld}' to '${resolvedNew}'.`];
+        const lines: string[] = [
+          `Moved note from '${displayWriteValue(resolvedOld)}' to '${displayWriteValue(resolvedNew)}'.`,
+        ];
         if (updateLinks !== false) {
           const updated = result.updatedReferrers.length;
           lines.push(
@@ -448,7 +453,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
         // recoverable, so no confirmation is needed for those.
         if (permanent && !confirm) {
           return errorResult(
-            `Permanent deletion of "${resolvedPath}" requires confirm=true. ` +
+            `Permanent deletion of "${displayWriteValue(resolvedPath)}" requires confirm=true. ` +
             "This is a destructive, irreversible operation. Set confirm to true to proceed, " +
             "or omit permanent (or set it to false) to move the note to the vault's .trash folder instead.",
           );
@@ -477,7 +482,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
           try {
             const elicit = await server.server.elicitInput({
               message:
-                `Permanently delete "${resolvedPath}" from the vault?` +
+                `Permanently delete "${displayWriteValue(resolvedPath)}" from the vault?` +
                 (removeReferences ? " References across the vault will also be stripped." : "") +
                 ` This cannot be undone. Type the note's path to confirm.`,
               requestedSchema: {
@@ -492,7 +497,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
               },
             });
             if (elicit.action !== "accept") {
-              return textResult(`Deletion of "${resolvedPath}" cancelled.`);
+              return textResult(`Deletion of "${displayWriteValue(resolvedPath)}" cancelled.`);
             }
             // An accept with no content (or a missing field) is treated as
             // a cancel rather than an error: the user dismissed the form
@@ -501,11 +506,11 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
             const content = elicit.content as { confirmPath?: unknown } | undefined;
             const confirmed = content?.confirmPath;
             if (confirmed === undefined || confirmed === null || confirmed === "") {
-              return textResult(`Deletion of "${resolvedPath}" cancelled (no confirmation provided).`);
+              return textResult(`Deletion of "${displayWriteValue(resolvedPath)}" cancelled (no confirmation provided).`);
             }
             if (typeof confirmed !== "string" || confirmed.trim() !== resolvedPath) {
               return errorResult(
-                `Confirmation path did not match "${resolvedPath}"; deletion aborted.`,
+                `Confirmation path did not match "${displayWriteValue(resolvedPath)}"; deletion aborted.`,
               );
             }
           } catch (err) {
@@ -515,7 +520,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
 
         const result = await deleteNote(vaultPath, resolvedPath, { permanent, removeReferences });
         const method = permanent ? "permanently deleted" : "moved to trash";
-        const lines: string[] = [`Note '${resolvedPath}' ${method}.`];
+        const lines: string[] = [`Note '${displayWriteValue(resolvedPath)}' ${method}.`];
         if (removeReferences && permanent) {
           const updated = result.updatedReferrers.length;
           lines.push(


### PR DESCRIPTION
Escapes control characters in write-tool note path labels before returning create, append, prepend, frontmatter, daily-note, move, delete, and permanent-delete confirmation messages. The raw resolved paths are still used for filesystem operations and confirmation comparison.

Risk: low; display-only escaping on existing text payloads.
Score: 3 severity x 3 reach / 1 effort = 9.

Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `escapeControlChars` to all display-facing path strings in the write-tool handlers (`create_note`, `append_to_note`, `prepend_to_note`, `update_frontmatter`, `create_daily_note`, `move_note`, `delete_note`) so that control characters in vault paths cannot inject newlines or terminal-control sequences into MCP client responses. Filesystem operations and confirmation comparisons were intended to keep using the raw resolved paths.

- **Display escaping** is correctly applied to every user-visible confirmation message across all eight write operations.
- **Elicitation confirmation mismatch**: the permanent-delete elicitation prompt shows the user the escaped path, but the typed-back value is compared against the raw `resolvedPath` (line 511); for any path containing a control character the confirmation will always fail, making it impossible to permanently delete such notes through the elicitation flow.
- **CHANGELOG** lists only five of the eight covered operations; append, prepend, and frontmatter are missing from the entry.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for normal vaults, but the elicitation-based permanent-delete confirmation is broken for notes whose paths contain control characters — the exact case this PR targets.

The display-escaping changes are correct everywhere except the elicitation confirmation comparison: the user is shown the escaped path but their typed input is checked against the raw path, so permanent deletion via the interactive confirmation dialog will always be rejected for dirty paths. The fix is a one-line change, but the bug affects the destructive-action confirmation path.

src/tools/write.ts — specifically the elicitation confirmation comparison around line 511.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/write.ts | Applies escapeControlChars to display paths in all write-tool confirmation messages; the elicitation confirmation comparison on line 511 still uses the raw resolvedPath instead of the escaped display value, making permanent deletion via elicitation impossible for paths containing control characters. |
| src/__tests__/handlers/write.test.ts | Adds escape-verification tests for create, append/prepend/frontmatter, daily-note, move, and delete (trash + permanent-confirm gate); the elicitation confirmation round-trip is not covered. |
| CHANGELOG.md | New changelog entry omits append, prepend, and frontmatter from the list of affected operations; otherwise correct. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["delete_note: permanent=true, confirm=true"] --> B{client supports elicitation?}
    B -- No --> E[deleteNote filesystem op]
    B -- Yes --> C["elicitInput: show escaped path\nask user to type path to confirm"]
    C --> D{user response}
    D -- cancelled or empty --> F[return cancelled message]
    D -- typed string --> G{"confirmed.trim() !== resolvedPath\ncompares against RAW path"}
    G -- "path has control chars" --> H["FAIL: Confirmation path did not match"]
    G -- "no control chars" --> I["match succeeds"]
    I --> E
    E --> J["return success with escaped path"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape write output"](https://github.com/rps321321/obsidian-mcp-pro/commit/452534f1b94f80f4de530e9330762cb0711211ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35525464)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->