### PR TITLE
docs: stop orphan discovery warm-path R&D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Active R&D experiment for `find_orphans` warm-path performance, with a synthetic benchmark harness in `scripts/bench-orphans.mjs` and ship/kill metric in `docs/rnd/orphan-discovery-warm-path.md`.
+- R&D experiment for `find_orphans` warm-path performance, with a synthetic benchmark harness in `scripts/bench-orphans.mjs` and ship/kill metric in `docs/rnd/orphan-discovery-warm-path.md`.
 - R&D experiment for `search_by_frontmatter` warm-path performance, with a synthetic benchmark harness in `scripts/bench-frontmatter-search.mjs` and ship/kill metric in `docs/rnd/frontmatter-search-warm-path.md`.
 - R&D experiment for `resolve_alias` warm-path performance, with a synthetic benchmark harness in `scripts/bench-resolve-alias.mjs` and ship/kill metric in `docs/rnd/resolve-alias-warm-path.md`.
 - R&D experiment for `get_vault_stats` warm-path performance, with a synthetic benchmark harness in `scripts/bench-vault-stats.mjs` and ship/kill metric in `docs/rnd/vault-stats-warm-path.md`.
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The `find_orphans` warm-path R&D experiment is stopped after simple stat-concurrency and derived-category prototypes missed the ship bar.
 - `search_by_frontmatter` now reads through the shared content cache, cutting the 1,000-note warm metadata lookup bench below the R&D ship bar while preserving scalar and array frontmatter matching.
 - `resolve_alias` now reads through the shared content cache, cutting the 1,000-note warm alias lookup bench below the R&D ship bar while preserving alias matching and basename fallback output.
 - `get_vault_stats` now reuses stat metadata returned by the content cache, cutting the 1,000-note warm bench below the R&D ship bar while preserving mtime freshness and aggregate output.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Orphan Discovery Warm Path](orphan-discovery-warm-path.md) | performance / vault hygiene | active | Baseline measures cold/warm `find_orphans` and backlink-only lookup on synthetic 100 and 1,000-note vaults. |
+| [Orphan Discovery Warm Path](orphan-discovery-warm-path.md) | performance / vault hygiene | stopped | Simple stat-concurrency and derived-category prototypes missed the 24ms warm-call ship bar, so no runtime change shipped. |
 | [Frontmatter Search Warm Path](frontmatter-search-warm-path.md) | performance / metadata workflows | shipped | Warm 1,000-note `search_by_frontmatter` fell from 93.1ms to 30.8ms while cold and folder-scoped calls stayed under their guardrails. |
 | [Resolve Alias Warm Path](resolve-alias-warm-path.md) | performance / agent workflows | shipped | Warm 1,000-note `resolve_alias` fell from 86.6ms to 40.5ms while cold lookups and basename fallback stayed under their guardrails. |
 | [Vault Stats Warm Path](vault-stats-warm-path.md) | performance / observability | shipped | Warm 1,000-note `get_vault_stats` fell from 94.6ms to 40.4ms while cold and folder-scoped calls stayed under their guardrails. |

--- a/docs/rnd/orphan-discovery-warm-path.md
+++ b/docs/rnd/orphan-discovery-warm-path.md
@@ -1,7 +1,7 @@
 # Orphan Discovery Warm Path
 
-_Status: active_
-_Started: 2026-06-04 - Decided: _
+_Status: stopped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -47,9 +47,9 @@ category ordering, truncation, and line-safe path display must stay unchanged.
 
 | | before | after |
 |---|---:|---:|
-| 1,000-note warm find_orphans | 29.9ms | |
-| 1,000-note cold find_orphans guardrail | 420.6ms | |
-| 1,000-note warm find_orphans backlink-only guardrail | 31.7ms | |
+| 1,000-note warm find_orphans | 29.9ms | 28.6ms / 27.9ms (not shipped) |
+| 1,000-note cold find_orphans guardrail | 420.6ms | 440.1ms / 408.8ms (not shipped) |
+| 1,000-note warm find_orphans backlink-only guardrail | 31.7ms | 25.8ms / 25.9ms (not shipped) |
 
 ## Safety review
 
@@ -77,4 +77,16 @@ needs a persistent index or filesystem watcher to stay correct.
 
 ## Decision
 
-Open.
+Stop. Two low-risk prototypes missed the 24ms ship bar:
+
+- Raising warm graph fingerprint stat concurrency from 16 to 64 produced
+  repeated 1,000-note warm `find_orphans` calls of 29.2ms and 28.6ms.
+- Raising it to 128 produced 29.7ms and 27.9ms.
+- Precomputing derived orphan categories in the graph cache plus 64-way
+  fingerprint stats produced 27.8ms and 30.7ms.
+
+The results improved the backlink-only guardrail but did not reduce the primary
+warm full orphan lookup by 20%, and precomputing categories adds state without
+clearing the metric. No runtime change shipped. Future work should only reopen
+this with a different freshness strategy, such as a carefully bounded watcher or
+another way to avoid full warm stat validation without serving stale graph data.


### PR DESCRIPTION
Stops the `find_orphans` warm-path experiment after the simple prototypes missed the 24ms ship bar. Stat-concurrency changes and derived orphan categories improved some secondary timings, but repeated 1,000-note warm full orphan lookups still measured 27.9ms or worse, so no runtime change ships.

Tested: `npm run build`; `node scripts\bench-orphans.mjs 100,1000 --json` for the tested prototypes; `npm run verify`.

Risk: low; this updates R&D docs and changelog only.

Score: 1 severity x 2 reach / 1 effort = 2.