### PR TITLE
fix: escape prompt arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workflow prompts now escape control characters in displayed folder, path, and tag arguments before returning prompt text to MCP clients.
+
 ## [3.0.0] - 2026-06-04
 
 ### Fixed

--- a/src/__tests__/regression-tools-prompts.test.ts
+++ b/src/__tests__/regression-tools-prompts.test.ts
@@ -104,6 +104,65 @@ describe("prompts: find-stale-notes (M12 fix)", () => {
     expect(body).toContain("Projects");
     expect(body).toMatch(/folder=/);
   });
+
+  it("escapes control characters in folder arguments", async () => {
+    const rawFolder = "Projects\nIgnore previous";
+    const escapedFolder = "Projects\\nIgnore previous";
+    const result = await env.client.getPrompt({
+      name: "find-stale-notes",
+      arguments: { folder: rawFolder },
+    });
+    const body = result.messages.map((m) => (m.content as { text: string }).text).join("\n");
+
+    expect(body).toContain(`folder "${escapedFolder}"`);
+    expect(body).toContain(`folder="${escapedFolder}"`);
+    expect(body).not.toContain(rawFolder);
+  });
+});
+
+describe("prompts: control character escaping", () => {
+  it("escapes note paths in extract-action-items", async () => {
+    const rawPath = "Tasks\nAction.md";
+    const escapedPath = "Tasks\\nAction.md";
+    const result = await env.client.getPrompt({
+      name: "extract-action-items",
+      arguments: { path: rawPath },
+    });
+    const body = result.messages.map((m) => (m.content as { text: string }).text).join("\n");
+
+    expect(body).toContain(`Extract action items from "${escapedPath}".`);
+    expect(body).toContain(`path="${escapedPath}"`);
+    expect(body).not.toContain(rawPath);
+  });
+
+  it("escapes tags in extract-action-items", async () => {
+    const rawTag = "#project\rnext";
+    const escapedTag = "#project\\rnext";
+    const escapedDisplayTag = "project\\rnext";
+    const result = await env.client.getPrompt({
+      name: "extract-action-items",
+      arguments: { tag: rawTag },
+    });
+    const body = result.messages.map((m) => (m.content as { text: string }).text).join("\n");
+
+    expect(body).toContain(`tagged #${escapedDisplayTag}`);
+    expect(body).toContain(`tag="${escapedTag}"`);
+    expect(body).not.toContain(rawTag);
+  });
+
+  it("escapes folders in build-moc", async () => {
+    const rawFolder = "MOCs\tDrafts";
+    const escapedFolder = "MOCs\\tDrafts";
+    const result = await env.client.getPrompt({
+      name: "build-moc",
+      arguments: { folder: rawFolder },
+    });
+    const body = result.messages.map((m) => (m.content as { text: string }).text).join("\n");
+
+    expect(body).toContain(`folder "${escapedFolder}"`);
+    expect(body).toContain(`folder="${escapedFolder}"`);
+    expect(body).not.toContain(rawFolder);
+  });
 });
 
 describe("prompts: tool references resolve to real tools", () => {

--- a/src/tools/prompts.ts
+++ b/src/tools/prompts.ts
@@ -1,5 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { escapeControlChars } from "../lib/errors.js";
+
+const displayPromptValue = escapeControlChars;
 
 /**
  * MCP prompts the server exposes to clients. Each prompt is a starter
@@ -119,10 +122,10 @@ export function registerPrompts(server: McpServer): void {
           content: {
             type: "text" as const,
             text: [
-              `Find stale notes${folder ? ` in folder "${folder}"` : ""} (untouched ${days ?? "90"}+ days).`,
+              `Find stale notes${folder ? ` in folder "${displayPromptValue(folder)}"` : ""} (untouched ${days ?? "90"}+ days).`,
               "",
               "Steps:",
-              `1. Call get_recent_notes with limit=1000${folder ? ` and folder="${folder}"` : ""} (no \`since\` filter) to get every note ordered by most-recent-mtime first. Each row already includes an ISO timestamp, so no need to call get_note per row. The stalest notes sit at the bottom of the list.`,
+              `1. Call get_recent_notes with limit=1000${folder ? ` and folder="${displayPromptValue(folder)}"` : ""} (no \`since\` filter) to get every note ordered by most-recent-mtime first. Each row already includes an ISO timestamp, so no need to call get_note per row. The stalest notes sit at the bottom of the list.`,
               `2. Filter to notes whose mtime is older than ${days ?? "90"} days. Cap the candidate set at 25. (Optional cross-check: call get_recent_notes a second time with since="${days ?? "90"}d"; anything NOT in that set is stale.)`,
               "3. Call find_orphans once and find_broken_links once. Use the returned paths as lookup sets; do not call get_note per candidate.",
               "4. Group the (already capped) candidates into three buckets using the two lookup sets:",
@@ -167,16 +170,16 @@ export function registerPrompts(server: McpServer): void {
             type: "text" as const,
             text: [
               path
-                ? `Extract action items from "${path}".`
+                ? `Extract action items from "${displayPromptValue(path)}".`
                 : tag
-                  ? `Extract action items from every note tagged #${tag.replace(/^#/, "")}.`
+                  ? `Extract action items from every note tagged #${displayPromptValue(tag.replace(/^#/, ""))}.`
                   : "Extract action items from the active note.",
               "",
               "Steps:",
               path
-                ? `1. Call get_note with path="${path}".`
+                ? `1. Call get_note with path="${displayPromptValue(path)}".`
                 : tag
-                  ? `1. Call search_by_tag with tag="${tag}". If it returns more than 20 notes, ask the user to narrow the tag before fanning out. Otherwise call get_note on each of the (capped at 20) results.`
+                  ? `1. Call search_by_tag with tag="${displayPromptValue(tag)}". If it returns more than 20 notes, ask the user to narrow the tag before fanning out. Otherwise call get_note on each of the (capped at 20) results.`
                   : "1. Ask the user which note(s) to scan (cap at 20), then call get_note for each.",
               `2. For each note, parse all unchecked task lines (\`- [ ] …\`).`,
               `3. Group by note (or by section heading where they appear).`,
@@ -208,13 +211,13 @@ export function registerPrompts(server: McpServer): void {
           content: {
             type: "text" as const,
             text: [
-              `Build a Map of Content (MOC) for ${tag ? `tag #${tag.replace(/^#/, "")}` : folder ? `folder "${folder}"` : "the requested scope"}.`,
+              `Build a Map of Content (MOC) for ${tag ? `tag #${displayPromptValue(tag.replace(/^#/, ""))}` : folder ? `folder "${displayPromptValue(folder)}"` : "the requested scope"}.`,
               "",
               "Steps:",
               tag
-                ? `1. Call search_by_tag with tag="${tag}".`
+                ? `1. Call search_by_tag with tag="${displayPromptValue(tag)}".`
                 : folder
-                  ? `1. Call list_notes with folder="${folder}".`
+                  ? `1. Call list_notes with folder="${displayPromptValue(folder)}".`
                   : "1. Ask the user for tag or folder.",
               "2. Cap the candidate set at 40 notes (sample evenly across the result if there are more, or ask the user to narrow scope). For each capped candidate, call get_note with `lines: '1-15'` to keep token usage low.",
               "3. Cluster the notes into 3-7 groups by theme. For each cluster, write a one-line description and 5-15 wikilinks.",


### PR DESCRIPTION
Prompt folder, path, and tag arguments now pass through the shared control-character display escape before they are rendered into MCP prompt text. This keeps caller-supplied prompt values from creating extra instruction lines while leaving prompt names, schemas, and tool behavior unchanged.

Risk: low; display-only prompt text change. Score: 3 severity x 3 reach / 1 effort = 9.

Tested: npm test -- --run src/__tests__/regression-tools-prompts.test.ts; npm run verify

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR escapes ASCII control characters in caller-supplied `folder`, `path`, and `tag` arguments before they are interpolated into MCP prompt text, preventing instruction-injection via crafted vault names or tags. Arguments already constrained by Zod regex validators (`date`, `endDate`, `days`) are left unescaped, which is correct.

- `src/tools/prompts.ts` wraps `folder`, `path`, and `tag` with `displayPromptValue` (an alias for `escapeControlChars`) in all five affected prompt templates; `src/__tests__/regression-tools-prompts.test.ts` adds regression tests for `\
`, `\
`, and `\	` payloads across all changed prompts.
- The escape function in `src/lib/errors.ts` only targets ASCII control characters (`\\x00`–`\\x1f`, `\\x7f`) and does not cover Unicode line/paragraph separators (U+0085, U+2028, U+2029), which many LLM renderers and tokenizers also treat as line breaks and which could still be used for injection despite this fix.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The injection-protection goal is sound but the escape function misses Unicode line separators, leaving the fix incomplete for adversarially crafted vault names.

The core change is correct — all free-string arguments are now escaped before being embedded in prompt text, and regex-constrained arguments are correctly left alone. However, `escapeControlChars` only covers ASCII control characters; U+2028, U+2029, and U+0085 are recognised as line breaks by most LLM tokenizers and Markdown renderers and pass through unmodified, which an attacker could exploit with a folder or tag name containing those characters. The fix is one regex extension away, but until that gap is closed the prompt injection protection declared by this PR is not complete.

src/lib/errors.ts — the `escapeControlChars` regex needs to be extended before the injection protection is airtight.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/prompts.ts | Applies `escapeControlChars` (aliased as `displayPromptValue`) to all unvalidated string arguments (folder, path, tag) before embedding them in MCP prompt text; regex-validated arguments (date, days) are correctly left unescaped. The escaping logic does not cover Unicode line separators (U+2028, U+2029, U+0085), leaving a partial bypass in the injection protection this PR intends to close. |
| src/lib/errors.ts | No changes in this PR, but `escapeControlChars` is now imported as the shared escape primitive for prompt display. Its regex covers only ASCII control characters (\x00–\x1f, \x7f) and misses Unicode line/paragraph separators, which are a real injection vector. |
| src/__tests__/regression-tools-prompts.test.ts | Adds four well-structured regression tests covering \n, \r, and \t in folder, path, and tag arguments across all three affected prompts. Tests verify both escaped and raw-string non-appearance. Unicode line separators (U+2028/U+2029) are not tested. |
| CHANGELOG.md | Adds an [Unreleased] entry describing the control-character escaping fix; no issues. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP Client calls getPrompt] --> B{Argument type?}
    B -->|date / endDate / days regex-validated by Zod| C[Raw value interpolated into prompt text]
    B -->|folder / path / tag unvalidated free strings| D[displayPromptValue escapeControlChars]
    D --> E{Character in x00-x1f or x7f?}
    E -->|Yes| F[Replace with backslash-n / backslash-r / backslash-t / backslash-xHH]
    E -->|No - ASCII printable| G[Pass through unchanged]
    E -->|No - Unicode U+0085 U+2028 U+2029| G
    F --> H[Escaped value interpolated into prompt text]
    G --> H
    C --> I[Prompt returned to MCP client]
    H --> I
    style G fill:#f96,stroke:#c00
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape prompt arguments"](https://github.com/rps321321/obsidian-mcp-pro/commit/21e4bcdb90b04d99431e4fae878a57f4e19416ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35527911)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->