### PR TITLE
fix: escape resource path output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Empty `get_vault_stats` folder output and missing daily-resource errors now escape control characters in displayed configured paths.
 - Workflow prompts now escape control characters in displayed folder, path, and tag arguments before returning prompt text to MCP clients.
 
 ## [3.0.0] - 2026-06-04

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -506,6 +506,21 @@ describe("read handlers — get_vault_stats", () => {
     expect(text).not.toContain(dirtyFolder);
     expect(text).not.toContain(dirtyPath);
   });
+
+  it("escapes folder labels in empty-folder output", async () => {
+    const dirtyFolder = "empty\x7fstats";
+    await fs.mkdir(path.join(env.vaultDir, dirtyFolder), { recursive: true });
+
+    const result = await env.client.callTool({
+      name: "get_vault_stats",
+      arguments: { folder: dirtyFolder },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain('No notes in "empty\\x7fstats"');
+    expect(text).not.toContain(dirtyFolder);
+  });
 });
 
 describe("read handlers — resolve_alias", () => {

--- a/src/__tests__/handlers/resources.test.ts
+++ b/src/__tests__/handlers/resources.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
 import { createTestEnv, type TestEnv } from "./harness.js";
 
 let env: TestEnv;
@@ -61,5 +63,23 @@ describe("MCP resources", () => {
     const tags = JSON.parse(firstText(result.contents)) as Record<string, string[]>;
     expect(tags["#review"]).toEqual(expect.arrayContaining(["note-a.md", "note-b.md"]));
     expect(tags["#nested/archive"]).toEqual(["nested/note-d.md"]);
+  });
+
+  it("escapes configured daily-note paths in missing daily resource errors", async () => {
+    const dirtyFolder = "daily\nnotes";
+    await fs.writeFile(
+      path.join(env.vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: dirtyFolder, format: "YYYY-MM-DD" }),
+    );
+
+    let message = "";
+    try {
+      await env.client.readResource({ uri: "obsidian://daily" });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(message).toContain("daily\\nnotes/");
+    expect(message).not.toContain(dirtyFolder);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { describePermissions } from "./lib/permissions.js";
 import { flushAllCachesAsync, readAllCached } from "./lib/index-cache.js";
 import { extractTags } from "./lib/markdown.js";
 import { log, configureLogger } from "./lib/logger.js";
-import { sanitizeError } from "./lib/errors.js";
+import { escapeControlChars, sanitizeError } from "./lib/errors.js";
 import { formatMomentDate } from "./lib/dates.js";
 import { registerReadTools } from "./tools/read.js";
 import { registerWriteTools } from "./tools/write.js";
@@ -27,6 +27,8 @@ import { registerSemanticTools } from "./tools/semantic.js";
 import { registerPrompts } from "./tools/prompts.js";
 import { startHttpServer } from "./http-server.js";
 import { runInstall, type InstallClient } from "./install.js";
+
+const displayResourceValue = escapeControlChars;
 
 interface CliOptions {
   command: "serve" | "install" | "help" | "version";
@@ -304,7 +306,7 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
       // response with body "No daily note found..." is indistinguishable to
       // MCP clients from a real note whose first line happens to say the
       // same thing — clients need a proper error so they can branch on it.
-      throw new Error(`No daily note found for today (expected at ${notePath})`);
+      throw new Error(`No daily note found for today (expected at ${displayResourceValue(notePath)})`);
     }
   });
 

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -584,7 +584,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
       try {
         const notes = await listNotes(vaultPath, folder);
         if (notes.length === 0) {
-          return { content: [{ type: "text" as const, text: folder ? `No notes in "${folder}"` : "Vault is empty." }] };
+          return { content: [{ type: "text" as const, text: folder ? `No notes in "${displayReadValue(folder)}"` : "Vault is empty." }] };
         }
         const { contents } = await readAllCached(vaultPath, notes, (note, err) => {
           log.warn("get_vault_stats: note read failed", { note, err });


### PR DESCRIPTION
The empty get_vault_stats folder response and missing obsidian://daily resource error now use the shared control-character display escape before showing folder or configured daily-note paths. This closes two client-visible path messages that were missed by the earlier read-output pass.

Risk: low; display-only error/empty output. Score: 3 severity x 3 reach / 1 effort = 9.

Tested: npm test -- --run src/__tests__/handlers/read.test.ts src/__tests__/handlers/resources.test.ts; npm run verify

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes two display-layer gaps where user-controlled path values (the `get_vault_stats` empty-folder label and the missing-daily-note error path) were returned to MCP clients without escaping control characters, following the same `escapeControlChars` pattern already applied across all other tool-output surfaces in a previous pass.

- **`src/index.ts`**: A `displayResourceValue` alias for `escapeControlChars` is introduced and applied to `notePath` in the `obsidian://daily` missing-note error, preventing a crafted `daily-notes.json` folder name from injecting newlines or other control chars into client-visible error text.
- **`src/tools/read.ts`**: The existing `displayReadValue` helper is now applied to the `folder` argument in the early-return empty-folder message inside `get_vault_stats`.
- **Tests**: Both fixes are covered by new integration tests that write dirty vault state and assert that escaped forms appear while raw control characters do not.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Display-only fix touching two output paths; no logic, data, or auth changes.

Both changes are single-line applications of the same `escapeControlChars` helper already used throughout the codebase. The fix is narrowly scoped to the text returned in an error message and an early-return tool response. New integration tests verify the escape on both paths. No data is modified, no auth or security boundaries are touched, and the fallback behaviour (empty vault / missing daily note) is unchanged.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/index.ts | Adds `escapeControlChars` import and a `displayResourceValue` alias; applies it to `notePath` in the missing daily-note error message to prevent control-character injection. |
| src/tools/read.ts | Applies existing `displayReadValue` to the folder parameter in the `get_vault_stats` empty-folder early-return message; no other changes. |
| src/__tests__/handlers/resources.test.ts | Adds `fs` and `path` imports and a new integration test that overwrites `daily-notes.json` with a dirty folder name and asserts the escaped form appears in the thrown error message. |
| src/__tests__/handlers/read.test.ts | Adds a test verifying that a DEL-character folder label is escaped in the empty-folder output of `get_vault_stats`. |
| CHANGELOG.md | Adds an Unreleased entry documenting the two new escape-on-display fixes. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["MCP Client request"] --> B{"Route"}
    B -- "readResource obsidian://daily" --> C["getDailyNoteConfig\n(reads .obsidian/daily-notes.json)"]
    C --> D["Build notePath\n= folder + filename"]
    D --> E{"readNote succeeds?"}
    E -- "Yes" --> F["Return note content"]
    E -- "No (ENOENT)" --> G["displayResourceValue(notePath)\n= escapeControlChars(notePath)"]
    G --> H["throw Error with escaped path ✅"]

    B -- "callTool get_vault_stats" --> I["listNotes(vaultPath, folder)"]
    I --> J{"notes.length === 0?"}
    J -- "Yes" --> K["displayReadValue(folder)\n= escapeControlChars(folder)"]
    K --> L["Return 'No notes in escaped' ✅"]
    J -- "No" --> M["Build full stats response\n(all paths already escaped)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape resource path output"](https://github.com/rps321321/obsidian-mcp-pro/commit/35addb368019ae628ab8e84604bdf461585f2eb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35528706)</sub>

<!-- /greptile_comment -->