### PR TITLE
perf: reuse graph data for broken links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `find_broken_links` now reuses link graph data for unresolved-link reporting and skips a duplicate cold fingerprint stat pass, cutting the 1,000-note warm broken-link bench below the R&D ship bar.
 - Link graph cache validation now reuses the vault root realpath across each fingerprint batch, cutting the 1,000-note warm `get_backlinks` bench below the R&D ship bar while keeping per-note symlink checks.
 - `search_notes` warm-cache scans now reuse the vault root realpath across each cached read batch and skip per-entry `lstat` calls during broad vault walks, cutting the 1,000-note warm bench below the R&D ship bar while keeping per-note symlink checks.
 

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Broken Link Warm Path](broken-link-warm-path.md) | performance / graph analysis | active | Baseline measures cold and warm `find_broken_links` scans on synthetic 100-note and 1,000-note vaults. |
+| [Broken Link Warm Path](broken-link-warm-path.md) | performance / graph analysis | shipped | Warm 1,000-note broken-link scans fell from 222.7ms to 29.1ms while cold stayed under the guardrail. |
 | [Link Graph Warm Path](link-graph-warm-path.md) | performance / graph analysis | shipped | Warm 1,000-note backlinks fell from 80.4ms to 42.5ms while cold graph traversal stayed under the guardrail. |
 | [Search Cache Warm Path](search-cache-warm-path.md) | performance / retrieval quality | shipped | Warm 1,000-note search fell from 91.5ms to 23.2ms while cold stayed under the guardrail. |
 

--- a/docs/rnd/broken-link-warm-path.md
+++ b/docs/rnd/broken-link-warm-path.md
@@ -1,7 +1,7 @@
 # Broken Link Warm Path
 
-_Status: active_
-_Started: 2026-06-04 - Decided: _
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -43,8 +43,8 @@ for aliases, line numbers, folder-scoped clean reports, or max-result summaries.
 
 | | before | after |
 |---|---:|---:|
-| 1,000-note warm broken-link scan | 222.7ms | |
-| 1,000-note cold broken-link guardrail | 264.3ms | |
+| 1,000-note warm broken-link scan | 222.7ms | 29.1ms |
+| 1,000-note cold broken-link guardrail | 264.3ms | 231.2ms |
 
 ## Safety review
 
@@ -70,4 +70,25 @@ implementation changes alias-resolved broken-link output.
 
 ## Decision
 
-Open.
+Ship. `find_broken_links` now uses the same link graph data path as the other
+graph-backed link tools. The graph builder already resolves every raw wikilink,
+so it now records unresolved links and their line numbers while building the
+graph. `find_broken_links` renders that preclassified list, preserving grouped
+output, folder scoping, alias resolution, max-result truncation, and displayed
+line numbers.
+
+The prototype also reuses the mtimes already gathered by `readAllCached` for the
+cold graph fingerprint, avoiding a second stat pass after the graph has just read
+the vault.
+
+Measured after the prototype with:
+
+```powershell
+npm run build
+node scripts\bench-broken-links.mjs 100,1000 --json
+node scripts\bench-broken-links.mjs 100,1000 --json
+```
+
+The two repeated 1,000-note warm runs were 29.1ms and 39.2ms, both below the
+178ms ship bar. The repeated cold runs were 231.2ms and 238.2ms, both below the
+291ms guardrail.

--- a/src/__tests__/index-cache.test.ts
+++ b/src/__tests__/index-cache.test.ts
@@ -44,6 +44,8 @@ describe("readAllCached", () => {
     const result = await readAllCached(vaultDir, ["a.md", "b.md"]);
     expect(result.contents.get("a.md")).toBe("alpha");
     expect(result.contents.get("b.md")).toBe("beta");
+    expect(result.mtimes.get("a.md")).toEqual(expect.any(Number));
+    expect(result.mtimes.get("b.md")).toEqual(expect.any(Number));
     expect(result.cacheMisses).toBe(2);
     expect(result.cacheHits).toBe(0);
   });

--- a/src/lib/index-cache.ts
+++ b/src/lib/index-cache.ts
@@ -279,6 +279,8 @@ export interface ReadAllResult {
    *  omitted; callers that need to know about failures should pass an
    *  `onError` callback. */
   contents: Map<string, string>;
+  /** vault-relative path -> stat mtime in whole milliseconds. */
+  mtimes: Map<string, number>;
   /** Number of files whose content was reused from cache. */
   cacheHits: number;
   /** Number of files newly read (or re-read after mtime change). */
@@ -300,6 +302,7 @@ export async function readAllCached(
   const cache = state.entries;
   const seen = new Set<string>();
   const contents = new Map<string, string>();
+  const mtimes = new Map<string, number>();
   let cacheHits = 0;
   let cacheMisses = 0;
   const realVaultRoot = await getVaultRootRealPath(vaultPath);
@@ -317,6 +320,7 @@ export async function readAllCached(
     try {
       const stat = await fs.stat(fullPath);
       mtimeMs = stat.mtimeMs;
+      mtimes.set(relPath, stat.mtime.getTime());
     } catch (err) {
       // ENOENT during stat means the file disappeared between listing and
       // reading — drop the cache entry and skip.
@@ -365,7 +369,7 @@ export async function readAllCached(
 
   if (state.dirty) scheduleFlush(vaultPath, state);
 
-  return { contents, cacheHits, cacheMisses };
+  return { contents, mtimes, cacheHits, cacheMisses };
 }
 
 /** Synchronously flush all known caches to disk. Wired into the process

--- a/src/tools/links.ts
+++ b/src/tools/links.ts
@@ -19,6 +19,8 @@ interface LinkGraphData {
    *  (get_backlinks, get_outlinks) so resolveWikilink can find alias-only
    *  targets the build pass already indexed. */
   aliasMap: Map<string, string>;
+  /** Unresolved wikilinks per note, keyed by source path. */
+  brokenLinks: Map<string, BrokenLink[]>;
 }
 
 // Per-vault+folder cache. Invalidated when any note's mtime changes,
@@ -50,15 +52,32 @@ function setGraphCache(key: string, entry: CachedGraph): void {
   }
 }
 
-async function fingerprintVault(
-  vaultPath: string,
+function fingerprintFromMtimes(
   notes: string[],
-): Promise<string> {
+  mtimes: ReadonlyMap<string, number>,
+): string {
   // Accumulate a 32-bit FNV-1a hash over "<sortedPath>|<mtimeMs>;" per note.
   // Catches add+delete churn and mtime-restoring edits that count+max-mtime
   // alone would miss.
   const sorted = [...notes].sort();
   let hash = 0x811c9dc5;
+  for (const note of sorted) {
+    const mtime = mtimes.get(note) ?? 0;
+    const entry = `${note}|${mtime};`;
+    for (let k = 0; k < entry.length; k++) {
+      hash ^= entry.charCodeAt(k);
+      hash = Math.imul(hash, 0x01000193);
+    }
+  }
+  return `${sorted.length}:${(hash >>> 0).toString(16)}`;
+}
+
+async function fingerprintVault(
+  vaultPath: string,
+  notes: string[],
+): Promise<string> {
+  const mtimes = new Map<string, number>();
+  const sorted = [...notes].sort();
   const CONCURRENCY = 16;
   const realVaultRoot = await getVaultRootRealPath(vaultPath);
   for (let i = 0; i < sorted.length; i += CONCURRENCY) {
@@ -68,14 +87,10 @@ async function fingerprintVault(
     );
     for (let j = 0; j < slice.length; j++) {
       const mtime = stats[j]?.modified?.getTime() ?? 0;
-      const entry = `${slice[j]}|${mtime};`;
-      for (let k = 0; k < entry.length; k++) {
-        hash ^= entry.charCodeAt(k);
-        hash = Math.imul(hash, 0x01000193);
-      }
+      mtimes.set(slice[j]!, mtime);
     }
   }
-  return `${sorted.length}:${(hash >>> 0).toString(16)}`;
+  return fingerprintFromMtimes(sorted, mtimes);
 }
 
 async function buildLinkGraph(
@@ -99,6 +114,7 @@ async function buildLinkGraph(
   const backlinks = new Map<string, Set<string>>();
   const rawLinks = new Map<string, LinkInfo[]>();
   const noteLines = new Map<string, string[]>();
+  const brokenLinks = new Map<string, BrokenLink[]>();
 
   // Initialize sets for all notes
   for (const notePath of allNotes) {
@@ -108,7 +124,7 @@ async function buildLinkGraph(
 
   // Read notes via the shared mtime cache so repeated graph builds (and
   // overlapping search_notes / get_tags scans) skip re-reads.
-  const { contents: noteContents } = await readAllCached(
+  const { contents: noteContents, mtimes } = await readAllCached(
     vaultPath,
     allNotes,
     (note, err) => {
@@ -139,7 +155,8 @@ async function buildLinkGraph(
     const content = noteContents.get(notePath);
     if (content === undefined) continue;
 
-    noteLines.set(notePath, content.split("\n"));
+    const lines = content.split("\n");
+    noteLines.set(notePath, lines);
     const links = extractWikilinks(content);
 
     // Fill in source for each link
@@ -164,6 +181,17 @@ async function buildLinkGraph(
           backlinks.set(resolved, new Set());
         }
         backlinks.get(resolved)!.add(notePath);
+      } else {
+        const lineInfo = findLineWithLink(lines, link.target);
+        const broken: BrokenLink = {
+          sourcePath: notePath,
+          targetLink: link.target,
+          line: lineInfo.line,
+        };
+        if (!brokenLinks.has(notePath)) {
+          brokenLinks.set(notePath, []);
+        }
+        brokenLinks.get(notePath)!.push(broken);
       }
     }
 
@@ -177,8 +205,9 @@ async function buildLinkGraph(
     rawLinks,
     noteLines,
     aliasMap,
+    brokenLinks,
   };
-  const fingerprint = await fingerprintVault(vaultPath, allNotes);
+  const fingerprint = fingerprintFromMtimes(allNotes, mtimes);
   setGraphCache(cacheKey, { data, fingerprint, cachedAt: Date.now() });
   return data;
 }
@@ -597,64 +626,18 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
     },
     async ({ folder, maxResults }) => {
       try {
-        // Get all notes in vault for resolution, but only scan the folder.
-        // Reads go through the shared mtime cache (`readAllCached`) so the
-        // scan parallelizes within the cache's concurrency cap and re-runs
-        // hit the cache instead of stat+read every file again - matching
-        // the pattern search_notes uses for similar full-vault sweeps.
-        const allNotes = await listNotes(vaultPath);
-        const scanNotes = folder ? await listNotes(vaultPath, folder) : allNotes;
-
-        // Build the alias map from the full vault so cross-folder alias
-        // resolution still works when scoping to a single folder.
-        const { contents: allContents } = await readAllCached(
-          vaultPath,
-          allNotes,
-          (note, err) => {
-            log.warn("find_broken_links: note read failed", { note, err });
-          },
-        );
-        const aliasMap = new Map<string, string>();
-        for (const notePath of allNotes) {
-          const content = allContents.get(notePath);
-          if (content === undefined) continue;
-          for (const alias of extractAliases(content)) {
-            const key = alias.toLowerCase();
-            if (!key) continue;
-            aliasMap.set(key, notePath);
-          }
-        }
+        // Validate and capture folder scope before the whole-vault graph work
+        // so a missing folder fails fast. Resolution still uses the full graph.
+        const scanNotes = folder ? await listNotes(vaultPath, folder) : null;
+        const graph = await buildLinkGraph(vaultPath);
+        const notesToScan = scanNotes ?? graph.allNotes;
 
         const brokenBySource = new Map<string, BrokenLink[]>();
 
-        for (const notePath of scanNotes) {
-          const content = allContents.get(notePath);
-          if (content === undefined) continue;
-
-          const lines = content.split("\n");
-          const links = extractWikilinks(content);
-
-          for (const link of links) {
-            const targetBase = link.target.split("#")[0]!.trim();
-            if (!targetBase) continue;
-
-            const resolved = resolveWikilink(targetBase, notePath, allNotes, {
-              aliasMap,
-            });
-            if (!resolved) {
-              const lineInfo = findLineWithLink(lines, link.target);
-              const broken: BrokenLink = {
-                sourcePath: notePath,
-                targetLink: link.target,
-                line: lineInfo.line,
-              };
-
-              if (!brokenBySource.has(notePath)) {
-                brokenBySource.set(notePath, []);
-              }
-              brokenBySource.get(notePath)!.push(broken);
-            }
-          }
+        for (const notePath of notesToScan) {
+          const brokenLinks = graph.brokenLinks.get(notePath);
+          if (!brokenLinks || brokenLinks.length === 0) continue;
+          brokenBySource.set(notePath, brokenLinks);
         }
 
         if (brokenBySource.size === 0) {


### PR DESCRIPTION
Reuse the link graph's pre-resolved raw link data for find_broken_links, and fingerprint cold graph builds from mtimes already gathered by readAllCached. This ships the Broken Link Warm Path R&D slice: 1,000-note warm scans fell from 222.7ms to 29.1ms and 39.2ms on repeated runs, while cold stayed under the 291ms guardrail.

Tested: npx vitest run src\\__tests__\\index-cache.test.ts src\\__tests__\\handlers\\links.test.ts src\\__tests__\\regression-tools-links.test.ts; npm run build; node scripts\\bench-broken-links.mjs 100,1000 --json twice; node scripts\\bench-links.mjs 100,1000 --json; npm run verify.
Risk: internal cache/report path only; no public API change.
Score: 2 severity x 3 reach / 1 effort = 6.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR ships the "Broken Link Warm Path" optimization: `find_broken_links` now reads precomputed broken-link data from the shared link graph instead of re-reading and re-parsing every note independently, and cold graph builds reuse the `mtime` values already gathered by `readAllCached` rather than doing a second stat pass.

- `readAllCached` now returns a `mtimes: Map<string, number>` alongside `contents`, and `buildLinkGraph` passes those values to the new `fingerprintFromMtimes` helper, eliminating the duplicate O(n) stat sweep on cold builds.
- `brokenLinks: Map<string, BrokenLink[]>` is populated inside the existing graph-build loop and stored in `LinkGraphData`; `find_broken_links` reads from this map, reducing the 1,000-note warm scan from ~222 ms to ~30–39 ms.
- Folder scoping is preserved: the handler still accepts a `folder` parameter, calls `listNotes(vaultPath, folder)` for fail-fast validation, and then filters the precomputed broken-link map to that subset.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is entirely internal to the cache and graph layer with no public API surface exposed.

The core logic is correct and the benchmarked results are compelling. The main concern is a precision mismatch: `mtimes` stores `stat.mtime.getTime()` (whole milliseconds) while the content cache invalidates on `stat.mtimeMs` (sub-ms float). A file modified twice within one millisecond would correctly evict the content cache both times but produce an identical graph fingerprint, letting the warm path serve a stale graph. This was present in the old `fingerprintVault` path too, but the new code ties graph freshness more directly to these truncated values. A test gap for `mtimes` on cache hits also exists, though the code path itself is correct.

`src/lib/index-cache.ts` for the precision mismatch between `stat.mtimeMs` and `stat.mtime.getTime()`, and `src/__tests__/index-cache.test.ts` for the missing assertion on cache-hit calls.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/index-cache.ts | Adds `mtimes: Map<string, number>` to `ReadAllResult`; `stat.mtime.getTime()` is stored (whole ms) while cache invalidation uses `stat.mtimeMs` (sub-ms float) — a minor precision mismatch. |
| src/tools/links.ts | Extracts `fingerprintFromMtimes` from `fingerprintVault` so the cold graph build avoids a second stat pass; adds `brokenLinks` to `LinkGraphData` and rewrites `find_broken_links` to read from the precomputed map. Logic is correct; `fingerprintVault` now double-sorts its notes array. |
| src/__tests__/index-cache.test.ts | Adds two assertions that `mtimes` is populated on the first (all-miss) call; missing coverage for the cache-hit path. |
| CHANGELOG.md | Adds a changelog entry for the broken-link warm-path optimization; no code issues. |
| docs/rnd/broken-link-warm-path.md | Updates the R&D doc from 'active' to 'shipped' with measured before/after numbers; no code issues. |
| docs/rnd/README.md | Updates the experiment table row for broken-link warm path to 'shipped'; no issues. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant FBL as find_broken_links handler
    participant BLG as buildLinkGraph
    participant GC as graphCache LRU
    participant RAC as readAllCached
    participant FS as File System

    FBL->>BLG: buildLinkGraph(vaultPath)
    BLG->>GC: get(cacheKey)
    alt Graph cached and within TTL
        BLG->>FS: fingerprintVault stat all notes
        alt Fingerprint unchanged
            GC-->>FBL: cached LinkGraphData with brokenLinks
        else Fingerprint changed
            BLG->>RAC: readAllCached(vaultPath, allNotes)
            RAC->>FS: stat and read concurrent
            RAC-->>BLG: contents and mtimes
            Note over BLG: classify links into brokenLinks map
            BLG->>BLG: fingerprintFromMtimes(allNotes, mtimes)
            BLG->>GC: set(cacheKey, new graph)
            BLG-->>FBL: fresh LinkGraphData
        end
    else No cache entry
        BLG->>RAC: readAllCached(vaultPath, allNotes)
        RAC->>FS: stat and read concurrent
        RAC-->>BLG: contents and mtimes
        Note over BLG: classify links into brokenLinks map
        BLG->>BLG: fingerprintFromMtimes(allNotes, mtimes)
        BLG->>GC: set(cacheKey, new graph)
        BLG-->>FBL: fresh LinkGraphData
    end
    FBL->>FBL: filter graph.brokenLinks by scanNotes
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/__tests__/index-cache.test.ts`, line 53-59 ([link](https://github.com/rps321321/obsidian-mcp-pro/blob/f3f0d717122338bbff8f8d0d64632e1e1f1cc2a3/src/__tests__/index-cache.test.ts#L53-L59)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`mtimes` not verified in cache-hit path**

   The new `mtimes` field on `ReadAllResult` is only asserted in the "all misses" case. The "cache hit" test calls `readAllCached` a second time but never checks that `result.mtimes` is still populated. The implementation is correct (`mtimes.set` fires before the early-return), but there is no regression guard for a future refactor that moves the set call past the cache-hit check, which would leave callers with a partial `mtimes` map on warm reads.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["perf: reuse graph data for broken links"](https://github.com/rps321321/obsidian-mcp-pro/commit/f3f0d717122338bbff8f8d0d64632e1e1f1cc2a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35536064)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->