### PR TITLE
perf: speed up warm link graph checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Link graph cache validation now reuses the vault root realpath across each fingerprint batch, cutting the 1,000-note warm `get_backlinks` bench below the R&D ship bar while keeping per-note symlink checks.
 - `search_notes` warm-cache scans now reuse the vault root realpath across each cached read batch and skip per-entry `lstat` calls during broad vault walks, cutting the 1,000-note warm bench below the R&D ship bar while keeping per-note symlink checks.
 
 ### Fixed

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Link Graph Warm Path](link-graph-warm-path.md) | performance / graph analysis | active | Baseline measures cold graph traversal plus warm shared-cache backlink and neighbor lookups on synthetic 100-note and 1,000-note vaults. |
+| [Link Graph Warm Path](link-graph-warm-path.md) | performance / graph analysis | shipped | Warm 1,000-note backlinks fell from 80.4ms to 42.5ms while cold graph traversal stayed under the guardrail. |
 | [Search Cache Warm Path](search-cache-warm-path.md) | performance / retrieval quality | shipped | Warm 1,000-note search fell from 91.5ms to 23.2ms while cold stayed under the guardrail. |
 
 Tracks to pull from: retrieval quality, agent workflows, Obsidian format coverage,

--- a/docs/rnd/link-graph-warm-path.md
+++ b/docs/rnd/link-graph-warm-path.md
@@ -1,7 +1,7 @@
 # Link Graph Warm Path
 
-_Status: active_
-_Started: 2026-06-04 - Decided: _
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -48,8 +48,8 @@ text for alias-resolved backlinks or graph traversal.
 
 | | before | after |
 |---|---:|---:|
-| 1,000-note warm backlinks | 80.4ms | |
-| 1,000-note cold graph guardrail | 331.3ms | |
+| 1,000-note warm backlinks | 80.4ms | 42.5ms |
+| 1,000-note cold graph guardrail | 331.3ms | 280.7ms |
 
 ## Safety review
 
@@ -75,4 +75,21 @@ implementation would weaken stale-cache detection or vault-boundary validation.
 
 ## Decision
 
-Open.
+Ship. The prototype keeps the existing graph cache, fingerprint, TTL, and result
+shape, but passes one resolved vault root through each fingerprint validation
+batch. `getNoteStats` still runs `resolveVaultPathSafe` for every note, so
+per-note symlink and vault-boundary checks stay in place while avoiding a
+repeated vault-root `realpath` syscall for each path.
+
+Measured after the prototype with:
+
+```powershell
+npm run build
+node scripts\bench-links.mjs 100,1000 --json
+node scripts\bench-links.mjs 100,1000 --json
+```
+
+The two repeated 1,000-note warm backlink runs were 42.5ms and 37.0ms, both
+below the 64ms ship bar. The slower repeated cold graph run was 283.7ms, below
+the 365ms guardrail. A regression test keeps symlink escapes rejected when
+`getNoteStats` receives a reused vault root.

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -15,6 +15,8 @@ import {
   searchNotes,
   listCanvasFiles,
   readCanvasFile,
+  getNoteStats,
+  getVaultRootRealPath,
 } from "../lib/vault.js";
 
 let vaultDir: string;
@@ -129,6 +131,26 @@ describe("listNotes", () => {
 
     const notes = await listNotes(vaultDir, "journal");
     expect(notes).toEqual(["journal/day1.md"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getNoteStats
+// ---------------------------------------------------------------------------
+describe("getNoteStats", () => {
+  it.skipIf(!SYMLINKS_SUPPORTED)("rejects symlink escapes with a reused vault root", async () => {
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-stats-outside-"));
+    try {
+      await fs.writeFile(path.join(outsideDir, "secret.md"), "outside");
+      await fs.symlink(path.join(outsideDir, "secret.md"), path.join(vaultDir, "linked.md"));
+
+      const realVaultRoot = await getVaultRootRealPath(vaultDir);
+      await expect(
+        getNoteStats(vaultDir, "linked.md", { realVaultRoot }),
+      ).rejects.toThrow("Path traversal via symlink detected");
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -900,8 +900,9 @@ export async function searchNotes(
 export async function getNoteStats(
   vaultPath: string,
   relativePath: string,
+  options?: { realVaultRoot?: string },
 ): Promise<{ size: number; created: Date | null; modified: Date | null }> {
-  const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
+  const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "read", options);
   const stats = await fs.stat(fullPath);
 
   return {

--- a/src/tools/links.ts
+++ b/src/tools/links.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { listNotes, getNoteStats } from "../lib/vault.js";
+import { listNotes, getNoteStats, getVaultRootRealPath } from "../lib/vault.js";
 import { readAllCached } from "../lib/index-cache.js";
 import { extractWikilinks, resolveWikilink, extractAliases } from "../lib/markdown.js";
 import { escapeControlChars, sanitizeError } from "../lib/errors.js";
@@ -60,10 +60,11 @@ async function fingerprintVault(
   const sorted = [...notes].sort();
   let hash = 0x811c9dc5;
   const CONCURRENCY = 16;
+  const realVaultRoot = await getVaultRootRealPath(vaultPath);
   for (let i = 0; i < sorted.length; i += CONCURRENCY) {
     const slice = sorted.slice(i, i + CONCURRENCY);
     const stats = await Promise.all(
-      slice.map((n) => getNoteStats(vaultPath, n).catch(() => null)),
+      slice.map((n) => getNoteStats(vaultPath, n, { realVaultRoot }).catch(() => null)),
     );
     for (let j = 0; j < slice.length; j++) {
       const mtime = stats[j]?.modified?.getTime() ?? 0;


### PR DESCRIPTION
Reuse a single resolved vault root while fingerprinting the link graph cache, so warm graph-backed tools keep per-note boundary checks without repeating vault-root realpath for every note. This ships the Link Graph Warm Path R&D slice: 1,000-note warm backlinks fell from 80.4ms to 42.5ms and 37.0ms on repeated runs, below the 64ms bar.

Tested: npx vitest run src\\__tests__\\vault.test.ts; npm run build; node scripts\\bench-links.mjs 100,1000 --json twice; npm run verify.
Risk: low; internal helper option and cache validation only, no public API change.
Score: 2 severity x 3 reach / 1 effort = 6.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR ships the Link Graph Warm Path R&D experiment by resolving the vault root path once per `fingerprintVault` call and threading it through all per-note `getNoteStats` invocations, removing the N+1 `realpath` pattern on warm graph-backed tool calls.

- `getNoteStats` gains an optional `{ realVaultRoot }` option that is forwarded to `resolveVaultPathSafe` → `assertRealPathWithinVault`, preserving per-note symlink boundary checks while skipping repeated vault-root resolution.
- `fingerprintVault` calls `getVaultRootRealPath` once before entering its concurrency loop, reducing vault-root syscalls from one-per-note to one-per-batch; a regression test confirms symlink escapes are still rejected with a reused root.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is narrowly scoped to fingerprint cache validation and does not touch any public API, data-access path, or auth boundary.

The optimisation is correct and the security invariant (per-note fs.realpath still computed fresh in assertRealPathWithinVault) is preserved and covered by a new regression test. The two non-blocking observations — the cold-miss path still triggers two independent fingerprintVault calls with separate vault-root resolutions, and the existing getRealVaultRoot comment warning against caching is not updated to explain why batch-scope reuse is different — are documentation and efficiency gaps rather than functional defects.

The interaction between the two fingerprintVault calls inside buildLinkGraph (src/tools/links.ts lines 90 and 181) is worth a second look if further cold-path optimisation is planned.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/tools/links.ts | Calls getVaultRootRealPath once per fingerprintVault invocation and passes the result to every getNoteStats call in that batch, eliminating N+1 realpath syscalls on the warm path. Cold-miss path still triggers two independent fingerprintVault calls (for cache-check + post-build storage), so realVaultRoot is computed twice there. |
| src/lib/vault.ts | Adds optional options.realVaultRoot parameter to getNoteStats, threading it to resolveVaultPathSafe → assertRealPathWithinVault. Per-note realpath checks remain intact; only vault-root resolution is reused. Comment at getRealVaultRoot warning against caching is not updated to explain why batch-scope reuse differs from process-lifetime caching. |
| src/__tests__/vault.test.ts | Adds a getNoteStats test that creates an out-of-vault symlink and verifies it is rejected even when a pre-resolved realVaultRoot is reused, directly covering the security invariant this PR relies on. |
| docs/rnd/link-graph-warm-path.md | R&D document updated to shipped status with measured before/after numbers (80.4 ms → 42.5 ms warm backlinks) and a clear decision rationale. |
| CHANGELOG.md | Changelog entry added under unreleased section describing the link-graph fingerprint optimisation. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Caller (get_backlinks)
    participant BLG as buildLinkGraph
    participant FP as fingerprintVault
    participant GVRP as getVaultRootRealPath
    participant GNS as getNoteStats (x N)
    participant ARPWV as assertRealPathWithinVault (x N)

    C->>BLG: buildLinkGraph(vaultPath)
    BLG->>FP: fingerprintVault(vaultPath, allNotes) [warm-path check]

    note over FP,GVRP: PR: resolve vault root ONCE per batch
    FP->>GVRP: getVaultRootRealPath(vaultPath)
    GVRP-->>FP: realVaultRoot

    loop batches of 16 notes
        FP->>GNS: "getNoteStats(vaultPath, note, {realVaultRoot})"
        GNS->>ARPWV: assertRealPathWithinVault(resolved, vaultPath, realVaultRoot)
        note over ARPWV: fs.realpath(note) still computed fresh per note
        ARPWV-->>GNS: ok / throws
        GNS-->>FP: "{size, modified}"
    end

    FP-->>BLG: fingerprint string
    BLG-->>C: cached LinkGraphData (warm hit)
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/vault.ts`, line 271-274 ([link](https://github.com/rps321321/obsidian-mcp-pro/blob/ff97c10fdefbe2bdcb33ea31ba57fad74d52461b/src/lib/vault.ts#L271-L274)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Comment warns against vault-root caching but doesn't explain why batch-scope reuse is safe**

   The existing comment on `getRealVaultRoot` says "No cache: a single realpath syscall per call is cheap, and caching across the process lifetime is unsafe … Stale entries would compare against the wrong real root and let symlink escapes through." The PR now reuses `realVaultRoot` across an entire `fingerprintVault` batch (up to 1 000 notes / 16 concurrent stat calls), which is safe because the per-note `fs.realpath` in `assertRealPathWithinVault` is still computed fresh for each note and the only risk is a false rejection (not a false acceptance) if the vault root symlink is retargeted mid-batch. Without a clarifying comment, a future maintainer may read the existing warning and remove the optimisation assuming it violates the documented principle.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["perf: speed up warm link graph checks"](https://github.com/rps321321/obsidian-mcp-pro/commit/ff97c10fdefbe2bdcb33ea31ba57fad74d52461b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35534581)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->