### PR TITLE
docs: stop graph neighbors warm-path R&D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - R&D experiment for `get_outlinks` warm-path performance, with a synthetic benchmark harness in `scripts/bench-outlinks.mjs` and ship/kill metric in `docs/rnd/outlinks-warm-path.md`.
-- Active R&D experiment for `get_graph_neighbors` warm-path performance, with a synthetic benchmark harness in `scripts/bench-graph-neighbors.mjs` and ship/kill metric in `docs/rnd/graph-neighbors-warm-path.md`.
+- R&D experiment for `get_graph_neighbors` warm-path performance, with a synthetic benchmark harness in `scripts/bench-graph-neighbors.mjs` and ship/kill metric in `docs/rnd/graph-neighbors-warm-path.md`.
 - R&D experiment for `find_orphans` warm-path performance, with a synthetic benchmark harness in `scripts/bench-orphans.mjs` and ship/kill metric in `docs/rnd/orphan-discovery-warm-path.md`.
 - R&D experiment for `search_by_frontmatter` warm-path performance, with a synthetic benchmark harness in `scripts/bench-frontmatter-search.mjs` and ship/kill metric in `docs/rnd/frontmatter-search-warm-path.md`.
 - R&D experiment for `resolve_alias` warm-path performance, with a synthetic benchmark harness in `scripts/bench-resolve-alias.mjs` and ship/kill metric in `docs/rnd/resolve-alias-warm-path.md`.
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `get_outlinks` now renders from resolved link rows captured by the shared graph cache, cutting the 1,000-note warm outlinks bench below the R&D ship bar while preserving alias resolution and valid/broken/embed grouping.
+- The `get_graph_neighbors` warm-path R&D experiment is stopped after traversal-only cleanup missed the ship bar and higher fingerprint stat concurrency exceeded guardrails.
 - The `find_orphans` warm-path R&D experiment is stopped after simple stat-concurrency and derived-category prototypes missed the ship bar.
 - `search_by_frontmatter` now reads through the shared content cache, cutting the 1,000-note warm metadata lookup bench below the R&D ship bar while preserving scalar and array frontmatter matching.
 - `resolve_alias` now reads through the shared content cache, cutting the 1,000-note warm alias lookup bench below the R&D ship bar while preserving alias matching and basename fallback output.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Graph Neighbors Warm Path](graph-neighbors-warm-path.md) | performance / vault navigation | active | Baseline measures cold/warm `get_graph_neighbors` and warm outbound traversal on synthetic 100 and 1,000-note vaults. |
+| [Graph Neighbors Warm Path](graph-neighbors-warm-path.md) | performance / vault navigation | stopped | Traversal-only cleanup missed the 23.5ms warm-call ship bar, and higher fingerprint stat concurrency exceeded guardrails. |
 | [Outlinks Warm Path](outlinks-warm-path.md) | performance / vault navigation | shipped | Warm 1,000-note `get_outlinks` fell from 40.2ms to 29.6ms while cold and mixed-output calls stayed under their guardrails. |
 | [Orphan Discovery Warm Path](orphan-discovery-warm-path.md) | performance / vault hygiene | stopped | Simple stat-concurrency and derived-category prototypes missed the 24ms warm-call ship bar, so no runtime change shipped. |
 | [Frontmatter Search Warm Path](frontmatter-search-warm-path.md) | performance / metadata workflows | shipped | Warm 1,000-note `search_by_frontmatter` fell from 93.1ms to 30.8ms while cold and folder-scoped calls stayed under their guardrails. |

--- a/docs/rnd/graph-neighbors-warm-path.md
+++ b/docs/rnd/graph-neighbors-warm-path.md
@@ -1,7 +1,7 @@
 # Graph Neighbors Warm Path
 
-_Status: active_
-_Started: 2026-06-04 - Decided: _
+_Status: stopped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -50,9 +50,9 @@ unchanged.
 
 | | before | after |
 |---|---:|---:|
-| 1,000-note warm graph_neighbors | 29.4ms | |
-| 1,000-note cold graph_neighbors guardrail | 76.4ms | |
-| 1,000-note warm outbound graph_neighbors guardrail | 26.9ms | |
+| 1,000-note warm graph_neighbors | 29.4ms | 29.6ms |
+| 1,000-note cold graph_neighbors guardrail | 76.4ms | 76.1ms |
+| 1,000-note warm outbound graph_neighbors guardrail | 26.9ms | 25.0ms |
 
 ## Safety review
 
@@ -80,4 +80,12 @@ stay correct.
 
 ## Decision
 
-Open.
+Stopped. Reusing the graph's source lookup for start-note resolution and avoiding
+the per-node neighbor array allocation did not move the primary warm metric: the
+1,000-note warm depth-2 run measured 29.6ms against the 23.5ms ship bar. Raising
+graph fingerprint stat concurrency from 64 to 128 made the fixture worse, with
+101.1ms cold, 46.5ms warm, and 39.3ms outbound runs, exceeding both guardrails.
+
+No runtime change ships. The result suggests `get_graph_neighbors` is mostly
+bound by whole-graph warm validation, and a safe next attempt needs a new
+freshness strategy rather than traversal-only cleanup.


### PR DESCRIPTION
Stops the `get_graph_neighbors` warm-path experiment after low-risk prototypes failed the metric. Reusing the graph source lookup and removing neighbor-array allocation measured 29.6ms warm against a 23.5ms ship bar, while raising fingerprint stat concurrency to 128 regressed the 1,000-note run to 101.1ms cold, 46.5ms warm, and 39.3ms outbound.

Tested: `npx vitest run src\__tests__\handlers\links.test.ts src\__tests__\regression-tools-links.test.ts`; `npm run build`; `node scripts\bench-graph-neighbors.mjs 100,1000 --json`; `npm run verify`.

Risk: low; no runtime change ships, only the stopped R&D record and changelog entry.

Score: 1 severity x 2 reach / 1 effort = 2.