### PR TITLE
docs: stop list notes warm-path R&D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - R&D experiment for `get_outlinks` warm-path performance, with a synthetic benchmark harness in `scripts/bench-outlinks.mjs` and ship/kill metric in `docs/rnd/outlinks-warm-path.md`.
-- Active R&D experiment for `list_notes` warm-path performance, with a synthetic benchmark harness in `scripts/bench-list-notes.mjs` and ship/kill metric in `docs/rnd/list-notes-warm-path.md`.
+- R&D experiment for `list_notes` warm-path performance, with a synthetic benchmark harness in `scripts/bench-list-notes.mjs` and ship/kill metric in `docs/rnd/list-notes-warm-path.md`.
 - R&D experiment for `get_graph_neighbors` warm-path performance, with a synthetic benchmark harness in `scripts/bench-graph-neighbors.mjs` and ship/kill metric in `docs/rnd/graph-neighbors-warm-path.md`.
 - R&D experiment for `find_orphans` warm-path performance, with a synthetic benchmark harness in `scripts/bench-orphans.mjs` and ship/kill metric in `docs/rnd/orphan-discovery-warm-path.md`.
 - R&D experiment for `search_by_frontmatter` warm-path performance, with a synthetic benchmark harness in `scripts/bench-frontmatter-search.mjs` and ship/kill metric in `docs/rnd/frontmatter-search-warm-path.md`.
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `get_outlinks` now renders from resolved link rows captured by the shared graph cache, cutting the 1,000-note warm outlinks bench below the R&D ship bar while preserving alias resolution and valid/broken/embed grouping.
+- The `list_notes` warm-path R&D experiment is stopped after a safe rendered-response cache missed the ship bar.
 - The `get_graph_neighbors` warm-path R&D experiment is stopped after traversal-only cleanup missed the ship bar and higher fingerprint stat concurrency exceeded guardrails.
 - The `find_orphans` warm-path R&D experiment is stopped after simple stat-concurrency and derived-category prototypes missed the ship bar.
 - `search_by_frontmatter` now reads through the shared content cache, cutting the 1,000-note warm metadata lookup bench below the R&D ship bar while preserving scalar and array frontmatter matching.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [List Notes Warm Path](list-notes-warm-path.md) | performance / agent workflows | active | Baseline measures cold/warm whole-vault `list_notes` and warm folder-scoped listing on synthetic 100 and 1,000-note vaults. |
+| [List Notes Warm Path](list-notes-warm-path.md) | performance / agent workflows | stopped | A safe rendered-response cache missed the 8.7ms warm-call ship bar, so no runtime change shipped. |
 | [Graph Neighbors Warm Path](graph-neighbors-warm-path.md) | performance / vault navigation | stopped | Traversal-only cleanup missed the 23.5ms warm-call ship bar, and higher fingerprint stat concurrency exceeded guardrails. |
 | [Outlinks Warm Path](outlinks-warm-path.md) | performance / vault navigation | shipped | Warm 1,000-note `get_outlinks` fell from 40.2ms to 29.6ms while cold and mixed-output calls stayed under their guardrails. |
 | [Orphan Discovery Warm Path](orphan-discovery-warm-path.md) | performance / vault hygiene | stopped | Simple stat-concurrency and derived-category prototypes missed the 24ms warm-call ship bar, so no runtime change shipped. |

--- a/docs/rnd/list-notes-warm-path.md
+++ b/docs/rnd/list-notes-warm-path.md
@@ -1,7 +1,7 @@
 # List Notes Warm Path
 
-_Status: active_
-_Started: 2026-06-04 - Decided: _
+_Status: stopped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -46,9 +46,9 @@ truncation, escaping, and path validation must stay unchanged.
 
 | | before | after |
 |---|---:|---:|
-| 1,000-note warm list_notes | 10.9ms | |
-| 1,000-note cold list_notes guardrail | 15.8ms | |
-| 1,000-note warm folder list_notes guardrail | 3.1ms | |
+| 1,000-note warm list_notes | 10.9ms | 10.4ms |
+| 1,000-note cold list_notes guardrail | 15.8ms | 13.8ms |
+| 1,000-note warm folder list_notes guardrail | 3.1ms | 3.9ms |
 
 ## Safety review
 
@@ -75,4 +75,11 @@ index or filesystem watcher to stay correct.
 
 ## Decision
 
-Open.
+Stopped. A rendered-response cache that still re-ran the safe `listNotes` walk
+for freshness measured 8.7ms on the first 1,000-note warm run but 10.4ms on the
+repeat, missing the 8.7ms ship bar. Cold and folder-scoped guardrails stayed
+under their limits, but the primary metric did not hold.
+
+No runtime change ships. The listing path is already fast enough that a safe
+warm improvement probably needs a broader freshness strategy shared with other
+vault file inventories, not a `list_notes`-only render cache.


### PR DESCRIPTION
Stops the `list_notes` warm-path experiment after the safe render-cache prototype missed the repeated ship metric. The first repeated 1,000-note warm run reached 8.7ms against the 8.7ms bar, but the second landed at 10.4ms; cold and folder guardrails stayed under limits, so no runtime change ships.

Tested: `npx vitest run src\__tests__\handlers\read.test.ts src\__tests__\regression-tools-read.test.ts`; `npm run build`; `node scripts\bench-list-notes.mjs 100,1000 --json` twice; `npm run verify`.

Risk: low; no runtime change ships, only the stopped R&D record and changelog entry.

Score: 1 severity x 2 reach / 1 effort = 2.