### PR TITLE
chore: stop daily note warm-path R&D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `list_sections` now reuses a small mtime-validated rendered heading cache, cutting the 1,000-heading warm bench below the R&D ship bar while preserving heading escaping and write freshness.
+- The `get_daily_note` warm-path R&D experiment is stopped after config and rendered-response cache prototypes missed the warm ship bar or exceeded guardrails.
 - The `get_note` section-read warm-path R&D experiment is stopped after cache and streaming-parser prototypes missed the cold or warm ship bar.
 - `get_note` line fragments now read only through the requested line range, cutting the 10,000-line warm fragment bench below the R&D ship bar while preserving section, block, full-note, and EOF behavior.
 - `get_outlinks` now renders from resolved link rows captured by the shared graph cache, cutting the 1,000-note warm outlinks bench below the R&D ship bar while preserving alias resolution and valid/broken/embed grouping.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Daily Note Warm Path](daily-note-warm-path.md) | performance / agent workflows | active | Baseline measures cold/warm configured `get_daily_note` calls plus warm other-date calls on synthetic 100 and 1,000-line daily notes. |
+| [Daily Note Warm Path](daily-note-warm-path.md) | performance / agent workflows | stopped | Config and rendered-response cache prototypes missed the warm ship bar or exceeded guardrails, so no runtime change shipped. |
 | [Section Read Warm Path](section-read-warm-path.md) | performance / agent workflows | stopped | Cache and streaming-parser prototypes missed the cold or warm ship bar, so no runtime change shipped. |
 | [Section List Warm Path](section-list-warm-path.md) | performance / agent workflows | shipped | Warm 1,000-heading `list_sections` fell from 3.2ms to 1.2ms while cold stayed under the guardrail. |
 | [Note Fragment Warm Path](note-fragment-warm-path.md) | performance / agent workflows | shipped | Warm 10,000-line `get_note` line fragments fell from 2.4ms to 1.2ms while cold line, section, and block fragments stayed under their guardrails. |

--- a/docs/rnd/daily-note-warm-path.md
+++ b/docs/rnd/daily-note-warm-path.md
@@ -1,7 +1,7 @@
 # Daily Note Warm Path
 
-_Status: active_
-_Started: 2026-06-04 - Decided: _
+_Status: stopped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -47,9 +47,9 @@ unchanged.
 
 | | before | after |
 |---|---:|---:|
-| 1,000-line warm get_daily_note | 1.9ms | |
-| 1,000-line cold get_daily_note guardrail | 7.1ms | |
-| 1,000-line warm get_daily_note other-date guardrail | 2.2ms | |
+| 1,000-line warm get_daily_note | 1.9ms | 2.0ms |
+| 1,000-line cold get_daily_note guardrail | 7.1ms | 7.6ms |
+| 1,000-line warm get_daily_note other-date guardrail | 2.2ms | 2.4ms |
 
 ## Safety review
 
@@ -74,4 +74,9 @@ watcher to stay correct.
 
 ## Decision
 
-Open.
+Stopped. An mtime/size/ctime-validated daily-note config cache preserved config
+freshness but still missed the primary warm bar, with the slower 1,000-line warm
+call at 2.0ms against the 1.5ms target. A rendered daily-note response cache
+added note metadata validation but made the fixture worse, including a
+21.2ms cold run and 4.3ms warm other-date run, both beyond guardrails. No
+runtime change shipped.


### PR DESCRIPTION
Stops the Daily Note Warm Path experiment after the measured cache prototypes missed the documented bar. The config cache preserved freshness but only reached 2.0ms against the 1.5ms warm target, and the rendered-response cache exceeded cold and other-date guardrails.

Risk: docs-only. Tested with focused read/write handler tests, `node scripts\bench-daily-notes.mjs 100,1000 --json`, and `npm run verify`.

Score: 2 x 3 / 1 = 6; daily notes are common, and recording the miss prevents retrying stale cache shapes without new evidence.