### PR TITLE
perf: reuse parsed tags for warm tag lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Active R&D experiment for tag-index warm-query performance, with a synthetic benchmark harness in `scripts/bench-tags.mjs` and ship/kill metric in `docs/rnd/tag-index-warm-path.md`.
+- R&D experiment for tag-index warm-query performance, with a synthetic benchmark harness in `scripts/bench-tags.mjs` and ship/kill metric in `docs/rnd/tag-index-warm-path.md`.
 - R&D experiment for `query_base` warm-query performance, with a synthetic benchmark harness in `scripts/bench-bases.mjs` and ship/kill metric in `docs/rnd/bases-query-warm-path.md`.
 - Active R&D experiment for `find_broken_links` warm-scan performance, with a synthetic benchmark harness in `scripts/bench-broken-links.mjs` and ship/kill metric in `docs/rnd/broken-link-warm-path.md`.
 - Active R&D experiment for link graph warm-cache performance, with a synthetic benchmark harness in `scripts/bench-links.mjs` and ship/kill metric in `docs/rnd/link-graph-warm-path.md`.
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `list_tags` and `search_by_tag` now reuse a warm in-memory tag index keyed by note mtimes, cutting the 1,000-note sparse tag-search bench below the R&D ship bar while preserving tag matching and preview behavior.
 - `query_base` now reuses stat metadata gathered by the content cache, cutting the 1,000-note warm Base query bench below the R&D ship bar while preserving stat-backed file filters.
 - `find_broken_links` now reuses link graph data for unresolved-link reporting and skips a duplicate cold fingerprint stat pass, cutting the 1,000-note warm broken-link bench below the R&D ship bar.
 - Link graph cache validation now reuses the vault root realpath across each fingerprint batch, cutting the 1,000-note warm `get_backlinks` bench below the R&D ship bar while keeping per-note symlink checks.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Tag Index Warm Path](tag-index-warm-path.md) | performance / retrieval quality | active | Baseline measures cold/warm `list_tags` plus sparse warm `search_by_tag` on synthetic 100-note and 1,000-note vaults. |
+| [Tag Index Warm Path](tag-index-warm-path.md) | performance / retrieval quality | shipped | Warm 1,000-note sparse tag searches fell from 36.8ms to 22.5ms while warm `list_tags` and cold scans stayed under their guardrails. |
 | [Bases Query Warm Path](bases-query-warm-path.md) | performance / Obsidian format coverage | shipped | Warm 1,000-note Base queries fell from 99.7ms to 54.1ms while cold stayed under the guardrail. |
 | [Broken Link Warm Path](broken-link-warm-path.md) | performance / graph analysis | shipped | Warm 1,000-note broken-link scans fell from 222.7ms to 29.1ms while cold stayed under the guardrail. |
 | [Link Graph Warm Path](link-graph-warm-path.md) | performance / graph analysis | shipped | Warm 1,000-note backlinks fell from 80.4ms to 42.5ms while cold graph traversal stayed under the guardrail. |

--- a/docs/rnd/tag-index-warm-path.md
+++ b/docs/rnd/tag-index-warm-path.md
@@ -1,7 +1,7 @@
 # Tag Index Warm Path
 
-_Status: active_
-_Started: 2026-06-04 - Decided: _
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -45,9 +45,9 @@ tag display must stay unchanged.
 
 | | before | after |
 |---|---:|---:|
-| 1,000-note warm sparse search_by_tag | 36.8ms | |
-| 1,000-note warm list_tags | 35.7ms | |
-| 1,000-note cold list_tags guardrail | 74.3ms | |
+| 1,000-note warm sparse search_by_tag | 36.8ms | 22.5ms / 26.0ms |
+| 1,000-note warm list_tags | 35.7ms | 23.8ms / 22.2ms |
+| 1,000-note cold list_tags guardrail | 74.3ms | 63.7ms / 61.3ms |
 
 ## Safety review
 
@@ -73,4 +73,11 @@ use stale note content.
 
 ## Decision
 
-Open.
+Ship. The tag tools now keep a small in-memory index keyed by vault path, note
+list, and the same per-note mtimes gathered by `readAllCached`. Repeat
+`list_tags` calls reuse normalized tag counts, and `search_by_tag` uses a reverse
+tag-to-file index while preserving note-order output, nested-tag matching, and
+preview content from the current content cache. Sequential repeated 1,000-note
+warm sparse searches landed at 22.5ms and 26.0ms against the 29ms ship bar,
+warm `list_tags` landed at 23.8ms and 22.2ms against the 29ms secondary bar,
+and cold `list_tags` stayed at 63.7ms and 61.3ms against the 82ms guardrail.

--- a/src/__tests__/handlers/tags.test.ts
+++ b/src/__tests__/handlers/tags.test.ts
@@ -149,6 +149,26 @@ describe("tag handlers — search_by_tag", () => {
     const text = textContent(result);
     expect(text).toMatch(/Found 1 note with tag #review/);
   });
+
+  it("refreshes the warm tag index after a new note appears", async () => {
+    await env.client.callTool({ name: "list_tags", arguments: {} });
+
+    await env.client.callTool({
+      name: "create_note",
+      arguments: {
+        path: "fresh-tag.md",
+        content: "A new indexed note. #freshcache",
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "freshcache" },
+    });
+
+    expect(isError(result)).toBe(false);
+    expect(textContent(result)).toContain("fresh-tag.md");
+  });
 });
 
 describe("tag handlers — rename_tag", () => {

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -12,12 +12,97 @@ import { log } from "../lib/logger.js";
 
 import type { TagInfo } from "../types.js";
 
+const TAG_INDEX_CACHE_LIMIT = 8;
+
+interface TagIndexEntry {
+  path: string;
+  tags: string[];
+}
+
+interface TagIndexCacheEntry {
+  fingerprint: string;
+  noteOrder: Map<string, number>;
+  tagInfos: TagInfo[];
+  tagToFiles: Map<string, string[]>;
+}
+
+const tagIndexCache = new Map<string, TagIndexCacheEntry>();
+
 function errorResult(text: string) {
   return { content: [{ type: "text" as const, text }], isError: true as const };
 }
 
 function displayTagValue(value: string): string {
   return escapeControlChars(value);
+}
+
+function tagIndexFingerprint(
+  notes: readonly string[],
+  contents: ReadonlyMap<string, string>,
+  mtimes: ReadonlyMap<string, number>,
+): string {
+  return notes
+    .map((notePath) => {
+      const mtime = mtimes.get(notePath);
+      return `${notePath}\0${contents.has(notePath) && mtime !== undefined ? mtime : "missing"}`;
+    })
+    .join("\0");
+}
+
+function getCachedTagIndex(
+  vaultPath: string,
+  notes: readonly string[],
+  contents: ReadonlyMap<string, string>,
+  mtimes: ReadonlyMap<string, number>,
+): TagIndexCacheEntry {
+  const fingerprint = tagIndexFingerprint(notes, contents, mtimes);
+  const cached = tagIndexCache.get(vaultPath);
+  if (cached?.fingerprint === fingerprint) {
+    tagIndexCache.delete(vaultPath);
+    tagIndexCache.set(vaultPath, cached);
+    return cached;
+  }
+
+  const entries: TagIndexEntry[] = [];
+  const noteOrder = new Map<string, number>();
+  const tagMap = new Map<string, { tag: string; files: Set<string> }>();
+  for (const notePath of notes) {
+    const content = contents.get(notePath);
+    if (content === undefined) continue;
+    const tags = extractTags(content);
+    noteOrder.set(notePath, entries.length);
+    entries.push({ path: notePath, tags });
+    for (const tag of tags) {
+      const normalizedTag = tag.toLowerCase();
+      const existing = tagMap.get(normalizedTag);
+      if (existing) {
+        existing.files.add(notePath);
+      } else {
+        tagMap.set(normalizedTag, {
+          tag: normalizedTag,
+          files: new Set([notePath]),
+        });
+      }
+    }
+  }
+
+  const tagInfos: TagInfo[] = Array.from(tagMap.values()).map(({ tag, files }) => ({
+    tag,
+    count: files.size,
+    files: [...files],
+  }));
+  const tagToFiles = new Map<string, string[]>();
+  for (const info of tagInfos) tagToFiles.set(info.tag, info.files);
+
+  const fresh = { fingerprint, noteOrder, tagInfos, tagToFiles };
+  tagIndexCache.set(vaultPath, fresh);
+  while (tagIndexCache.size > TAG_INDEX_CACHE_LIMIT) {
+    const oldestKey = tagIndexCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    tagIndexCache.delete(oldestKey);
+  }
+
+  return fresh;
 }
 
 export function registerTagTools(server: McpServer, vaultPath: string): void {
@@ -43,37 +128,19 @@ export function registerTagTools(server: McpServer, vaultPath: string): void {
     async ({ sortBy }) => {
       try {
         const notes = await listNotes(vaultPath);
-        const tagMap = new Map<string, { tag: string; files: Set<string> }>();
 
         // Cached batch read: re-uses content for files whose mtime hasn't
         // moved since the last vault-wide scan. Per-file failures are
         // logged and dropped so one unreadable note can't abort the index.
-        const { contents } = await readAllCached(vaultPath, notes, (note, err) => {
+        const { contents, mtimes } = await readAllCached(vaultPath, notes, (note, err) => {
           log.warn("list_tags: note read failed", { note, err });
         });
 
-        for (const notePath of notes) {
-          const content = contents.get(notePath);
-          if (content === undefined) continue;
-          const tags = extractTags(content);
-          for (const tag of tags) {
-            const normalizedTag = tag.toLowerCase();
-            const existing = tagMap.get(normalizedTag);
-            if (existing) {
-              existing.files.add(notePath);
-            } else {
-              tagMap.set(normalizedTag, {
-                tag: normalizedTag,
-                files: new Set([notePath]),
-              });
-            }
-          }
-        }
-
-        const tagInfos: TagInfo[] = Array.from(tagMap.values()).map(({ tag, files }) => ({
-          tag,
-          count: files.size,
-          files: [...files],
+        const tagIndex = getCachedTagIndex(vaultPath, notes, contents, mtimes);
+        const tagInfos: TagInfo[] = tagIndex.tagInfos.map((info) => ({
+          tag: info.tag,
+          count: info.count,
+          files: [...info.files],
         }));
 
         if (sortBy === "name") {
@@ -137,29 +204,29 @@ export function registerTagTools(server: McpServer, vaultPath: string): void {
         const searchTag = tag.replace(/^#/, "").toLowerCase();
         const notes = await listNotes(vaultPath);
 
-        const { contents } = await readAllCached(vaultPath, notes, (note, err) => {
+        const { contents, mtimes } = await readAllCached(vaultPath, notes, (note, err) => {
           log.warn("search_by_tag: note read failed", { note, err });
         });
 
-        const matchingNotes: { path: string; preview?: string }[] = [];
-        for (const notePath of notes) {
-          if (matchingNotes.length >= maxResults) break;
-          const content = contents.get(notePath);
-          if (content === undefined) continue;
-          const tags = extractTags(content);
-          const hasMatch = tags.some((t) => {
-            const normalized = t.toLowerCase();
-            return normalized === searchTag || normalized.startsWith(`${searchTag}/`);
-          });
-          if (hasMatch) {
-            const entry: { path: string; preview?: string } = { path: notePath };
-            if (includeContent) {
-              const stripped = content.replace(/^---\n[\s\S]*?\n---\n/, "");
-              entry.preview = stripped.slice(0, 200).trim();
-            }
-            matchingNotes.push(entry);
+        const tagIndex = getCachedTagIndex(vaultPath, notes, contents, mtimes);
+        const matchingPathSet = new Set<string>();
+        for (const [normalizedTag, files] of tagIndex.tagToFiles) {
+          if (normalizedTag === searchTag || normalizedTag.startsWith(`${searchTag}/`)) {
+            for (const file of files) matchingPathSet.add(file);
           }
         }
+        const matchingPaths = [...matchingPathSet]
+          .sort((a, b) => (tagIndex.noteOrder.get(a) ?? 0) - (tagIndex.noteOrder.get(b) ?? 0))
+          .slice(0, maxResults);
+        const matchingNotes: { path: string; preview?: string }[] = matchingPaths.map((notePath) => {
+          const entry: { path: string; preview?: string } = { path: notePath };
+          if (includeContent) {
+            const content = contents.get(notePath)!;
+            const stripped = content.replace(/^---\n[\s\S]*?\n---\n/, "");
+            entry.preview = stripped.slice(0, 200).trim();
+          }
+          return entry;
+        });
 
         if (matchingNotes.length === 0) {
           return {


### PR DESCRIPTION
Adds a small in-memory tag index keyed by vault path, note list, and the mtimes already gathered by `readAllCached`. `list_tags` reuses normalized tag counts, and `search_by_tag` uses a reverse tag-to-file lookup while preserving note-order output, nested matches, and preview text from the current content cache.

Tested: `npx vitest run src\__tests__\handlers\tags.test.ts src\__tests__\regression-tools-tags.test.ts`; `npm run build`; `node scripts\bench-tags.mjs 100,1000 --json` twice sequentially (1,000-note warm sparse search 22.5ms / 26.0ms, warm list 23.8ms / 22.2ms, cold list 63.7ms / 61.3ms); `npm run verify`.

Risk: low to medium; no public API change, and the cache invalidates when the note list or cached mtimes change. A handler regression covers a warm index seeing a newly created tagged note.

Score: 2 severity x 3 reach / 1 effort = 6.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR ships the tag-index warm-path experiment by introducing a small module-level LRU cache (`tagIndexCache`, capped at 8 vault entries) that stores parsed tag data keyed on vault path and note mtimes. Both `list_tags` and `search_by_tag` now call `getCachedTagIndex` instead of re-parsing every note on each invocation.

- **`list_tags`** maps the cached `tagInfos` into a fresh array (with a copied `files` slice) before sorting, so the sort never mutates the shared cache entry.
- **`search_by_tag`** iterates the cached `tagToFiles` reverse-lookup Map, collects matching paths into a `Set` (deduplication for nested-tag multi-match), re-sorts by the cached `noteOrder`, then slices to `maxResults`.
- A new regression test primes the cache via `list_tags`, creates a new tagged note, then asserts `search_by_tag` finds it, confirming the fingerprint-based invalidation works across tool calls.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core cache-invalidation logic is sound and well-tested. The only issues are confined to LRU ordering on a stale-fingerprint miss and unused dead code, neither of which affects correctness in the common single-vault case.

The fingerprint-based invalidation correctly handles note creation, deletion, and content changes. The delete+set LRU promotion is missing from the cache-miss path (it exists on the hit path), which could cause a freshly rebuilt vault index to be evicted before older entries in a multi-vault server. The TagIndexEntry interface and entries array are populated but never consumed. The non-null assertion on contents.get(notePath) is safe today but relies on an implicit cross-function invariant the type system does not enforce.

src/tools/tags.ts — specifically the cache-miss LRU promotion (line 98) and the dead entries/TagIndexEntry code (lines 17–74).
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/tags.ts | Adds a module-level tag index cache keyed by vault path with LRU eviction; reuses index for both list_tags and search_by_tag. Three minor issues: LRU promotion missing on cache miss, dead TagIndexEntry/entries code, and a non-null assertion relying on an implicit cross-function invariant. |
| src/__tests__/handlers/tags.test.ts | Adds a regression test verifying that a warm index is invalidated when a new tagged note appears; good coverage of the warm/cold cache transition. |
| docs/rnd/tag-index-warm-path.md | Status updated from active to shipped, benchmark results filled in, and decision section written. |
| CHANGELOG.md | Changelog updated correctly; removes 'Active' prefix and adds a Changed entry for the tag index warm path. |
| docs/rnd/README.md | R&D table updated to mark the tag index experiment as shipped with accurate benchmark summary. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[list_tags / search_by_tag called] --> B[listNotes + readAllCached]
    B --> C[tagIndexFingerprint: notes x mtime]
    C --> D{tagIndexCache hit?}
    D -- warm --> E[delete + re-set LRU, return cached]
    D -- cold/stale --> F[Build: noteOrder, tagMap, tagInfos, tagToFiles]
    F --> G[delete + set vaultPath, evict oldest if size > 8]
    G --> H[return fresh entry]
    E --> I[list_tags: copy tagInfos, sort, format]
    H --> I
    E --> J[search_by_tag: tagToFiles lookup, Set, sort by noteOrder, slice]
    H --> J
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf: reuse parsed tags for warm tag loo..."](https://github.com/rps321321/obsidian-mcp-pro/commit/24ab3768795fea581a9c4e0be914010eed92eab3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35538834)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->