### PR TITLE
perf: reuse cached stats for base queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Active R&D experiment for `query_base` warm-query performance, with a synthetic benchmark harness in `scripts/bench-bases.mjs` and ship/kill metric in `docs/rnd/bases-query-warm-path.md`.
+- R&D experiment for `query_base` warm-query performance, with a synthetic benchmark harness in `scripts/bench-bases.mjs` and ship/kill metric in `docs/rnd/bases-query-warm-path.md`.
 - Active R&D experiment for `find_broken_links` warm-scan performance, with a synthetic benchmark harness in `scripts/bench-broken-links.mjs` and ship/kill metric in `docs/rnd/broken-link-warm-path.md`.
 - Active R&D experiment for link graph warm-cache performance, with a synthetic benchmark harness in `scripts/bench-links.mjs` and ship/kill metric in `docs/rnd/link-graph-warm-path.md`.
 - Active R&D experiment for `search_notes` warm-cache performance, with a baseline fixture and ship/kill metric in `docs/rnd/search-cache-warm-path.md`.
 
 ### Changed
 
+- `query_base` now reuses stat metadata gathered by the content cache, cutting the 1,000-note warm Base query bench below the R&D ship bar while preserving stat-backed file filters.
 - `find_broken_links` now reuses link graph data for unresolved-link reporting and skips a duplicate cold fingerprint stat pass, cutting the 1,000-note warm broken-link bench below the R&D ship bar.
 - Link graph cache validation now reuses the vault root realpath across each fingerprint batch, cutting the 1,000-note warm `get_backlinks` bench below the R&D ship bar while keeping per-note symlink checks.
 - `search_notes` warm-cache scans now reuse the vault root realpath across each cached read batch and skip per-entry `lstat` calls during broad vault walks, cutting the 1,000-note warm bench below the R&D ship bar while keeping per-note symlink checks.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Bases Query Warm Path](bases-query-warm-path.md) | performance / Obsidian format coverage | active | Baseline measures cold and warm `query_base` scans on synthetic 100-note and 1,000-note vaults. |
+| [Bases Query Warm Path](bases-query-warm-path.md) | performance / Obsidian format coverage | shipped | Warm 1,000-note Base queries fell from 99.7ms to 54.1ms while cold stayed under the guardrail. |
 | [Broken Link Warm Path](broken-link-warm-path.md) | performance / graph analysis | shipped | Warm 1,000-note broken-link scans fell from 222.7ms to 29.1ms while cold stayed under the guardrail. |
 | [Link Graph Warm Path](link-graph-warm-path.md) | performance / graph analysis | shipped | Warm 1,000-note backlinks fell from 80.4ms to 42.5ms while cold graph traversal stayed under the guardrail. |
 | [Search Cache Warm Path](search-cache-warm-path.md) | performance / retrieval quality | shipped | Warm 1,000-note search fell from 91.5ms to 23.2ms while cold stayed under the guardrail. |

--- a/docs/rnd/bases-query-warm-path.md
+++ b/docs/rnd/bases-query-warm-path.md
@@ -1,7 +1,7 @@
 # Bases Query Warm Path
 
-_Status: active_
-_Started: 2026-06-04 - Decided: _
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -44,8 +44,8 @@ matching rows, warnings, or included frontmatter.
 
 | | before | after |
 |---|---:|---:|
-| 1,000-note warm Base query | 99.7ms | |
-| 1,000-note cold Base query guardrail | 149.0ms | |
+| 1,000-note warm Base query | 99.7ms | 54.1ms / 57.0ms |
+| 1,000-note cold Base query guardrail | 149.0ms | 84.8ms / 92.8ms |
 
 ## Safety review
 
@@ -71,4 +71,9 @@ properties become stale.
 
 ## Decision
 
-Open.
+Ship. `readAllCached` now returns the stat fields it already gathers for each
+safe, vault-boundary-checked markdown path, and `query_base` passes those fields
+into `buildRow` instead of running a second stat pass. Repeated 1,000-note warm
+queries landed at 54.1ms and 57.0ms against the 80ms ship bar, while cold runs
+stayed at 84.8ms and 92.8ms against the 164ms guardrail. Result shape, filters,
+warnings, link extraction, and stat-backed file properties remain unchanged.

--- a/src/__tests__/index-cache.test.ts
+++ b/src/__tests__/index-cache.test.ts
@@ -46,6 +46,11 @@ describe("readAllCached", () => {
     expect(result.contents.get("b.md")).toBe("beta");
     expect(result.mtimes.get("a.md")).toEqual(expect.any(Number));
     expect(result.mtimes.get("b.md")).toEqual(expect.any(Number));
+    expect(result.stats.get("a.md")).toEqual({
+      size: 5,
+      ctime: expect.any(Number),
+      mtime: expect.any(Number),
+    });
     expect(result.cacheMisses).toBe(2);
     expect(result.cacheHits).toBe(0);
   });

--- a/src/lib/index-cache.ts
+++ b/src/lib/index-cache.ts
@@ -50,6 +50,12 @@ interface CacheEntry {
   mtimeMs: number;
 }
 
+export interface CachedFileStats {
+  size: number;
+  ctime: number;
+  mtime: number;
+}
+
 interface VaultCacheState {
   entries: Map<string, CacheEntry>;
   /** True once we've attempted to load the on-disk snapshot for this vault. */
@@ -281,6 +287,8 @@ export interface ReadAllResult {
   contents: Map<string, string>;
   /** vault-relative path -> stat mtime in whole milliseconds. */
   mtimes: Map<string, number>;
+  /** vault-relative path -> stat fields collected before each read/cache hit. */
+  stats: Map<string, CachedFileStats>;
   /** Number of files whose content was reused from cache. */
   cacheHits: number;
   /** Number of files newly read (or re-read after mtime change). */
@@ -303,6 +311,7 @@ export async function readAllCached(
   const seen = new Set<string>();
   const contents = new Map<string, string>();
   const mtimes = new Map<string, number>();
+  const statsByPath = new Map<string, CachedFileStats>();
   let cacheHits = 0;
   let cacheMisses = 0;
   const realVaultRoot = await getVaultRootRealPath(vaultPath);
@@ -321,6 +330,11 @@ export async function readAllCached(
       const stat = await fs.stat(fullPath);
       mtimeMs = stat.mtimeMs;
       mtimes.set(relPath, stat.mtime.getTime());
+      statsByPath.set(relPath, {
+        size: stat.size,
+        ctime: stat.ctimeMs,
+        mtime: stat.mtimeMs,
+      });
     } catch (err) {
       // ENOENT during stat means the file disappeared between listing and
       // reading — drop the cache entry and skip.
@@ -369,7 +383,7 @@ export async function readAllCached(
 
   if (state.dirty) scheduleFlush(vaultPath, state);
 
-  return { contents, mtimes, cacheHits, cacheMisses };
+  return { contents, mtimes, stats: statsByPath, cacheHits, cacheMisses };
 }
 
 /** Synchronously flush all known caches to disk. Wired into the process

--- a/src/tools/bases.ts
+++ b/src/tools/bases.ts
@@ -1,15 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import fs from "fs/promises";
-import { listBaseFiles, readBaseFile, listNotes, resolveVaultPathSafe } from "../lib/vault.js";
+import { listBaseFiles, readBaseFile, listNotes } from "../lib/vault.js";
 import { parseBaseFile, queryBase, buildRow } from "../lib/bases.js";
 import { readAllCached } from "../lib/index-cache.js";
 import { extractWikilinks } from "../lib/markdown.js";
-import { mapConcurrent } from "../lib/concurrency.js";
 import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { log } from "../lib/logger.js";
-
-const MAX_CONCURRENT_STATS = 16;
 
 function textResult(text: string) {
   return { content: [{ type: "text" as const, text }] };
@@ -151,52 +147,18 @@ export function registerBaseTools(server: McpServer, vaultPath: string): void {
         // note individually. readAllCached stat()'s each path and only re-reads
         // files whose mtime has moved, which makes repeat queries near-instant.
         const readFailures: string[] = [];
-        const { contents } = await readAllCached(vaultPath, notes, (relPath, err) => {
+        const { contents, stats } = await readAllCached(vaultPath, notes, (relPath, err) => {
           readFailures.push(relPath);
           log.warn("query_base: note read failed", {
             note: relPath,
             err,
           });
         });
-        type QueryBaseStats = {
-          path: string;
-          stats: { size: number; ctime: number; mtime: number };
-        };
-        const statFailures: string[] = [];
-        const statRows = await mapConcurrent<string, QueryBaseStats | undefined>(
-          notes.filter((notePath) => contents.has(notePath)),
-          MAX_CONCURRENT_STATS,
-          async (notePath) => {
-            try {
-              const fullPath = await resolveVaultPathSafe(vaultPath, notePath);
-              const st = await fs.stat(fullPath);
-              return {
-                path: notePath,
-                stats: {
-                  size: st.size,
-                  ctime: st.ctimeMs,
-                  mtime: st.mtimeMs,
-                },
-              };
-            } catch (err) {
-              statFailures.push(notePath);
-              log.warn("query_base: note stat failed", {
-                note: notePath,
-                err: err as Error,
-              });
-              return undefined;
-            }
-          },
-        );
-        const statsByPath = new Map<string, QueryBaseStats["stats"]>();
-        for (const row of statRows) {
-          if (row) statsByPath.set(row.path, row.stats);
-        }
         const validRows = notes
           .filter((notePath) => contents.has(notePath))
           .map((notePath) => {
             const content = contents.get(notePath)!;
-            const row = buildRow(notePath, content, statsByPath.get(notePath));
+            const row = buildRow(notePath, content, stats.get(notePath));
             // BUG-4: Populate row.links from the note's outgoing wikilinks so
             // file.linksTo() / file.hasLink() filters evaluate correctly.
             // Without this, row.links is undefined and the evaluator falls
@@ -215,11 +177,6 @@ export function registerBaseTools(server: McpServer, vaultPath: string): void {
         if (readFailures.length > 0) {
           allWarnings.push(
             `Could not read ${readFailures.length} note(s); they were excluded from results.`,
-          );
-        }
-        if (statFailures.length > 0) {
-          allWarnings.push(
-            `Could not stat ${statFailures.length} note(s); file.size/file.ctime/file.mtime may be unavailable for them.`,
           );
         }
         const truncated = result.rows.slice(0, limit);


### PR DESCRIPTION
Reuses stat metadata that `readAllCached` already collects so `query_base` avoids a second stat pass on cached note bodies. This keeps Base row semantics and stat-backed filters unchanged while bringing repeated 1,000-note warm queries under the R&D ship bar.

Tested: `npx vitest run src\__tests__\index-cache.test.ts src\__tests__\handlers\bases.test.ts`; `npm run build`; `node scripts\bench-bases.mjs 100,1000 --json` twice (1,000-note warm 54.1ms / 57.0ms, cold 84.8ms / 92.8ms); `npm run verify`.

Risk: low; no public API change, and stat values still come from per-file `fs.stat` inside the existing vault-boundary-checked read path.

Score: 2 severity x 3 reach / 1 effort = 6.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR eliminates the redundant second `fs.stat()` pass that `query_base` previously ran after `readAllCached` by surfacing the stat fields already gathered inside the cache function. The `ReadAllResult` type gains a `stats: Map<string, CachedFileStats>` field, and `bases.ts` drops the `mapConcurrent` stat loop, the `statFailures` tracking, and the corresponding user-facing warning.

- **`index-cache.ts`**: `statsByPath.set()` is called immediately after `fs.stat()`, before the cache-hit branch, so both warm (cache-hit) and cold (cache-miss) paths correctly populate stats — eliminating ~1,000 extra syscalls on a 1,000-note warm query.
- **`bases.ts`**: The removed second stat loop and `statFailures` warning are safe to drop; stat failures now cause a note to be excluded from results via the existing `readFailures` path rather than included without stats.
- **Tests and docs**: Benchmark results (54.1ms / 57.0ms warm vs. the 80ms ship bar) are recorded; the `bases.test.ts` integration test verifies stat-backed filters still match; the cache-miss stats assertion is added to `index-cache.test.ts`.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the optimization is correct and stat fields are populated for both warm and cold paths.

The stat collection is positioned before the cache-hit branch, so the core warm-query correctness is solid. The only gap is that the existing `hits the cache on the second call` test does not assert `stats` is populated on a hit, leaving a quiet regression surface if that ordering changes in a future refactor.

src/__tests__/index-cache.test.ts — the cache-hit test case would benefit from a stats assertion to guard the warm-query path.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/index-cache.ts | Adds `CachedFileStats` interface and `stats` map to `readAllCached`; stat fields are collected in the same `fs.stat()` call already used for mtime validation, before the cache-hit check, so stats are correctly populated for both hits and misses. |
| src/tools/bases.ts | Removes the redundant second `mapConcurrent` stat pass and `statFailures` warning; now passes `stats.get(notePath)` from `readAllCached` directly into `buildRow`, eliminating ~1,000 extra syscalls per warm query. |
| src/__tests__/index-cache.test.ts | Adds stats assertion for the cache-miss case; does not assert that `stats` is populated on cache hits, leaving a coverage gap for the warm-query path. |
| docs/rnd/bases-query-warm-path.md | Updated with benchmark results (54.1ms / 57.0ms warm, 84.8ms / 92.8ms cold) and ship decision; status changed from active to shipped. |
| CHANGELOG.md | Changelog updated to describe the stat-reuse optimization and move bases experiment entry to Changed section. |
| docs/rnd/README.md | R&D table row for bases query warm path updated to shipped status with decision summary. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant B as bases.ts (query_base)
    participant C as readAllCached
    participant FS as fs (per file)

    note over B,FS: Before this PR — two stat passes
    B->>C: readAllCached(notes)
    loop "each note (concurrency=16)"
        C->>FS: fs.stat() [mtime check]
        C->>FS: fs.readFile() [on miss]
    end
    C-->>B: "{ contents, mtimes }"
    loop "each readable note (concurrency=16)"
        B->>FS: fs.stat() [gather size/ctime/mtime]
    end
    B->>B: buildRow(path, content, stats)

    note over B,FS: After this PR — single stat pass
    B->>C: readAllCached(notes)
    loop "each note (concurrency=16)"
        C->>FS: fs.stat() [mtime check + collect size/ctime/mtime]
        C->>FS: fs.readFile() [on miss only]
    end
    C-->>B: "{ contents, mtimes, stats }"
    B->>B: buildRow(path, content, stats.get(path))
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/__tests__/index-cache.test.ts`, line 58-64 ([link](https://github.com/rps321321/obsidian-mcp-pro/blob/5ea92ac45689190d026a4cd67c8717f629ef1db2/src/__tests__/index-cache.test.ts#L58-L64)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The cache-hit path is not covered by a `stats` assertion. `statsByPath.set()` is correctly called before the cache-hit branch in `readAllCached`, but if that ordering were ever accidentally reversed (e.g., moving the set inside the miss-only branch), warm `query_base` queries would silently return `undefined` stats for every cached note, causing stat-backed filters (`file.size`, `file.ctime`, `file.mtime`) to drop all results with no error or warning.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["perf: reuse cached stats for base querie..."](https://github.com/rps321321/obsidian-mcp-pro/commit/5ea92ac45689190d026a4cd67c8717f629ef1db2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35537473)</sub>

<!-- /greptile_comment -->