### PR TITLE
perf: stream get_note line fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Active R&D experiment for `get_note` fragment-read performance, with a synthetic benchmark harness in `scripts/bench-note-fragments.mjs` and ship/kill metric in `docs/rnd/note-fragment-warm-path.md`.
+- R&D experiment for `get_note` fragment-read performance, with a synthetic benchmark harness in `scripts/bench-note-fragments.mjs` and ship/kill metric in `docs/rnd/note-fragment-warm-path.md`.
 - R&D experiment for `get_outlinks` warm-path performance, with a synthetic benchmark harness in `scripts/bench-outlinks.mjs` and ship/kill metric in `docs/rnd/outlinks-warm-path.md`.
 - R&D experiment for `list_notes` warm-path performance, with a synthetic benchmark harness in `scripts/bench-list-notes.mjs` and ship/kill metric in `docs/rnd/list-notes-warm-path.md`.
 - R&D experiment for `get_graph_neighbors` warm-path performance, with a synthetic benchmark harness in `scripts/bench-graph-neighbors.mjs` and ship/kill metric in `docs/rnd/graph-neighbors-warm-path.md`.
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `get_note` line fragments now read only through the requested line range, cutting the 10,000-line warm fragment bench below the R&D ship bar while preserving section, block, full-note, and EOF behavior.
 - `get_outlinks` now renders from resolved link rows captured by the shared graph cache, cutting the 1,000-note warm outlinks bench below the R&D ship bar while preserving alias resolution and valid/broken/embed grouping.
 - The `list_notes` warm-path R&D experiment is stopped after a safe rendered-response cache missed the ship bar.
 - The `get_graph_neighbors` warm-path R&D experiment is stopped after traversal-only cleanup missed the ship bar and higher fingerprint stat concurrency exceeded guardrails.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Note Fragment Warm Path](note-fragment-warm-path.md) | performance / agent workflows | active | Baseline measures cold/warm line-fragment `get_note` calls plus warm section and block fragments on synthetic 1,000 and 10,000-line notes. |
+| [Note Fragment Warm Path](note-fragment-warm-path.md) | performance / agent workflows | shipped | Warm 10,000-line `get_note` line fragments fell from 2.4ms to 1.2ms while cold line, section, and block fragments stayed under their guardrails. |
 | [List Notes Warm Path](list-notes-warm-path.md) | performance / agent workflows | stopped | A safe rendered-response cache missed the 8.7ms warm-call ship bar, so no runtime change shipped. |
 | [Graph Neighbors Warm Path](graph-neighbors-warm-path.md) | performance / vault navigation | stopped | Traversal-only cleanup missed the 23.5ms warm-call ship bar, and higher fingerprint stat concurrency exceeded guardrails. |
 | [Outlinks Warm Path](outlinks-warm-path.md) | performance / vault navigation | shipped | Warm 1,000-note `get_outlinks` fell from 40.2ms to 29.6ms while cold and mixed-output calls stayed under their guardrails. |

--- a/docs/rnd/note-fragment-warm-path.md
+++ b/docs/rnd/note-fragment-warm-path.md
@@ -1,7 +1,7 @@
 # Note Fragment Warm Path
 
-_Status: active_
-_Started: 2026-06-04 - Decided: _
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -48,10 +48,10 @@ displayed errors must stay unchanged.
 
 | | before | after |
 |---|---:|---:|
-| 10,000-line warm get_note lines | 2.4ms | |
-| 10,000-line cold get_note lines guardrail | 5.2ms | |
-| 10,000-line warm get_note section guardrail | 4.7ms | |
-| 10,000-line warm get_note block guardrail | 5.5ms | |
+| 10,000-line warm get_note lines | 2.4ms | 0.9ms / 1.2ms |
+| 10,000-line cold get_note lines guardrail | 5.2ms | 3.7ms / 3.8ms |
+| 10,000-line warm get_note section guardrail | 4.7ms | 3.7ms / 3.7ms |
+| 10,000-line warm get_note block guardrail | 5.5ms | 3.9ms / 4.0ms |
 
 ## Safety review
 
@@ -75,4 +75,25 @@ implementation needs a persistent index or filesystem watcher to stay correct.
 
 ## Decision
 
-Open.
+Ship. `get_note` now routes line-only fragment reads through a bounded line
+range reader that resolves the note with the same vault-boundary checks, reads
+until the requested range is complete, and preserves the old EOF line-count
+error. Section, block, invalid line strings, and full-note reads keep the
+existing full-file path.
+
+A regression test covers line fragments without metadata headers, EOF line
+counts, and fresh reads after a note changes.
+
+Measured after the prototype with:
+
+```powershell
+npm run build
+node scripts\bench-note-fragments.mjs 1000,10000 --json
+node scripts\bench-note-fragments.mjs 1000,10000 --json
+```
+
+The repeated 10,000-line warm line-fragment calls were 0.9ms and 1.2ms, both
+below the 1.9ms ship bar. Cold line-fragment calls were 3.7ms and 3.8ms, below
+the 5.8ms guardrail. Warm section calls were 3.7ms and 3.7ms, below the 5.2ms
+guardrail, and warm block calls were 3.9ms and 4.0ms, below the 6.1ms
+guardrail.

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -185,6 +185,57 @@ describe("read handlers — get_note", () => {
     expect(text).toContain('Block not found: "^bad\\nblock" in note-a.md');
     expect(text).not.toContain("bad\nblock");
   });
+
+  it("returns line fragments without frontmatter or tag headers", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, "line-fragment.md"),
+      ["---", "status: hidden", "---", "one", "two", "three", "four"].join("\n"),
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "line-fragment.md", lines: "5-6" },
+    });
+
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toBe("two\nthree");
+    expect(text).not.toContain("Frontmatter");
+    expect(text).not.toContain("Tags:");
+  });
+
+  it("reports line fragments past EOF with the total line count", async () => {
+    await fs.writeFile(path.join(env.vaultDir, "short-lines.md"), "one\ntwo\nthree", "utf-8");
+
+    const result = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "short-lines.md", lines: "9" },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toContain("Line 9 is past end of file (3 lines)");
+  });
+
+  it("reads fresh line fragments after the note changes", async () => {
+    const fullPath = path.join(env.vaultDir, "fresh-lines.md");
+    await fs.writeFile(fullPath, "first\nold\nthird", "utf-8");
+
+    const before = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "fresh-lines.md", lines: "2" },
+    });
+    expect(textContent(before)).toBe("old");
+
+    await fs.writeFile(fullPath, "first\nnew\nthird", "utf-8");
+    const after = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "fresh-lines.md", lines: "2" },
+    });
+
+    expect(isError(after)).toBe(false);
+    expect(textContent(after)).toBe("new");
+  });
 });
 
 describe("read handlers — list_notes", () => {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1,6 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
 import { randomBytes } from "crypto";
+import { StringDecoder } from "string_decoder";
 import { mapConcurrent } from "./concurrency.js";
 import { assertAllowed, type AccessKind } from "./permissions.js";
 import { renameWithRetry } from "./fs-ops.js";
@@ -429,6 +430,80 @@ export async function readNote(
       throw new Error(`Note not found: ${relativePath}`, { cause: err });
     }
     throw err;
+  }
+}
+
+export interface NoteLineRangeRead {
+  text: string;
+  pastEndLine?: {
+    requested: number;
+    total: number;
+  };
+}
+
+export async function readNoteLineRange(
+  vaultPath: string,
+  relativePath: string,
+  startLine: number,
+  endLine: number,
+): Promise<NoteLineRangeRead> {
+  const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
+  let handle: fs.FileHandle | undefined;
+  try {
+    handle = await fs.open(fullPath, "r");
+    const decoder = new StringDecoder("utf8");
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    const collected: string[] = [];
+    let pending = "";
+    let currentLine = 1;
+
+    const processLine = (line: string): boolean => {
+      if (currentLine >= startLine && currentLine <= endLine) {
+        collected.push(line);
+      }
+      const reachedRequestedEnd = currentLine >= endLine;
+      currentLine += 1;
+      return reachedRequestedEnd;
+    };
+
+    while (true) {
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+
+      let chunk = decoder.write(buffer.subarray(0, bytesRead));
+      while (true) {
+        const newline = chunk.indexOf("\n");
+        if (newline === -1) {
+          pending += chunk;
+          break;
+        }
+        const line = pending + chunk.slice(0, newline);
+        pending = "";
+        if (processLine(line)) {
+          return { text: collected.join("\n") };
+        }
+        chunk = chunk.slice(newline + 1);
+      }
+    }
+
+    const tail = decoder.end();
+    if (tail.length > 0) pending += tail;
+    if (processLine(pending)) {
+      return { text: collected.join("\n") };
+    }
+
+    const totalLines = currentLine - 1;
+    if (startLine > totalLines) {
+      return { text: "", pastEndLine: { requested: startLine, total: totalLines } };
+    }
+    return { text: collected.join("\n") };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`Note not found: ${relativePath}`, { cause: err });
+    }
+    throw err;
+  } finally {
+    await handle?.close();
   }
 }
 

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -2,7 +2,14 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import fs from "fs/promises";
 import path from "path";
-import { searchInContents, readNote, listNotes, resolveVaultPathSafe, getVaultRootRealPath } from "../lib/vault.js";
+import {
+  searchInContents,
+  readNote,
+  readNoteLineRange,
+  listNotes,
+  resolveVaultPathSafe,
+  getVaultRootRealPath,
+} from "../lib/vault.js";
 import { readAllCached } from "../lib/index-cache.js";
 import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { log } from "../lib/logger.js";
@@ -145,6 +152,21 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
     },
     async ({ path: notePath, section, block, lines }) => {
       try {
+        if (!section && !block && lines) {
+          const m = /^(\d+)(?:-(\d+))?$/.exec(lines);
+          if (m) {
+            const a = Math.max(1, Number(m[1]));
+            const b = m[2] ? Math.max(a, Number(m[2])) : a;
+            const range = await readNoteLineRange(vaultPath, notePath, a, b);
+            if (range.pastEndLine) {
+              return errorResult(`Line ${range.pastEndLine.requested} is past end of file (${range.pastEndLine.total} lines)`);
+            }
+            return {
+              content: [{ type: "text" as const, text: range.text }],
+            };
+          }
+        }
+
         const content = await readNote(vaultPath, notePath);
 
         // Fragment modes are mutually exclusive — picking one skips the


### PR DESCRIPTION
`get_note` now handles line-only fragments with a bounded line-range reader, keeping section, block, invalid-line, and full-note reads on the existing full-file path. Repeated 10,000-line warm line fragments measured 0.9ms and 1.2ms against the 1.9ms ship bar, with cold line, section, and block guardrails all under their limits.

Tested: `npx vitest run src\__tests__\handlers\read.test.ts src\__tests__\regression-tools-read.test.ts`; `npm run build`; `node scripts\bench-note-fragments.mjs 1000,10000 --json` twice; `npm run verify`.

Risk: low; the runtime change is limited to `get_note` calls that pass `lines` without `section` or `block`, and regression tests cover metadata omission, EOF line counts, and fresh reads after edits.

Score: 2 severity x 3 reach / 1 effort = 6.