### PR TITLE
fix: escape read metadata output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Semantic tools now escape control characters in displayed queries, provider labels, note paths, heading paths, and snippets before returning them to MCP clients.
 - Write tools now escape control characters in displayed note paths before returning create, update, move, delete, and daily-note messages to MCP clients.
 - `list_tags` and `rename_tag` now escape control characters in displayed tag labels before returning them to MCP clients.
+- Read tools now escape control characters in generated frontmatter/tag headers, note-list rows, and vault-stat path labels before returning them to MCP clients.
 
 ## [2.2.0] - 2026-06-03
 

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -116,6 +116,34 @@ describe("read handlers — get_note", () => {
     expect(text).toContain("Links to");
   });
 
+  it("escapes generated frontmatter and tag labels", async () => {
+    const dirtyKey = "dirty\x7fkey";
+    const dirtyValue = "value\x7fvalue";
+    const dirtyTag = "dirty\x7ftag";
+    await env.client.callTool({
+      name: "create_note",
+      arguments: {
+        path: "dirty-metadata.md",
+        content: "Body stays raw.",
+        frontmatter: JSON.stringify({ [dirtyKey]: dirtyValue, tags: [dirtyTag] }),
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "dirty-metadata.md" },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain('dirty\\x7fkey: "value\\x7fvalue"');
+    expect(text).toContain('tags: ["dirty\\x7ftag"]');
+    expect(text).toContain("Tags: dirty\\x7ftag");
+    expect(text).not.toContain(dirtyKey);
+    expect(text).not.toContain(dirtyValue);
+    expect(text).not.toContain(dirtyTag);
+  });
+
   it("returns isError for a missing note with sanitized message", async () => {
     const result = await env.client.callTool({
       name: "get_note",
@@ -191,6 +219,27 @@ describe("read handlers — list_notes", () => {
     expect(text).toContain("Found 7 note");
     expect(text).toContain("showing first 2");
   });
+
+  it("escapes folder labels and listed note paths", async () => {
+    const dirtyFolder = "list\x7ffolder";
+    const dirtyPath = `${dirtyFolder}/note\x7fname.md`;
+    await env.client.callTool({
+      name: "create_note",
+      arguments: { path: dirtyPath, content: "Listed note." },
+    });
+
+    const result = await env.client.callTool({
+      name: "list_notes",
+      arguments: { folder: dirtyFolder },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain('Found 1 note(s) in "list\\x7ffolder"');
+    expect(text).toContain("list\\x7ffolder/note\\x7fname.md");
+    expect(text).not.toContain(dirtyFolder);
+    expect(text).not.toContain(dirtyPath);
+  });
 });
 
 describe("read handlers — get_daily_note", () => {
@@ -230,6 +279,30 @@ describe("read handlers — get_daily_note", () => {
     const text = textContent(result);
     expect(text).toContain('expected at "daily\\nnotes/1999-01-01.md"');
     expect(text).not.toContain("daily\nnotes");
+  });
+
+  it("escapes generated daily-note frontmatter labels", async () => {
+    const dirtyKey = "daily\x7fkey";
+    const dirtyValue = "daily\x7fvalue";
+    await env.client.callTool({
+      name: "create_note",
+      arguments: {
+        path: "daily/2026-05-08.md",
+        content: "Daily body.",
+        frontmatter: JSON.stringify({ [dirtyKey]: dirtyValue }),
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "get_daily_note",
+      arguments: { date: "2026-05-08" },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain('daily\\x7fkey: "daily\\x7fvalue"');
+    expect(text).not.toContain(dirtyKey);
+    expect(text).not.toContain(dirtyValue);
   });
 
   it("rejects malformed dates at the schema layer", async () => {
@@ -411,6 +484,27 @@ describe("read handlers — get_vault_stats", () => {
     expect(text).toMatch(/folder: nested/);
     // Only nested/note-d.md sits there.
     expect(text).toMatch(/Notes:\s+1/);
+  });
+
+  it("escapes folder labels and most-recent note paths", async () => {
+    const dirtyFolder = "stats\x7ffolder";
+    const dirtyPath = `${dirtyFolder}/recent\x7fnote.md`;
+    await env.client.callTool({
+      name: "create_note",
+      arguments: { path: dirtyPath, content: "Stats note." },
+    });
+
+    const result = await env.client.callTool({
+      name: "get_vault_stats",
+      arguments: { folder: dirtyFolder },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain("Vault stats (folder: stats\\x7ffolder)");
+    expect(text).toContain("Most recent:     stats\\x7ffolder/recent\\x7fnote.md");
+    expect(text).not.toContain(dirtyFolder);
+    expect(text).not.toContain(dirtyPath);
   });
 });
 

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -184,7 +184,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         if (lines) {
           const allLines = content.split("\n");
           const m = /^(\d+)(?:-(\d+))?$/.exec(lines);
-          if (!m) return errorResult(`Invalid lines format: "${lines}"`);
+          if (!m) return errorResult(`Invalid lines format: "${displayReadValue(lines)}"`);
           const a = Math.max(1, Number(m[1]));
           const b = m[2] ? Math.max(a, Number(m[2])) : a;
           if (a > allLines.length) {
@@ -202,7 +202,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         if (Object.keys(frontmatterData).length > 0) {
           header.push("--- Frontmatter ---");
           for (const [key, value] of Object.entries(frontmatterData)) {
-            header.push(`${key}: ${JSON.stringify(value)}`);
+            header.push(`${displayReadValue(key)}: ${displayReadValue(JSON.stringify(value) ?? "")}`);
           }
           header.push("--- End Frontmatter ---");
           header.push("");
@@ -210,7 +210,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
 
         const tags = extractTags(content);
         if (tags.length > 0) {
-          header.push(`Tags: ${tags.join(", ")}`);
+          header.push(`Tags: ${tags.map(displayReadValue).join(", ")}`);
           header.push("");
         }
 
@@ -265,9 +265,9 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         const totalCount = notes.length;
 
         const lines: string[] = [
-          `Found ${totalCount} note(s)${folder ? ` in "${folder}"` : ""}${totalCount > limit ? ` (showing first ${limit})` : ""}:`,
+          `Found ${totalCount} note(s)${folder ? ` in "${displayReadValue(folder)}"` : ""}${totalCount > limit ? ` (showing first ${limit})` : ""}:`,
           "",
-          ...limited,
+          ...limited.map(displayReadValue),
         ];
 
         return {
@@ -305,11 +305,11 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         const targetDate = date ?? formatLocalDateOnly();
 
         if (!/^\d{4}-\d{2}-\d{2}$/.test(targetDate)) {
-          return errorResult(`Invalid date format: "${targetDate}". Use YYYY-MM-DD.`);
+          return errorResult(`Invalid date format: "${displayReadValue(targetDate)}". Use YYYY-MM-DD.`);
         }
         const parsed = parseLocalDateOnly(targetDate);
         if (!parsed) {
-          return errorResult(`Invalid date: "${targetDate}".`);
+          return errorResult(`Invalid date: "${displayReadValue(targetDate)}".`);
         }
 
         // Build the filename using moment-style tokens (YYYY, MMM, ddd, etc).
@@ -339,7 +339,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         if (Object.keys(dailyFrontmatter).length > 0) {
           header.push("--- Frontmatter ---");
           for (const [key, value] of Object.entries(dailyFrontmatter)) {
-            header.push(`${key}: ${JSON.stringify(value)}`);
+            header.push(`${displayReadValue(key)}: ${displayReadValue(JSON.stringify(value) ?? "")}`);
           }
           header.push("--- End Frontmatter ---");
           header.push("");
@@ -638,7 +638,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         const avgWords = Math.round(totalWords / notes.length);
         const untaggedPct = ((untagged / notes.length) * 100).toFixed(1);
         const lines = [
-          `Vault stats${folder ? ` (folder: ${folder})` : ""}`,
+          `Vault stats${folder ? ` (folder: ${displayReadValue(folder)})` : ""}`,
           "",
           `  Notes:           ${notes.length}`,
           `  Total bytes:     ${totalBytes.toLocaleString()}`,
@@ -648,7 +648,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
           `  Unique tags:     ${tagSet.size}`,
           `  Untagged notes:  ${untagged} (${untaggedPct}%)`,
           mostRecent
-            ? `  Most recent:     ${mostRecent.path} (${new Date(mostRecent.mtimeMs).toISOString()})`
+            ? `  Most recent:     ${displayReadValue(mostRecent.path)} (${new Date(mostRecent.mtimeMs).toISOString()})`
             : `  Most recent:     (none)`,
         ];
         return { content: [{ type: "text" as const, text: lines.join("\n") }] };


### PR DESCRIPTION
Escapes control characters in generated read-tool labels: get_note and get_daily_note frontmatter/tag headers, list_notes folder labels and path rows, and get_vault_stats folder and most-recent path labels. Fragment reads and note bodies still return raw note text.

Risk: low; display-only escaping on generated labels and path rows.
Score: 3 severity x 3 reach / 1 effort = 9.

Tested: npm run verify.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR applies `escapeControlChars` (via a thin `displayReadValue` wrapper) to generated label strings in the read tool handlers — frontmatter keys/values, tag headers, folder labels, note-path list rows, and vault-stats lines — while intentionally leaving raw note body text unescaped.

- `get_note` and `get_daily_note`: frontmatter keys, JSON-serialised values, and the `Tags:` line are now escaped before being included in the output header.
- `list_notes`: the folder label in the "Found N note(s) in …" line and each listed path are escaped.
- `get_vault_stats`: the `folder` parameter in the stats title and `mostRecent.path` are escaped; four integration tests cover these paths using the DEL (0x7F) character.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The change is mostly correct but has one gap: the empty-folder early-return in `get_vault_stats` echoes the raw `folder` string, inconsistent with every other label-display site in the same handler.

The escaping is applied consistently across all label sites except for the `notes.length === 0` early-return in `get_vault_stats`, which still interpolates `folder` without escaping. Every other handler and every path through the non-empty branch applies `displayReadValue`. The missing call means a dirty folder name with no notes produces unescaped output, directly contradicting the goal of this PR.

src/tools/read.ts — specifically the `notes.length === 0` early-return inside `get_vault_stats`.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/tools/read.ts | Adds `displayReadValue` wrapper around `escapeControlChars` and applies it to generated labels across `get_note`, `list_notes`, `get_daily_note`, and `get_vault_stats`. One gap: the empty-folder early-return in `get_vault_stats` still echoes `folder` raw. |
| src/__tests__/handlers/read.test.ts | Adds four integration tests covering escaping of dirty frontmatter keys/values/tags, list folder labels, daily note frontmatter, and vault-stats path labels. The empty-folder path for `get_vault_stats` is not tested. |
| CHANGELOG.md | Adds a changelog entry describing the new escaping behavior for read-tool generated labels. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP Client Input] --> B{Tool Handler}
    B --> C[get_note / get_daily_note]
    B --> D[list_notes]
    B --> E[get_vault_stats]

    C --> C1[frontmatter keys → displayReadValue]
    C --> C2[frontmatter JSON values → displayReadValue]
    C --> C3[Tags line → displayReadValue per tag]
    C --> C4[body content → RAW unchanged]

    D --> D1["folder label → displayReadValue ✓"]
    D --> D2["note paths → .map(displayReadValue) ✓"]

    E --> E3{notes.length === 0?}
    E3 -- Yes --> E4["folder in error msg → RAW ⚠️ missing escape"]
    E3 -- No --> E5["folder in title → displayReadValue ✓"]
    E3 -- No --> E6["mostRecent.path → displayReadValue ✓"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/tools/read.ts`, line 586-588 ([link](https://github.com/rps321321/obsidian-mcp-pro/blob/0c13aebe9829dcdd96614ba50b1dc3a4cae1049e/src/tools/read.ts#L586-L588)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> The `folder` parameter is echoed back without escaping in the early-return path when the vault/folder is empty. Any control characters in the folder name would reach the MCP client unescaped here, while the non-empty path (line 641) correctly calls `displayReadValue(folder)`. A folder named `"stats\x7ffolder"` with no notes would return the raw DEL byte to the client.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: escape read metadata output"](https://github.com/rps321321/obsidian-mcp-pro/commit/0c13aebe9829dcdd96614ba50b1dc3a4cae1049e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35526686)</sub>

<!-- /greptile_comment -->