### PR TITLE
perf: cache rendered section lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Active R&D experiment for `list_sections` warm-path performance, with a synthetic benchmark harness in `scripts/bench-sections.mjs` and ship/kill metric in `docs/rnd/section-list-warm-path.md`.
+- R&D experiment for `list_sections` warm-path performance, with a synthetic benchmark harness in `scripts/bench-sections.mjs` and ship/kill metric in `docs/rnd/section-list-warm-path.md`.
 - R&D experiment for `get_note` fragment-read performance, with a synthetic benchmark harness in `scripts/bench-note-fragments.mjs` and ship/kill metric in `docs/rnd/note-fragment-warm-path.md`.
 - R&D experiment for `get_outlinks` warm-path performance, with a synthetic benchmark harness in `scripts/bench-outlinks.mjs` and ship/kill metric in `docs/rnd/outlinks-warm-path.md`.
 - R&D experiment for `list_notes` warm-path performance, with a synthetic benchmark harness in `scripts/bench-list-notes.mjs` and ship/kill metric in `docs/rnd/list-notes-warm-path.md`.
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `list_sections` now reuses a small mtime-validated rendered heading cache, cutting the 1,000-heading warm bench below the R&D ship bar while preserving heading escaping and write freshness.
 - `get_note` line fragments now read only through the requested line range, cutting the 10,000-line warm fragment bench below the R&D ship bar while preserving section, block, full-note, and EOF behavior.
 - `get_outlinks` now renders from resolved link rows captured by the shared graph cache, cutting the 1,000-note warm outlinks bench below the R&D ship bar while preserving alias resolution and valid/broken/embed grouping.
 - The `list_notes` warm-path R&D experiment is stopped after a safe rendered-response cache missed the ship bar.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Section List Warm Path](section-list-warm-path.md) | performance / agent workflows | active | Baseline measures cold/warm `list_sections` calls on synthetic 100 and 1,000-heading notes. |
+| [Section List Warm Path](section-list-warm-path.md) | performance / agent workflows | shipped | Warm 1,000-heading `list_sections` fell from 3.2ms to 1.2ms while cold stayed under the guardrail. |
 | [Note Fragment Warm Path](note-fragment-warm-path.md) | performance / agent workflows | shipped | Warm 10,000-line `get_note` line fragments fell from 2.4ms to 1.2ms while cold line, section, and block fragments stayed under their guardrails. |
 | [List Notes Warm Path](list-notes-warm-path.md) | performance / agent workflows | stopped | A safe rendered-response cache missed the 8.7ms warm-call ship bar, so no runtime change shipped. |
 | [Graph Neighbors Warm Path](graph-neighbors-warm-path.md) | performance / vault navigation | stopped | Traversal-only cleanup missed the 23.5ms warm-call ship bar, and higher fingerprint stat concurrency exceeded guardrails. |

--- a/docs/rnd/section-list-warm-path.md
+++ b/docs/rnd/section-list-warm-path.md
@@ -1,7 +1,7 @@
 # Section List Warm Path
 
-_Status: active_
-_Started: 2026-06-04 - Decided: _
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -44,8 +44,8 @@ heading text, and missing-note/no-heading behavior must stay unchanged.
 
 | | before | after |
 |---|---:|---:|
-| 1,000-heading warm list_sections | 3.2ms | |
-| 1,000-heading cold list_sections guardrail | 5.9ms | |
+| 1,000-heading warm list_sections | 3.2ms | 1.4ms / 1.2ms |
+| 1,000-heading cold list_sections guardrail | 5.9ms | 5.6ms / 5.6ms |
 
 ## Safety review
 
@@ -69,4 +69,23 @@ persistent index or filesystem watcher to stay correct.
 
 ## Decision
 
-Open.
+Ship. `list_sections` now renders through a small cache keyed by vault path and
+note path, and reuses the rendered heading list only when the current resolved
+path, size, and mtime match. Cache misses read the already-validated full path
+directly, preserving the vault-boundary check while avoiding duplicate path
+resolution. Section write tools invalidate the cached heading list after
+successful same-process edits.
+
+A regression test warms `list_sections`, edits a same-size heading through
+`replace_in_note`, and verifies the next heading list reflects the new heading.
+
+Measured after the prototype with:
+
+```powershell
+npm run build
+node scripts\bench-sections.mjs 100,1000 --json
+node scripts\bench-sections.mjs 100,1000 --json
+```
+
+The repeated 1,000-heading warm calls were 1.4ms and 1.2ms, both below the
+2.6ms ship bar. Cold calls were 5.6ms and 5.6ms, below the 6.5ms guardrail.

--- a/src/__tests__/regression-tools-sections.test.ts
+++ b/src/__tests__/regression-tools-sections.test.ts
@@ -211,6 +211,38 @@ describe("regression: section tool output escaping", () => {
     expect(text).not.toContain("Dirty\tHeading");
   });
 
+  it("re-renders list_sections after a same-size heading edit", async () => {
+    await fs.writeFile(path.join(env.vaultDir, "cached-heading.md"), "# Old\n\nBody\n", "utf-8");
+
+    const before = await env.client.callTool({
+      name: "list_sections",
+      arguments: { path: "cached-heading.md" },
+    });
+    expect(isError(before)).toBe(false);
+    expect(textContent(before)).toContain("# Old");
+
+    const edit = await env.client.callTool({
+      name: "replace_in_note",
+      arguments: {
+        path: "cached-heading.md",
+        find: "Old",
+        replace: "New",
+        expectedCount: 1,
+      },
+    });
+    expect(isError(edit)).toBe(false);
+
+    const after = await env.client.callTool({
+      name: "list_sections",
+      arguments: { path: "cached-heading.md" },
+    });
+
+    const text = textContent(after);
+    expect(isError(after)).toBe(false);
+    expect(text).toContain("# New");
+    expect(text).not.toContain("# Old");
+  });
+
   it("escapes control characters in update_section success output", async () => {
     await fs.writeFile(
       path.join(env.vaultDir, "update-dirty-heading.md"),

--- a/src/tools/sections.ts
+++ b/src/tools/sections.ts
@@ -1,6 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { updateNote } from "../lib/vault.js";
+import fs from "fs/promises";
+import path from "path";
+import { readNote, resolveVaultPathSafe, updateNote } from "../lib/vault.js";
 import {
   findSection,
   findBlockById,
@@ -10,6 +12,17 @@ import {
 } from "../lib/sections.js";
 import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { log } from "../lib/logger.js";
+
+const SECTION_LIST_CACHE_LIMIT = 16;
+
+interface SectionListCacheEntry {
+  fullPath: string;
+  size: number;
+  mtimeMs: number;
+  text: string;
+}
+
+const sectionListCache = new Map<string, SectionListCacheEntry>();
 
 function textResult(text: string) {
   return { content: [{ type: "text" as const, text }] };
@@ -24,6 +37,74 @@ const displaySectionValue = escapeControlChars;
 
 function splitHeadingPath(section: string): string[] {
   return section.split("/").map((s) => s.trim()).filter(Boolean);
+}
+
+function sectionListCacheKey(vaultPath: string, notePath: string): string {
+  return `${path.resolve(vaultPath)}\0${notePath}`;
+}
+
+async function getSectionListSignature(
+  vaultPath: string,
+  notePath: string,
+): Promise<{ fullPath: string; size: number; mtimeMs: number }> {
+  const fullPath = await resolveVaultPathSafe(vaultPath, notePath);
+  try {
+    const stats = await fs.stat(fullPath);
+    return { fullPath, size: stats.size, mtimeMs: stats.mtimeMs };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      await readNote(vaultPath, notePath);
+    }
+    throw err;
+  }
+}
+
+function renderSectionList(notePath: string, content: string): string {
+  const headings = parseHeadings(content);
+  if (headings.length === 0) return `No headings in ${displaySectionValue(notePath)}`;
+  const lines = [`${headings.length} heading(s) in ${displaySectionValue(notePath)}:`, ""];
+  for (const h of headings) {
+    lines.push(`${"  ".repeat(h.level - 1)}${"#".repeat(h.level)} ${displaySectionValue(h.text)}`);
+  }
+  return lines.join("\n");
+}
+
+async function readSectionListCached(vaultPath: string, notePath: string): Promise<string> {
+  const signature = await getSectionListSignature(vaultPath, notePath);
+  const key = sectionListCacheKey(vaultPath, notePath);
+  const cached = sectionListCache.get(key);
+  if (
+    cached &&
+    cached.fullPath === signature.fullPath &&
+    cached.size === signature.size &&
+    cached.mtimeMs === signature.mtimeMs
+  ) {
+    sectionListCache.delete(key);
+    sectionListCache.set(key, cached);
+    return cached.text;
+  }
+
+  let content: string;
+  try {
+    content = await fs.readFile(signature.fullPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`Note not found: ${notePath}`, { cause: err });
+    }
+    throw err;
+  }
+  const text = renderSectionList(notePath, content);
+  sectionListCache.set(key, { ...signature, text });
+  while (sectionListCache.size > SECTION_LIST_CACHE_LIMIT) {
+    const oldestKey = sectionListCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    sectionListCache.delete(oldestKey);
+  }
+  return text;
+}
+
+function invalidateSectionListCache(vaultPath: string, notePath: string): void {
+  sectionListCache.delete(sectionListCacheKey(vaultPath, notePath));
 }
 
 export function registerSectionTools(server: McpServer, vaultPath: string): void {
@@ -73,6 +154,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
           bodyBytes = Buffer.byteLength(newBody, "utf-8");
           return updated;
         });
+        invalidateSectionListCache(vaultPath, notePath);
         return textResult(
           `Updated section "${displaySectionValue(resolvedHeading)}" in ${displaySectionValue(notePath)} (${bodyBytes} bytes of new body)`,
         );
@@ -136,6 +218,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
           if (!payload.endsWith("\n")) payload += "\n";
           return before + payload + after;
         });
+        invalidateSectionListCache(vaultPath, notePath);
         return textResult(
           `Inserted ${Buffer.byteLength(content, "utf-8")} bytes into "${displaySectionValue(resolvedHeading)}" (${position}) in ${displaySectionValue(notePath)}`,
         );
@@ -163,15 +246,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
     },
     async ({ path: notePath }) => {
       try {
-        const { readNote } = await import("../lib/vault.js");
-        const content = await readNote(vaultPath, notePath);
-        const headings = parseHeadings(content);
-        if (headings.length === 0) return textResult(`No headings in ${displaySectionValue(notePath)}`);
-        const lines = [`${headings.length} heading(s) in ${displaySectionValue(notePath)}:`, ""];
-        for (const h of headings) {
-          lines.push(`${"  ".repeat(h.level - 1)}${"#".repeat(h.level)} ${displaySectionValue(h.text)}`);
-        }
-        return textResult(lines.join("\n"));
+        return textResult(await readSectionListCached(vaultPath, notePath));
       } catch (err) {
         log.error("list_sections failed", { tool: "list_sections", err: err as Error });
         return errorResult(`Error listing sections: ${sanitizeError(err)}`);
@@ -275,6 +350,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
             ? existing.replace(pattern, replace)
             : existing.replace(pattern, () => replace);
         });
+        invalidateSectionListCache(vaultPath, notePath);
         return textResult(
           count === 0
             ? `No matches in ${displaySectionValue(notePath)} - file unchanged.`
@@ -330,6 +406,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
           const replacement = isMultiline ? `${body}\n^${block}\n` : `${body} ^${block}\n`;
           return before + replacement + after;
         });
+        invalidateSectionListCache(vaultPath, notePath);
         return textResult(`Updated block ^${displaySectionValue(block)} in ${displaySectionValue(notePath)}`);
       } catch (err) {
         log.error("edit_block failed", { tool: "edit_block", err: err as Error });


### PR DESCRIPTION
`list_sections` now reuses a small rendered heading cache validated by the note's resolved path, size, and mtime. Section write tools invalidate the cached heading list after same-process edits, and the cache miss path reads the already-validated full path to avoid duplicate path resolution.

Repeated 1,000-heading warm calls measured 1.4ms and 1.2ms against the 2.6ms ship bar, with cold calls at 5.6ms and 5.6ms under the 6.5ms guardrail.

Tested: `npx vitest run src\__tests__\regression-tools-sections.test.ts`; `npm run build`; `node scripts\bench-sections.mjs 100,1000 --json` twice after the final cold-path cleanup; `npm run verify`.

Risk: low; the cache is bounded, mtime/size-validated, and only affects `list_sections` rendering. Same-size heading edits are covered by a regression test.

Score: 2 severity x 3 reach / 1 effort = 6.