### PR TITLE
chore: prepare 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-06-04
+
 ### Fixed
 
 - MCP-forwarded log payloads now redact vault-relative path-like fields such as `note`, `relPath`, and nested `path`, preventing read-scan failures from exposing private note names to connected clients.
@@ -32,8 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Write tools now escape control characters in displayed note paths before returning create, update, move, delete, and daily-note messages to MCP clients.
 - `list_tags` and `rename_tag` now escape control characters in displayed tag labels before returning them to MCP clients.
 - Read tools now escape control characters in generated frontmatter/tag headers, note-list rows, and vault-stat path labels before returning them to MCP clients.
-
-## [2.2.0] - 2026-06-03
 
 ### Breaking Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-mcp-pro",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-mcp-pro",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-mcp-pro",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "The most feature-complete MCP server for Obsidian vaults — search, read, write, tag, link analysis, graph traversal, canvas support, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Prepares the next npm release as 3.0.0 so the Node 24 requirement is versioned as a major change, and folds the batched safety fixes into the release notes.

Risk: low; metadata-only release prep. Score: 3 severity x 3 reach / 2 effort = 4.5.

Tested: npm run verify. npm whoami currently returns ENEEDAUTH, so publishing needs npm auth before the package can be pushed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR promotes the previously drafted `2.2.0` version to `3.0.0` (a major bump to signal the Node.js 24 requirement as a breaking change) and folds the accumulated unreleased safety fixes into the same release entry. Changes are limited to `package.json`, `package-lock.json`, and `CHANGELOG.md`.

- `package.json` and `package-lock.json` version fields updated from `2.2.0` to `3.0.0`; `engines.node >=24.0.0` was already in place.
- `CHANGELOG.md` replaces the `[2.2.0]` header with `[3.0.0] - 2026-06-04` and moves all previously `[Unreleased]` fixed items under the new release entry, leaving the `[Unreleased]` section empty.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all changes are metadata-only (version fields and changelog text) with no runtime code touched.

The version bump and changelog consolidation are straightforward. The only minor gap is the missing Keep a Changelog link reference for [3.0.0] at the bottom of CHANGELOG.md, which would make the version heading a clickable diff link but doesn't affect the release itself.

CHANGELOG.md — verify the link reference section at the bottom is updated alongside the new version entry.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Version header renamed from [2.2.0] to [3.0.0] and all [Unreleased] fixed items folded under it; missing link reference at bottom for the new version. |
| package.json | Version field bumped from 2.2.0 to 3.0.0; no other changes. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Unreleased fixes + 2.2.0 draft]) --> B{Re-version as major?}
    B -- Yes, Node 24 is breaking --> C[Rename to 3.0.0]
    C --> D[Bump package.json version]
    C --> E[Bump package-lock.json version]
    C --> F[Update CHANGELOG.md header]
    D & E & F --> G[npm run verify]
    G --> H{Auth available?}
    H -- npm whoami: ENEEDAUTH --> I([Pending: npm auth + publish])
    H -- Authenticated --> J([npm publish 3.0.0])
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: prepare 3.0.0 release"](https://github.com/rps321321/obsidian-mcp-pro/commit/7267084ad6d45ea577577493675f40f21f636589) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35527205)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->