### PR TITLE
perf: cache warm attachment inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Active R&D experiment for attachment inventory warm-path performance, with a synthetic benchmark harness in `scripts/bench-attachments.mjs` and ship/kill metric in `docs/rnd/attachment-inventory-warm-path.md`.
+- R&D experiment for attachment inventory warm-path performance, with a synthetic benchmark harness in `scripts/bench-attachments.mjs` and ship/kill metric in `docs/rnd/attachment-inventory-warm-path.md`.
 - R&D experiment for `read_canvas` warm-read performance, with a synthetic benchmark harness in `scripts/bench-canvas.mjs` and ship/kill metric in `docs/rnd/canvas-read-warm-path.md`.
 - R&D experiment for tag-index warm-query performance, with a synthetic benchmark harness in `scripts/bench-tags.mjs` and ship/kill metric in `docs/rnd/tag-index-warm-path.md`.
 - R&D experiment for `query_base` warm-query performance, with a synthetic benchmark harness in `scripts/bench-bases.mjs` and ship/kill metric in `docs/rnd/bases-query-warm-path.md`.
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `find_unused_attachments` now reuses a warm in-memory attachment inventory keyed by attachment paths and note mtimes, cutting the 1,000 attachment/note warm unused-scan bench below the R&D ship bar while preserving reference matching and byte reporting.
 - `read_canvas` now reuses a warm in-memory rendered summary keyed by canvas file metadata, cutting the 1,000-node warm canvas-read bench below the R&D ship bar while preserving path validation and displayed output.
 - `list_tags` and `search_by_tag` now reuse a warm in-memory tag index keyed by note mtimes, cutting the 1,000-note sparse tag-search bench below the R&D ship bar while preserving tag matching and preview behavior.
 - `query_base` now reuses stat metadata gathered by the content cache, cutting the 1,000-note warm Base query bench below the R&D ship bar while preserving stat-backed file filters.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Attachment Inventory Warm Path](attachment-inventory-warm-path.md) | performance / vault hygiene | active | Baseline measures cold/warm attachment listing and unused-attachment scans on synthetic 100 and 1,000 attachment/note vaults. |
+| [Attachment Inventory Warm Path](attachment-inventory-warm-path.md) | performance / vault hygiene | shipped | Warm 1,000 attachment/note unused scans fell from 58.9ms to 39.3ms while cold scans and warm listings stayed under their guardrails. |
 | [Canvas Read Warm Path](canvas-read-warm-path.md) | performance / Obsidian format coverage | shipped | Warm 1,000-node canvas reads fell from 6.9ms to 1.7ms while cold stayed under the guardrail. |
 | [Tag Index Warm Path](tag-index-warm-path.md) | performance / retrieval quality | shipped | Warm 1,000-note sparse tag searches fell from 36.8ms to 22.5ms while warm `list_tags` and cold scans stayed under their guardrails. |
 | [Bases Query Warm Path](bases-query-warm-path.md) | performance / Obsidian format coverage | shipped | Warm 1,000-note Base queries fell from 99.7ms to 54.1ms while cold stayed under the guardrail. |

--- a/docs/rnd/attachment-inventory-warm-path.md
+++ b/docs/rnd/attachment-inventory-warm-path.md
@@ -1,7 +1,7 @@
 # Attachment Inventory Warm Path
 
-_Status: active_
-_Started: 2026-06-04 - Decided: _
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -47,9 +47,9 @@ totals, progress labels, and displayed paths must stay unchanged.
 
 | | before | after |
 |---|---:|---:|
-| 1,000 attachment/note warm find_unused_attachments | 58.9ms | |
-| 1,000 attachment/note cold find_unused_attachments guardrail | 92ms | |
-| 1,000 attachment/note warm list_attachments guardrail | 11ms | |
+| 1,000 attachment/note warm find_unused_attachments | 58.9ms | 39.3ms / 31.6ms |
+| 1,000 attachment/note cold find_unused_attachments guardrail | 92ms | 72.3ms / 60.4ms |
+| 1,000 attachment/note warm list_attachments guardrail | 11ms | 7.7ms / 7.1ms |
 
 ## Safety review
 
@@ -57,11 +57,10 @@ Data accessed: synthetic temporary markdown notes and attachment files generated
 by `scripts/bench-attachments.mjs`. No real vault content, secrets, network
 calls, or embedding providers are involved.
 
-Writes performed: temporary fixture vault creation and deletion only. A future
-prototype may add in-memory attachment inventory metadata; it must preserve
+Writes performed: temporary fixture vault creation and deletion only. The
+prototype adds in-memory attachment inventory metadata; it preserves
 vault-boundary checks, permission filtering, excluded-folder handling, mtime
-invalidation, MIME/security checks in `get_attachment`, and raw attachment
-bytes.
+invalidation, MIME/security checks in `get_attachment`, and raw attachment bytes.
 
 Logs emitted: normal stdio server startup logs with temporary vault paths. No
 note body or attachment bytes are logged.
@@ -77,4 +76,12 @@ referenced attachments are marked stale after note or attachment edits.
 
 ## Decision
 
-Open.
+Ship. `find_unused_attachments` now keeps a small in-memory attachment inventory
+cache keyed by the current attachment list and note mtimes. Repeat scans reuse
+the derived basename/reference sets after a stat-only note fingerprint check, so
+the warm path skips note content reads while still invalidating on note or
+attachment changes. Exact attachment matching also uses a lowercase path index
+instead of scanning every attachment for every reference. Repeated 1,000
+attachment/note warm unused scans landed at 39.3ms and 31.6ms against the 47ms
+ship bar, cold scans stayed at 72.3ms and 60.4ms against the 92ms guardrail, and
+warm `list_attachments` stayed at 7.7ms and 7.1ms against the 11ms guardrail.

--- a/src/__tests__/handlers/attachments.test.ts
+++ b/src/__tests__/handlers/attachments.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
 import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
 
 let env: TestEnv;
@@ -81,6 +83,42 @@ describe("attachments handlers — find_unused_attachments", () => {
     expect(text).not.toMatch(/notes\.pdf/);
     // orphan-image.png and screenshot.jpg have no references at all.
     expect(text).toMatch(/orphan-image\.png/);
+    expect(text).toMatch(/screenshot\.jpg/);
+  });
+
+  it("serves repeated unused scans without changing output", async () => {
+    const first = await env.client.callTool({
+      name: "find_unused_attachments",
+      arguments: {},
+    });
+    const second = await env.client.callTool({
+      name: "find_unused_attachments",
+      arguments: {},
+    });
+
+    expect(isError(first)).toBe(false);
+    expect(isError(second)).toBe(false);
+    expect(textContent(second)).toBe(textContent(first));
+  });
+
+  it("refreshes cached unused scans after a note references an attachment", async () => {
+    const first = await env.client.callTool({
+      name: "find_unused_attachments",
+      arguments: {},
+    });
+    expect(textContent(first)).toMatch(/orphan-image\.png/);
+
+    const notePath = path.join(env.vaultDir, "embed-host.md");
+    await fs.appendFile(notePath, "\nNow referenced: ![[orphan-image.png]]\n", "utf-8");
+    const future = new Date(Date.now() + 5_000);
+    await fs.utimes(notePath, future, future);
+
+    const second = await env.client.callTool({
+      name: "find_unused_attachments",
+      arguments: {},
+    });
+    const text = textContent(second);
+    expect(text).not.toMatch(/orphan-image\.png/);
     expect(text).toMatch(/screenshot\.jpg/);
   });
 

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -6,10 +6,13 @@ import {
   listAttachments,
   listNotes,
   getAttachmentStats,
+  getNoteStats,
+  getVaultRootRealPath,
   resolveVaultPathSafe,
 } from "../lib/vault.js";
 import { readAllCached } from "../lib/index-cache.js";
 import { makeProgressReporter } from "../lib/progress.js";
+import { mapConcurrent } from "../lib/concurrency.js";
 import {
   extractWikilinkSpans,
   extractMarkdownLinkSpans,
@@ -29,6 +32,15 @@ import { log } from "../lib/logger.js";
  *  with `maxBytes`. */
 const DEFAULT_GET_ATTACHMENT_LIMIT = 5 * 1024 * 1024; // 5 MB
 const ABSOLUTE_GET_ATTACHMENT_LIMIT = 50 * 1024 * 1024; // 50 MB hard cap
+const ATTACHMENT_INVENTORY_CACHE_LIMIT = 8;
+
+interface AttachmentInventoryCacheEntry {
+  attachmentsFingerprint: string;
+  noteFingerprint: string;
+  referenced: Set<string>;
+}
+
+const attachmentInventoryCache = new Map<string, AttachmentInventoryCacheEntry>();
 
 function textResult(text: string) {
   return { content: [{ type: "text" as const, text }] };
@@ -52,6 +64,44 @@ function summarizeByExtension(paths: readonly string[]): Map<string, number> {
   return out;
 }
 
+function attachmentListFingerprint(attachments: readonly string[]): string {
+  return attachments.join("\0");
+}
+
+function noteMtimeFingerprint(
+  notes: readonly string[],
+  contents: ReadonlyMap<string, string>,
+  mtimes: ReadonlyMap<string, number>,
+): string {
+  return notes
+    .map((notePath) => {
+      const mtime = mtimes.get(notePath);
+      return `${notePath}\0${contents.has(notePath) && mtime !== undefined ? mtime : "missing"}`;
+    })
+    .join("\0");
+}
+
+async function noteStatsFingerprint(
+  vaultPath: string,
+  notes: readonly string[],
+): Promise<string | undefined> {
+  const realVaultRoot = await getVaultRootRealPath(vaultPath);
+  const parts = await mapConcurrent(
+    notes,
+    16,
+    async (notePath): Promise<string | undefined> => {
+      try {
+        const stats = await getNoteStats(vaultPath, notePath, { realVaultRoot });
+        return `${notePath}\0${stats.modified?.getTime() ?? 0}`;
+      } catch {
+        return undefined;
+      }
+    },
+  );
+  if (parts.some((part) => part === undefined)) return undefined;
+  return parts.join("\0");
+}
+
 /**
  * Resolve the set of attachment paths referenced by a single note. Considers:
  *   - `![[file.png]]` and `![[file.png|alt]]` wikilink embeds
@@ -63,7 +113,7 @@ function summarizeByExtension(paths: readonly string[]): Map<string, number> {
  */
 function collectReferencedAttachments(
   noteContent: string,
-  attachmentSet: ReadonlySet<string>,
+  lowerPathIndex: ReadonlyMap<string, string>,
   basenameIndex: ReadonlyMap<string, string[]>,
 ): { resolved: Set<string>; unresolved: string[] } {
   const resolved = new Set<string>();
@@ -76,11 +126,10 @@ function collectReferencedAttachments(
     // 1) Exact relative-path match (case-insensitive on case-insensitive FS,
     //    but we lowercase consistently to keep cross-platform behavior stable).
     const lower = t.toLowerCase();
-    for (const att of attachmentSet) {
-      if (att.toLowerCase() === lower) {
-        resolved.add(att);
-        return;
-      }
+    const exact = lowerPathIndex.get(lower);
+    if (exact) {
+      resolved.add(exact);
+      return;
     }
 
     // 2) Basename match. Obsidian also allows missing extensions on
@@ -106,6 +155,75 @@ function collectReferencedAttachments(
     consider(span.urlPath);
   }
   return { resolved, unresolved };
+}
+
+async function getCachedAttachmentInventory(
+  vaultPath: string,
+  attachments: readonly string[],
+  notes: readonly string[],
+  contents: ReadonlyMap<string, string>,
+  mtimes: ReadonlyMap<string, number>,
+  reportProgress: (progress: number, total: number, message?: string) => Promise<void>,
+): Promise<AttachmentInventoryCacheEntry> {
+  const attachmentsFingerprint = attachmentListFingerprint(attachments);
+  const noteFingerprint = noteMtimeFingerprint(notes, contents, mtimes);
+  const cacheKey = path.resolve(vaultPath);
+
+  const lowerPathIndex = new Map<string, string>();
+  const basenameIndex = new Map<string, string[]>();
+  for (const p of attachments) {
+    if (!lowerPathIndex.has(p.toLowerCase())) lowerPathIndex.set(p.toLowerCase(), p);
+    const base = path.basename(p).toLowerCase();
+    const list = basenameIndex.get(base);
+    if (list) list.push(p);
+    else basenameIndex.set(base, [p]);
+  }
+
+  const referenced = new Set<string>();
+  let scanned = 0;
+  for (const notePath of notes) {
+    const content = contents.get(notePath);
+    if (content !== undefined) {
+      const { resolved } = collectReferencedAttachments(content, lowerPathIndex, basenameIndex);
+      for (const r of resolved) referenced.add(r);
+    }
+    scanned++;
+    await reportProgress(scanned, notes.length, `Scanned ${scanned}/${notes.length} notes`);
+  }
+
+  const fresh = { attachmentsFingerprint, noteFingerprint, referenced };
+  attachmentInventoryCache.set(cacheKey, fresh);
+  while (attachmentInventoryCache.size > ATTACHMENT_INVENTORY_CACHE_LIMIT) {
+    const oldestKey = attachmentInventoryCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    attachmentInventoryCache.delete(oldestKey);
+  }
+  return fresh;
+}
+
+async function getReusableAttachmentInventory(
+  vaultPath: string,
+  attachments: readonly string[],
+  notes: readonly string[],
+  reportProgress: (progress: number, total: number, message?: string) => Promise<void>,
+): Promise<AttachmentInventoryCacheEntry | undefined> {
+  const cacheKey = path.resolve(vaultPath);
+  const cached = attachmentInventoryCache.get(cacheKey);
+  if (!cached || cached.attachmentsFingerprint !== attachmentListFingerprint(attachments)) {
+    return undefined;
+  }
+  const currentNoteFingerprint = await noteStatsFingerprint(vaultPath, notes);
+  if (currentNoteFingerprint === undefined || currentNoteFingerprint !== cached.noteFingerprint) {
+    return undefined;
+  }
+  attachmentInventoryCache.delete(cacheKey);
+  attachmentInventoryCache.set(cacheKey, cached);
+  let scanned = 0;
+  for (const _notePath of notes) {
+    scanned++;
+    await reportProgress(scanned, notes.length, `Scanned ${scanned}/${notes.length} notes`);
+  }
+  return cached;
 }
 
 export function registerAttachmentTools(server: McpServer, vaultPath: string): void {
@@ -207,34 +325,25 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         if (attachments.length === 0) {
           return textResult("No attachments in this vault — nothing to check.");
         }
-        const attachmentSet = new Set(attachments);
-        const basenameIndex = new Map<string, string[]>();
-        for (const p of attachments) {
-          const base = path.basename(p).toLowerCase();
-          const list = basenameIndex.get(base);
-          if (list) list.push(p);
-          else basenameIndex.set(base, [p]);
-        }
-
         const notes = await listNotes(vaultPath);
         await reportProgress(0, notes.length, "Reading notes…");
-        const { contents } = await readAllCached(vaultPath, notes, (note, err) => {
-          log.warn("find_unused_attachments: note read failed", { note, err });
-        });
+        let inventory = await getReusableAttachmentInventory(vaultPath, attachments, notes, reportProgress);
+        if (!inventory) {
+          const { contents, mtimes } = await readAllCached(vaultPath, notes, (note, err) => {
+            log.warn("find_unused_attachments: note read failed", { note, err });
+          });
 
-        const referenced = new Set<string>();
-        let scanned = 0;
-        for (const notePath of notes) {
-          const content = contents.get(notePath);
-          if (content !== undefined) {
-            const { resolved } = collectReferencedAttachments(content, attachmentSet, basenameIndex);
-            for (const r of resolved) referenced.add(r);
-          }
-          scanned++;
-          await reportProgress(scanned, notes.length, `Scanned ${scanned}/${notes.length} notes`);
+          inventory = await getCachedAttachmentInventory(
+            vaultPath,
+            attachments,
+            notes,
+            contents,
+            mtimes,
+            reportProgress,
+          );
         }
 
-        const unused = attachments.filter((p) => !referenced.has(p));
+        const unused = attachments.filter((p) => !inventory.referenced.has(p));
         if (unused.length === 0) {
           return textResult(
             `All ${attachments.length} attachment(s) are referenced — nothing to clean up.`,


### PR DESCRIPTION
Adds a small attachment inventory cache for `find_unused_attachments`, keyed by the current attachment list and note mtimes, so repeat scans can reuse derived reference sets after a stat-only freshness check. 1,000 attachment/note warm unused scans measured at 39.3ms and 31.6ms against the 47ms ship bar, with cold scans at 72.3ms and 60.4ms under the 92ms guardrail.

Tested: `npx vitest run src/__tests__/handlers/attachments.test.ts src/__tests__/regression-tools-attachments.test.ts src/__tests__/attachments-display.test.ts`; `npm run build`; `node scripts\bench-attachments.mjs 100,1000 --json` twice; `npm run verify`.

Risk: medium-low; cache hits still validate attachment paths and note mtimes before reuse, and regression tests cover repeated scans plus note-edit invalidation.

Score: 2 severity x 3 reach / 1 effort = 6.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an in-memory LRU cache (keyed by vault path) to `find_unused_attachments` so repeat scans reuse a precomputed reference set after a stat-only freshness check against note mtimes.

- The warm path in `getReusableAttachmentInventory` re-stats every note file to build a fresh fingerprint and compares it to the one stored at scan time (produced by `noteMtimeFingerprint` from `readAllCached`'s `mtimes` Map). Both fingerprint functions rely on `stat.mtime.getTime()`, so they produce compatible values for the same files — the only asymmetry is notes that failed to read are encoded as `"missing"` in the stored fingerprint but cause a full `undefined` return from the fresh stat fingerprint, giving conservative cache misses rather than false hits.
- The `lowerPathIndex` replaces an O(n) linear scan per reference with an O(1) Map lookup; the new first-match-wins behavior for case-folded collisions is identical to the old `for…of attachmentSet` loop that returned on the first match.
- New tests cover the repeated-scan stability and the note-edit invalidation case, with a synthetic mtime bump to guarantee the cache sees a changed fingerprint.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with minor polish; the warm path correctly invalidates on note or attachment changes and the cold path is unchanged.

The cache invalidation logic is sound — both fingerprint functions rely on the same `stat.mtime.getTime()` source and `listNotes`/`listAttachments` both sort their output, so fingerprints are stable across calls. The `referenced` Set is shared by reference from the cache but is never mutated by any call site, so there is no current data corruption risk. The minor concern is the `"missing"` vs `0` fallback asymmetry between `noteMtimeFingerprint` and `noteStatsFingerprint`, which could in theory produce a false warm-cache hit if `stats.modified` is ever null — an edge case confined to unusual filesystems. The `getVaultRootRealPath` call on every freshness check is a latent syscall overhead, not a correctness issue.

src/tools/attachments.ts — specifically the fingerprint helper functions and the cache entry interface.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/tools/attachments.ts | Core change: adds module-level LRU cache, two fingerprint functions, and cold/warm inventory helpers. The referenced Set is mutable but unexposed; fingerprint logic is sound for the happy path but has a minor asymmetry for read-failed notes. |
| src/__tests__/handlers/attachments.test.ts | Adds two targeted tests: repeated-scan stability and note-edit invalidation. Correctly bumps mtime by +5s to force fingerprint change. Test isolation relies on per-test vault directories. |
| docs/rnd/attachment-inventory-warm-path.md | R&D doc updated to "shipped" with benchmark results and decision rationale. No code logic. |
| docs/rnd/README.md | Status update: attachment inventory warm-path row changed from "active" to "shipped" with result summary. |
| CHANGELOG.md | Adds changelog entry for the warm-path cache and removes "Active" prefix from the R&D experiment line. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Caller
    participant H as find_unused_attachments handler
    participant RV as getReusableAttachmentInventory
    participant GC as getCachedAttachmentInventory
    participant FS as Filesystem / vault

    C->>H: callTool("find_unused_attachments")
    H->>FS: listAttachments()
    H->>FS: listNotes()
    H->>RV: getReusableAttachmentInventory(vaultPath, attachments, notes)
    RV->>RV: check attachmentsFingerprint in cache
    alt cold path (no cache or fingerprint mismatch)
        RV-->>H: undefined
        H->>FS: readAllCached(notes) → contents, mtimes
        H->>GC: getCachedAttachmentInventory(...)
        GC->>GC: build lowerPathIndex + basenameIndex
        GC->>GC: scan all notes → referenced Set
        GC->>GC: store entry in LRU cache
        GC-->>H: AttachmentInventoryCacheEntry
    else warm path (attachment fingerprint matches)
        RV->>FS: noteStatsFingerprint → stat each note (concurrency 16)
        alt note mtimes unchanged
            RV->>RV: LRU refresh (delete + re-set)
            RV->>RV: emit progress ticks without re-scanning
            RV-->>H: cached AttachmentInventoryCacheEntry
        else any mtime changed or stat failed
            RV-->>H: undefined (falls through to cold path)
        end
    end
    H->>H: "attachments.filter(p => !inventory.referenced.has(p))"
    H-->>C: unused attachment list
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf: cache warm attachment inventory"](https://github.com/rps321321/obsidian-mcp-pro/commit/ab86dd4415fd4fc74880bb96843a1f19804a6e42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35543074)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->