### PR TITLE
chore: stop section read warm-path R&D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `list_sections` now reuses a small mtime-validated rendered heading cache, cutting the 1,000-heading warm bench below the R&D ship bar while preserving heading escaping and write freshness.
+- The `get_note` section-read warm-path R&D experiment is stopped after cache and streaming-parser prototypes missed the cold or warm ship bar.
 - `get_note` line fragments now read only through the requested line range, cutting the 10,000-line warm fragment bench below the R&D ship bar while preserving section, block, full-note, and EOF behavior.
 - `get_outlinks` now renders from resolved link rows captured by the shared graph cache, cutting the 1,000-note warm outlinks bench below the R&D ship bar while preserving alias resolution and valid/broken/embed grouping.
 - The `list_notes` warm-path R&D experiment is stopped after a safe rendered-response cache missed the ship bar.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Section Read Warm Path](section-read-warm-path.md) | performance / agent workflows | active | Baseline measures cold/warm late-section `get_note` calls plus warm early-section calls on synthetic 100 and 1,000-section notes. |
+| [Section Read Warm Path](section-read-warm-path.md) | performance / agent workflows | stopped | Cache and streaming-parser prototypes missed the cold or warm ship bar, so no runtime change shipped. |
 | [Section List Warm Path](section-list-warm-path.md) | performance / agent workflows | shipped | Warm 1,000-heading `list_sections` fell from 3.2ms to 1.2ms while cold stayed under the guardrail. |
 | [Note Fragment Warm Path](note-fragment-warm-path.md) | performance / agent workflows | shipped | Warm 10,000-line `get_note` line fragments fell from 2.4ms to 1.2ms while cold line, section, and block fragments stayed under their guardrails. |
 | [List Notes Warm Path](list-notes-warm-path.md) | performance / agent workflows | stopped | A safe rendered-response cache missed the 8.7ms warm-call ship bar, so no runtime change shipped. |

--- a/docs/rnd/section-read-warm-path.md
+++ b/docs/rnd/section-read-warm-path.md
@@ -1,7 +1,7 @@
 # Section Read Warm Path
 
-_Status: active_
-_Started: 2026-06-04 - Decided: _
+_Status: stopped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -46,9 +46,9 @@ vault-boundary checks must stay unchanged.
 
 | | before | after |
 |---|---:|---:|
-| 1,000-section warm late get_note section | 2.5ms | |
-| 1,000-section cold late get_note section guardrail | 5.6ms | |
-| 1,000-section warm early get_note section guardrail | 2.0ms | |
+| 1,000-section warm late get_note section | 2.5ms | 2.2ms |
+| 1,000-section cold late get_note section guardrail | 5.6ms | 5.8ms |
+| 1,000-section warm early get_note section guardrail | 2.0ms | 1.6ms |
 
 ## Safety review
 
@@ -72,4 +72,8 @@ implementation needs a persistent index or filesystem watcher to stay correct.
 
 ## Decision
 
-Open.
+Stopped. A small rendered section cache cut warm repeated reads but added too
+much cold-read variance; one 1,000-section cold run hit 9.0ms against the
+6.2ms guardrail. A narrower streaming section finder preserved cold reads, but
+the slower two-run sample still hit 2.2ms for the 1,000-section warm late read,
+above the 2.0ms ship bar. No runtime change shipped.


### PR DESCRIPTION
Stops the section-read warm-path R&D after both cache and streaming parser prototypes missed the documented ship or guardrail bars. This keeps the negative result visible so future performance work starts from new evidence instead of repeating the same shapes.

Risk: docs-only. Tested with `npm run verify`.

Score: 2 x 4 / 1 = 8; low severity, but section reads are common in agent workflows and the cleanup prevents stale follow-up work.