### PR TITLE
chore: start attachment inventory warm-path r&d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Active R&D experiment for attachment inventory warm-path performance, with a synthetic benchmark harness in `scripts/bench-attachments.mjs` and ship/kill metric in `docs/rnd/attachment-inventory-warm-path.md`.
 - R&D experiment for `read_canvas` warm-read performance, with a synthetic benchmark harness in `scripts/bench-canvas.mjs` and ship/kill metric in `docs/rnd/canvas-read-warm-path.md`.
 - R&D experiment for tag-index warm-query performance, with a synthetic benchmark harness in `scripts/bench-tags.mjs` and ship/kill metric in `docs/rnd/tag-index-warm-path.md`.
 - R&D experiment for `query_base` warm-query performance, with a synthetic benchmark harness in `scripts/bench-bases.mjs` and ship/kill metric in `docs/rnd/bases-query-warm-path.md`.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,6 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
+| [Attachment Inventory Warm Path](attachment-inventory-warm-path.md) | performance / vault hygiene | active | Baseline measures cold/warm attachment listing and unused-attachment scans on synthetic 100 and 1,000 attachment/note vaults. |
 | [Canvas Read Warm Path](canvas-read-warm-path.md) | performance / Obsidian format coverage | shipped | Warm 1,000-node canvas reads fell from 6.9ms to 1.7ms while cold stayed under the guardrail. |
 | [Tag Index Warm Path](tag-index-warm-path.md) | performance / retrieval quality | shipped | Warm 1,000-note sparse tag searches fell from 36.8ms to 22.5ms while warm `list_tags` and cold scans stayed under their guardrails. |
 | [Bases Query Warm Path](bases-query-warm-path.md) | performance / Obsidian format coverage | shipped | Warm 1,000-note Base queries fell from 99.7ms to 54.1ms while cold stayed under the guardrail. |

--- a/docs/rnd/attachment-inventory-warm-path.md
+++ b/docs/rnd/attachment-inventory-warm-path.md
@@ -1,0 +1,80 @@
+# Attachment Inventory Warm Path
+
+_Status: active_
+_Started: 2026-06-04 - Decided: _
+
+## Hypothesis
+
+`find_unused_attachments` already reads markdown notes through the shared content
+cache, but it rebuilds attachment sets, basename indexes, and reference sets on
+repeat calls. A small metadata-keyed attachment inventory cache may cut the
+1,000 attachment/note warm unused scan by at least 20% without changing
+extension filtering, reference resolution, unused counts, byte reporting,
+progress updates, or displayed output.
+
+## Fixture
+
+Bench command:
+
+```powershell
+npm run build
+node scripts\bench-attachments.mjs 100,1000 --json
+```
+
+The harness creates temporary vaults with 100 or 1,000 attachments and the same
+number of markdown notes. Attachments are spread across nested asset folders and
+mixed `.png`, `.jpg`, `.webp`, and `.pdf` extensions. Notes reference a subset
+with both wikilink embeds and markdown image links, leaving a realistic unused
+set. It calls `list_attachments` twice, then calls `find_unused_attachments`
+twice through a real stdio MCP client.
+
+Baseline captured on 2026-06-04:
+
+| attachments + notes | cold list_attachments | warm list_attachments | cold find_unused_attachments | warm find_unused_attachments |
+|---:|---:|---:|---:|---:|
+| 100 | 9.6ms | 5.9ms | 23.8ms | 12.0ms |
+| 1,000 | 17.3ms | 9.4ms | 83.6ms | 58.9ms |
+
+## Metric
+
+Primary metric: 1,000 attachment/note warm `find_unused_attachments` wall time.
+
+Ship bar: warm `find_unused_attachments` at or below 47ms (20% faster than the
+58.9ms baseline), with 1,000 attachment/note cold `find_unused_attachments` no
+worse than 92ms and warm `list_attachments` no worse than 11ms. Attachment
+ordering, extension summaries, unused counts, reference matching, optional byte
+totals, progress labels, and displayed paths must stay unchanged.
+
+| | before | after |
+|---|---:|---:|
+| 1,000 attachment/note warm find_unused_attachments | 58.9ms | |
+| 1,000 attachment/note cold find_unused_attachments guardrail | 92ms | |
+| 1,000 attachment/note warm list_attachments guardrail | 11ms | |
+
+## Safety review
+
+Data accessed: synthetic temporary markdown notes and attachment files generated
+by `scripts/bench-attachments.mjs`. No real vault content, secrets, network
+calls, or embedding providers are involved.
+
+Writes performed: temporary fixture vault creation and deletion only. A future
+prototype may add in-memory attachment inventory metadata; it must preserve
+vault-boundary checks, permission filtering, excluded-folder handling, mtime
+invalidation, MIME/security checks in `get_attachment`, and raw attachment
+bytes.
+
+Logs emitted: normal stdio server startup logs with temporary vault paths. No
+note body or attachment bytes are logged.
+
+Rollback path: drop the prototype and keep direct attachment listing and note
+reference scanning per call.
+
+## Kill criterion
+
+Stop if the warm unused scan improves by less than 20%, if cold unused scans or
+warm attachment listings exceed their guardrails, if unused counts change, or if
+referenced attachments are marked stale after note or attachment edits.
+
+## Decision
+
+Open.

--- a/scripts/bench-attachments.mjs
+++ b/scripts/bench-attachments.mjs
@@ -1,0 +1,153 @@
+// Attachment benchmark: generate throwaway attachment-heavy vaults and time
+// attachment inventory tools through a real stdio MCP client.
+//
+// Direct use: node scripts/bench-attachments.mjs [sizes] [--json]
+//   e.g. node scripts/bench-attachments.mjs 100,1000
+// Run after `npm run build`.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { performance } from "node:perf_hooks";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const entry = join(root, "build", "index.js");
+
+function attachmentName(i) {
+  const ext = i % 7 === 0 ? "pdf" : i % 5 === 0 ? "webp" : i % 3 === 0 ? "jpg" : "png";
+  return `asset-${String(i).padStart(6, "0")}.${ext}`;
+}
+
+function attachmentPath(i) {
+  return `assets/group-${String(i % 20).padStart(2, "0")}/${attachmentName(i)}`;
+}
+
+function noteName(i) {
+  return `note-${String(i).padStart(6, "0")}`;
+}
+
+export function makeAttachmentVault(n) {
+  const dir = mkdtempSync(join(tmpdir(), `ompro-attachment-bench-${n}-`));
+  mkdirSync(join(dir, ".obsidian"));
+
+  for (let i = 0; i < n; i++) {
+    const rel = attachmentPath(i);
+    const full = join(dir, rel);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, `fixture attachment ${i}\n`.repeat((i % 5) + 1));
+  }
+
+  const noteCount = n;
+  for (let i = 0; i < noteCount; i++) {
+    const folder = i % 10 === 0 ? join(dir, `notes/area-${i % 50}`) : join(dir, "notes");
+    mkdirSync(folder, { recursive: true });
+    const referenced = attachmentPath((i * 3) % n);
+    const maybeSecond = i % 4 === 0 ? `\n![diagram](${attachmentPath((i * 7) % n)})` : "";
+    writeFileSync(
+      join(folder, `${noteName(i)}.md`),
+      [
+        `# ${noteName(i)}`,
+        "",
+        `Primary embed: ![[${referenced}]]`,
+        maybeSecond,
+        "",
+        "This synthetic note keeps find_unused_attachments scanning realistic.",
+        "",
+      ].join("\n"),
+    );
+  }
+
+  return dir;
+}
+
+async function timeCall(client, name, args) {
+  const start = performance.now();
+  await client.callTool({ name, arguments: args });
+  return performance.now() - start;
+}
+
+async function timeAttachments(vault, n) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [entry],
+    cwd: root,
+    env: { ...process.env, OBSIDIAN_VAULT_PATH: vault },
+  });
+  const client = new Client({ name: "attachment-bench", version: "1.0.0" });
+  await client.connect(transport);
+  try {
+    const coldListAttachmentsMs = await timeCall(client, "list_attachments", { limit: n });
+    const warmListAttachmentsMs = await timeCall(client, "list_attachments", { limit: n });
+    const coldFindUnusedAttachmentsMs = await timeCall(client, "find_unused_attachments", {
+      limit: 100,
+      includeBytes: false,
+    });
+    const warmFindUnusedAttachmentsMs = await timeCall(client, "find_unused_attachments", {
+      limit: 100,
+      includeBytes: false,
+    });
+    return {
+      coldListAttachmentsMs,
+      warmListAttachmentsMs,
+      coldFindUnusedAttachmentsMs,
+      warmFindUnusedAttachmentsMs,
+    };
+  } finally {
+    await client.close();
+  }
+}
+
+export async function runAttachmentBench(sizes) {
+  const rows = [];
+  for (const n of sizes) {
+    const vault = makeAttachmentVault(n);
+    try {
+      const timings = await timeAttachments(vault, n);
+      rows.push({ n, ...timings });
+    } finally {
+      rmSync(vault, { recursive: true, force: true });
+    }
+  }
+  return rows;
+}
+
+const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (invokedDirectly) {
+  if (!existsSync(entry)) {
+    console.error("build/index.js missing - run `npm run build` first.");
+    process.exit(1);
+  }
+  const args = process.argv.slice(2);
+  const asJson = args.includes("--json");
+  const sizesArg = args.find((a) => !a.startsWith("--"));
+  const sizes = (sizesArg ?? "100,1000")
+    .split(",")
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  const rows = await runAttachmentBench(sizes);
+  if (asJson) {
+    console.log(JSON.stringify(rows));
+  } else {
+    for (const r of rows) {
+      console.log(
+        [
+          `${r.n} attachments`,
+          `cold list_attachments ${r.coldListAttachmentsMs.toFixed(0)}ms`,
+          `warm list_attachments ${r.warmListAttachmentsMs.toFixed(0)}ms`,
+          `cold find_unused_attachments ${r.coldFindUnusedAttachmentsMs.toFixed(0)}ms`,
+          `warm find_unused_attachments ${r.warmFindUnusedAttachmentsMs.toFixed(0)}ms`,
+        ].join("\t"),
+      );
+    }
+    console.log("\n| attachments + notes | cold list_attachments | warm list_attachments | cold find_unused_attachments | warm find_unused_attachments |");
+    console.log("|--------------------:|----------------------:|----------------------:|-----------------------------:|-----------------------------:|");
+    for (const r of rows) {
+      console.log(
+        `| ${r.n} | ${r.coldListAttachmentsMs.toFixed(0)}ms | ${r.warmListAttachmentsMs.toFixed(0)}ms | ${r.coldFindUnusedAttachmentsMs.toFixed(0)}ms | ${r.warmFindUnusedAttachmentsMs.toFixed(0)}ms |`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
Starts a measured Attachment Inventory Warm Path experiment with a synthetic stdio benchmark for repeated `list_attachments` and `find_unused_attachments` calls on generated 100 and 1,000 attachment/note vaults. The baseline captures 1,000-item timings at 17.3ms cold / 9.4ms warm for `list_attachments`, and 83.6ms cold / 58.9ms warm for `find_unused_attachments`, with a 47ms warm unused-scan ship bar.

Tested: `npm run build`; `node scripts\bench-attachments.mjs 100,1000 --json` twice; `npm run verify`.

Risk: low; this adds docs and a throwaway-vault benchmark only, with no public API or runtime behavior change.

Score: 1 severity x 2 reach / 1 effort = 2.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR starts a new R&D experiment tracking attachment-inventory performance by adding a stdio benchmark harness (`scripts/bench-attachments.mjs`) and the accompanying experiment doc, with no changes to production runtime code.

- **`scripts/bench-attachments.mjs`**: New benchmark that spins up synthetic vaults (100 / 1,000 attachments + notes), times `list_attachments` and `find_unused_attachments` cold/warm through a real MCP stdio client, and cleans up temp dirs in `finally` blocks. The structure mirrors the existing `bench-tags.mjs` / `bench-bases.mjs` scripts.
- **`docs/rnd/attachment-inventory-warm-path.md`**: New experiment doc with baseline metrics, a 47ms ship bar for warm `find_unused_attachments`, and kill criteria.
- **`CHANGELOG.md` / `docs/rnd/README.md`**: Changelog and R&D index updated to register the new experiment.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — no production code is touched; only a dev benchmark script and docs are added.

The benchmark script follows the established pattern of other bench scripts in the repo, temp-dir cleanup is properly guarded in finally blocks, and the docs are well-structured with clear ship/kill criteria. The one thing worth revisiting is the hardcoded limit: 100 on find_unused_attachments versus the size-scaled limit used for list_attachments, which could make the baseline metrics less representative if the server supports early-exit on that parameter.

scripts/bench-attachments.mjs — the limit inconsistency between list_attachments and find_unused_attachments calls.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/bench-attachments.mjs | New benchmark harness; follows existing bench script conventions; minor inconsistency where find_unused_attachments uses a fixed limit: 100 while list_attachments scales with n. |
| docs/rnd/attachment-inventory-warm-path.md | New R&D experiment doc; well-structured with hypothesis, baseline metrics, ship bar, safety review, and kill criteria. |
| docs/rnd/README.md | R&D index updated with a new row for the attachment inventory warm path experiment. |
| CHANGELOG.md | Changelog entry added for the new R&D experiment; consistent with existing entries. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant B as bench-attachments.mjs
    participant FS as Temp Filesystem
    participant S as MCP Server (build/index.js)

    loop for each size (100, 1000)
        B->>FS: mkdtempSync — create vault dir
        B->>FS: writeFileSync x n attachments + notes
        B->>S: client.connect() via StdioClientTransport
        B->>S: callTool list_attachments limit n — cold
        S-->>B: result + timing
        B->>S: callTool list_attachments limit n — warm
        S-->>B: result + timing
        B->>S: callTool find_unused_attachments limit 100 — cold
        S-->>B: result + timing
        B->>S: callTool find_unused_attachments limit 100 — warm
        S-->>B: result + timing
        B->>S: client.close()
        B->>FS: rmSync vault recursive
    end
    B->>B: print table or JSON
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: start attachment inventory warm-p..."](https://github.com/rps321321/obsidian-mcp-pro/commit/94fd13ffa490851cf94fa029cad23766e8260182) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35541683)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->