### PR TITLE
fix: escape tag output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Section tools now escape control characters in displayed note paths, headings, block ids, and invalid regex flags before returning them to MCP clients.
 - Semantic tools now escape control characters in displayed queries, provider labels, note paths, heading paths, and snippets before returning them to MCP clients.
 - Write tools now escape control characters in displayed note paths before returning create, update, move, delete, and daily-note messages to MCP clients.
+- `list_tags` and `rename_tag` now escape control characters in displayed tag labels before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/tags.test.ts
+++ b/src/__tests__/handlers/tags.test.ts
@@ -23,6 +23,28 @@ describe("tag handlers — list_tags", () => {
     expect(text).toMatch(/#nested\/archive/);
   });
 
+  it("escapes frontmatter tag labels in list output", async () => {
+    const dirtyTag = "dirty\x7ftag";
+    await env.client.callTool({
+      name: "create_note",
+      arguments: {
+        path: "dirty-tag.md",
+        content: "Body.",
+        frontmatter: JSON.stringify({ tags: [dirtyTag] }),
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "list_tags",
+      arguments: { sortBy: "name" },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain("#dirty\\x7ftag (1 note)");
+    expect(text).not.toContain(dirtyTag);
+  });
+
   it("sorts by count desc by default (review appears in 2 notes)", async () => {
     const result = await env.client.callTool({ name: "list_tags", arguments: {} });
     const text = textContent(result);

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -16,7 +16,7 @@ function errorResult(text: string) {
   return { content: [{ type: "text" as const, text }], isError: true as const };
 }
 
-function displayTagSearchValue(value: string): string {
+function displayTagValue(value: string): string {
   return escapeControlChars(value);
 }
 
@@ -87,7 +87,7 @@ export function registerTagTools(server: McpServer, vaultPath: string): void {
         lines.push("");
 
         for (const info of tagInfos) {
-          lines.push(`#${info.tag} (${info.count} ${info.count === 1 ? "note" : "notes"})`);
+          lines.push(`#${displayTagValue(info.tag)} (${info.count} ${info.count === 1 ? "note" : "notes"})`);
         }
 
         return {
@@ -164,21 +164,21 @@ export function registerTagTools(server: McpServer, vaultPath: string): void {
         if (matchingNotes.length === 0) {
           return {
             content: [
-              { type: "text" as const, text: `No notes found with tag #${displayTagSearchValue(searchTag)}` },
+              { type: "text" as const, text: `No notes found with tag #${displayTagValue(searchTag)}` },
             ],
           };
         }
 
         const lines: string[] = [];
         lines.push(
-          `Found ${matchingNotes.length} ${matchingNotes.length === 1 ? "note" : "notes"} with tag #${displayTagSearchValue(searchTag)}`,
+          `Found ${matchingNotes.length} ${matchingNotes.length === 1 ? "note" : "notes"} with tag #${displayTagValue(searchTag)}`,
         );
         lines.push("");
 
         for (const note of matchingNotes) {
-          lines.push(`- ${displayTagSearchValue(note.path)}`);
+          lines.push(`- ${displayTagValue(note.path)}`);
           if (note.preview) {
-            lines.push(`  ${displayTagSearchValue(note.preview)}`);
+            lines.push(`  ${displayTagValue(note.preview)}`);
             lines.push("");
           }
         }
@@ -308,7 +308,7 @@ export function registerTagTools(server: McpServer, vaultPath: string): void {
 
         const verb = dryRun ? "Would rewrite" : "Rewrote";
         const lines = [
-          `${verb} #${oldName} → #${newName}${hierarchical ? " (and nested sub-tags)" : ""}`,
+          `${verb} #${displayTagValue(oldName)} → #${displayTagValue(newName)}${hierarchical ? " (and nested sub-tags)" : ""}`,
           `  Files affected: ${updatedFiles}`,
           `  Inline #tag occurrences: ${totalInline}`,
           `  Frontmatter occurrences: ${totalFrontmatter}`,


### PR DESCRIPTION
Escapes control characters in tag labels returned by list_tags and rename_tag, while keeping matching and rewrite behavior on the raw tag names. search_by_tag now uses the same display helper for consistency.

Risk: low; display-only escaping on existing text payloads.
Score: 2 severity x 3 reach / 1 effort = 6.

Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the existing control-character escaping pattern to `list_tags` and `rename_tag` display output, and unifies the helper function name (`displayTagSearchValue` → `displayTagValue`) across all tag tools.

- `list_tags` now wraps each tag label with `escapeControlChars` before building the output line; `rename_tag` does the same for the old/new name in its summary line — both were previously emitting raw tag values.
- `search_by_tag` behavior is unchanged; the rename is cosmetic alignment with the new shared helper.
- A new integration test verifies that a DEL-character (`\x7f`) in a frontmatter tag label is escaped to `\\x7f` in `list_tags` output and that the raw control character is absent from the response.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Display-only escaping on text that is already owned by the vault owner; no writes, no schema changes, and the raw tag values used for matching and rewriting are untouched.

The change is narrowly scoped to output formatting: escapeControlChars is applied to the display string only after all matching and rewriting logic has already operated on the original raw value. The helper is well-tested elsewhere in the codebase, and the new integration test exercises the exact DEL-character path that motivated the fix. rename_tag inputs are additionally guarded by isValidTagName before reaching the display code, so the escaping there is purely defense-in-depth.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/tags.ts | Renames displayTagSearchValue → displayTagValue and applies escapeControlChars to list_tags tag labels and rename_tag display output; search_by_tag paths/previews unchanged in behavior. |
| src/__tests__/handlers/tags.test.ts | Adds one integration test verifying that a DEL-character (\x7f) in a frontmatter tag label is escaped in list_tags output; existing search_by_tag escaping test already covered the analogous path. |
| CHANGELOG.md | Adds a changelog entry documenting the list_tags / rename_tag control-char escaping fix under the Unreleased section. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Raw tag name from vault] --> B{Tool}
    B -->|list_tags| C[extractTags → toLowerCase → tagMap]
    B -->|search_by_tag| D[extractTags → match against searchTag]
    B -->|rename_tag| E[isValidTagName validation]
    C --> F[displayTagValue / escapeControlChars]
    D --> G[displayTagValue / escapeControlChars]
    E --> H[displayTagValue / escapeControlChars]
    F --> I[MCP response: tag label]
    G --> J[MCP response: header + note paths + previews]
    H --> K[MCP response: verb line]
    style F fill:#90EE90
    style G fill:#90EE90
    style H fill:#90EE90
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape tag output"](https://github.com/rps321321/obsidian-mcp-pro/commit/7a0d6de9a60d8da7f6d3fc9f54e4c99ffa35051d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35525998)</sub>

<!-- /greptile_comment -->