### PR TITLE
fix: escape tag resource output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `obsidian://tags` now escapes control characters in generated tag keys and note-path values before returning its JSON index.
 - Empty `get_vault_stats` folder output and missing daily-resource errors now escape control characters in displayed configured paths.
 - Workflow prompts now escape control characters in displayed folder, path, and tag arguments before returning prompt text to MCP clients.
 

--- a/src/__tests__/handlers/resources.test.ts
+++ b/src/__tests__/handlers/resources.test.ts
@@ -65,6 +65,27 @@ describe("MCP resources", () => {
     expect(tags["#nested/archive"]).toEqual(["nested/note-d.md"]);
   });
 
+  it("escapes control characters in tag resource JSON labels", async () => {
+    const dirtyTag = "resource\x7ftag";
+    const dirtyPath = "resource\x7fnote.md";
+    await env.client.callTool({
+      name: "create_note",
+      arguments: {
+        path: dirtyPath,
+        frontmatter: JSON.stringify({ tags: [dirtyTag] }),
+        content: "# Tagged resource note",
+      },
+    });
+
+    const result = await env.client.readResource({ uri: "obsidian://tags" });
+    const text = firstText(result.contents);
+    const tags = JSON.parse(text) as Record<string, string[]>;
+
+    expect(tags["#resource\\x7ftag"]).toEqual(["resource\\x7fnote.md"]);
+    expect(text).not.toContain(dirtyTag);
+    expect(text).not.toContain(dirtyPath);
+  });
+
   it("escapes configured daily-note paths in missing daily resource errors", async () => {
     const dirtyFolder = "daily\nnotes";
     await fs.writeFile(

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,8 +262,8 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
       const content = contents.get(notePath);
       if (content === undefined) continue;
       for (const tag of extractTags(content)) {
-        const normalizedTag = `#${tag}`;
-        (tagIndex[normalizedTag] ??= []).push(notePath);
+        const normalizedTag = `#${displayResourceValue(tag)}`;
+        (tagIndex[normalizedTag] ??= []).push(displayResourceValue(notePath));
       }
     }
 


### PR DESCRIPTION
The obsidian://tags JSON index now runs generated tag keys and note-path values through the shared control-character display escape. Raw note and daily resources still return note body content unchanged.

Risk: low; only control-character labels in the tag index are normalized. Score: 2 severity x 2 reach / 1 effort = 4.

Tested: npm test -- --run src/__tests__/handlers/resources.test.ts; npm run verify

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR escapes ASCII control characters (0x00–0x1F and 0x7F) in tag names and note-path values before they are written into the `obsidian://tags` JSON index, preventing raw control bytes from reaching MCP clients. The change mirrors the existing `displayResourceValue` pattern already used in error messages and prompt outputs.

- `src/index.ts`: two lines updated to call `displayResourceValue` on the tag key and note path inside the tag-index builder; clean paths are unaffected (the regex replacement is a no-op on them).
- `src/__tests__/handlers/resources.test.ts`: one new test case exercises a DEL (`\\x7f`) character in both a tag name and a file path and asserts the escaped form appears in the JSON output.
- `CHANGELOG.md`: release note added under the unreleased Fixed section.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for all real-world vaults; the only edge case is note paths or tag names that contain raw control characters, which most OS file systems and Obsidian itself effectively disallow.

The change is small and correctly escapes control bytes that could cause injection issues for MCP clients. Normal clean paths are unaffected. The one design tension — escaped paths in a machine-readable JSON index may not resolve back to actual files — is limited to pathological filenames unlikely to exist in practice.

src/index.ts — the `notePath` escaping inside the inner tag loop and the semantic tradeoff of lossy path display in a machine-readable resource are worth a second look.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/index.ts | Two-line change: tag keys and note-path values are now passed through `displayResourceValue` (alias for `escapeControlChars`) before being stored in `tagIndex`. Clean and contained. |
| src/__tests__/handlers/resources.test.ts | New test verifies that DEL (`\x7f`) in both a tag name and note path is escaped to literal `\x7f` in the JSON output and that the raw character no longer appears in the text. |
| CHANGELOG.md | Entry added under the unreleased Fixed section, accurately describing the tag resource change. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Server as MCP Server
    participant Vault as Vault (disk)

    Client->>Server: readResource("obsidian://tags")
    Server->>Vault: listNotes()
    Vault-->>Server: [notePaths...]
    Server->>Vault: readAllCached(vaultPath, notes)
    Vault-->>Server: "{contents: Map<path, markdown>}"
    loop for each notePath
        Server->>Server: "content = contents.get(notePath)"
        loop for each tag in extractTags(content)
            Server->>Server: "escapedTag = displayResourceValue(tag)"
            Server->>Server: "escapedPath = displayResourceValue(notePath)"
            Server->>Server: tagIndex[escapedTag].push(escapedPath)
        end
    end
    Server-->>Client: JSON.stringify(tagIndex)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: escape tag resource output"](https://github.com/rps321321/obsidian-mcp-pro/commit/a6a8f5520ca11087ed088b26ec8bd17e6d1e8600) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35529350)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->