### PR TITLE
chore: start chunker boundary rnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Active R&D experiment for chunker boundary quality, with a synthetic fixture in `scripts/bench-chunker-quality.mjs` and ship/kill metric in `docs/rnd/chunker-boundary-quality.md`.
 - Active R&D experiment for `get_daily_note` warm-path performance, with a synthetic benchmark harness in `scripts/bench-daily-notes.mjs` and ship/kill metric in `docs/rnd/daily-note-warm-path.md`.
 - Active R&D experiment for `get_note` section-read performance, with a synthetic benchmark harness in `scripts/bench-section-reads.mjs` and ship/kill metric in `docs/rnd/section-read-warm-path.md`.
 - R&D experiment for `list_sections` warm-path performance, with a synthetic benchmark harness in `scripts/bench-sections.mjs` and ship/kill metric in `docs/rnd/section-list-warm-path.md`.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,6 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
+| [Chunker Boundary Quality](chunker-boundary-quality.md) | retrieval quality | active | Baseline score is 88.0 with two fenced-code fractures; next step is a chunker prototype that keeps code fences intact without raising token load above 1.30x. |
 | [Daily Note Warm Path](daily-note-warm-path.md) | performance / agent workflows | stopped | Config and rendered-response cache prototypes missed the warm ship bar or exceeded guardrails, so no runtime change shipped. |
 | [Section Read Warm Path](section-read-warm-path.md) | performance / agent workflows | stopped | Cache and streaming-parser prototypes missed the cold or warm ship bar, so no runtime change shipped. |
 | [Section List Warm Path](section-list-warm-path.md) | performance / agent workflows | shipped | Warm 1,000-heading `list_sections` fell from 3.2ms to 1.2ms while cold stayed under the guardrail. |

--- a/docs/rnd/chunker-boundary-quality.md
+++ b/docs/rnd/chunker-boundary-quality.md
@@ -1,0 +1,71 @@
+# Chunker Boundary Quality
+
+_Status: active_
+_Started: 2026-06-04 - Decided: pending_
+
+## Hypothesis
+
+Semantic indexing chunks are more useful when they keep title and heading context
+and do not slice syntax boundaries such as fenced code blocks. The current chunker
+keeps heading context well, but long fenced blocks can still be split by the
+character-window fallback.
+
+## Fixture
+
+The fixture is `scripts/bench-chunker-quality.mjs`.
+
+It builds three synthetic notes:
+
+- `project-playbook`: frontmatter title and aliases plus H1/H2/H3 sections.
+- `code-reference`: a long fenced TypeScript block under a heading.
+- `dense-meeting-log`: dense meeting notes with tasks and follow-up headings.
+
+Run:
+
+```powershell
+npm run build
+node scripts/bench-chunker-quality.mjs --json
+```
+
+## Metric
+
+Primary metric: weighted boundary score from the fixture. A perfect score is 100.
+The score penalizes chunks that split fenced code blocks, exceed the target size,
+or lose title/heading prefixes.
+
+Ship bar: reach at least 95 with zero fenced-code fractures, mean token-load ratio
+at or below 1.30x, and no more than 24 chunks on the fixture.
+
+| metric | before | after |
+|---|---:|---:|
+| Boundary score | 88.0 | |
+| Fenced-code fractures | 2 | |
+| Oversize chunks | 0 | |
+| Heading prefix coverage | 100% | |
+| Title prefix coverage | 100% | |
+| Mean token-load ratio | 1.18x | |
+| Chunk count | 21 | |
+
+Baseline command samples:
+
+- `node scripts/bench-chunker-quality.mjs --json`: score 88.0, two fence
+  fractures, 21 chunks, 1.18x mean token load.
+- `node scripts/bench-chunker-quality.mjs --json`: score 88.0, two fence
+  fractures, 21 chunks, 1.18x mean token load.
+
+## Safety review
+
+The fixture generates note bodies in memory and calls the compiled chunker
+directly. It performs no vault reads, no vault writes, no embedding-provider calls,
+and no network calls. Output contains only synthetic fixture text and aggregate
+metrics. Rollback is removing the script and this R&D document.
+
+## Kill criterion
+
+Stop if fenced-code fractures cannot reach zero without pushing token load above
+1.30x, producing more than 24 chunks, or changing the public semantic tool surface.
+
+## Decision
+
+Active. The next step is a chunker prototype that preserves fenced-code boundaries
+while keeping the existing title and heading prefix behavior.

--- a/scripts/bench-chunker-quality.mjs
+++ b/scripts/bench-chunker-quality.mjs
@@ -1,0 +1,205 @@
+// Chunker boundary-quality benchmark: generate synthetic notes that exercise
+// semantic indexing chunk boundaries, then score the resulting chunks.
+//
+// Direct use: node scripts/bench-chunker-quality.mjs [--json]
+// Run after `npm run build`.
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { performance } from "node:perf_hooks";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const chunkerEntry = join(root, "build", "lib", "chunker.js");
+
+const OPTIONS = {
+  targetChars: 900,
+  overlapChars: 120,
+};
+
+function repeatSentences(seed, count) {
+  const lines = [];
+  for (let i = 1; i <= count; i++) {
+    lines.push(`${seed} Detail ${String(i).padStart(2, "0")} keeps enough text for a real embedding-sized paragraph.`);
+  }
+  return lines.join(" ");
+}
+
+function makeCodeBlock(lineCount) {
+  const lines = ["```ts", "export function importantBoundaryCase(input: string): string {"];
+  for (let i = 1; i <= lineCount; i++) {
+    lines.push(`  const value${i} = input.trim().toLowerCase() + "-case-${i}";`);
+  }
+  lines.push("  return value1;", "}", "```");
+  return lines.join("\n");
+}
+
+const fixtures = [
+  {
+    name: "project-playbook",
+    expectedTitle: "Atlas Playbook / Project Atlas",
+    content: [
+      "---",
+      "title: Atlas Playbook",
+      "aliases: [Project Atlas]",
+      "---",
+      "# Atlas",
+      repeatSentences("The overview explains owners, milestones, and constraints.", 8),
+      "## Research",
+      repeatSentences("Research notes compare candidate retrieval behavior.", 11),
+      "### Open Questions",
+      repeatSentences("The open-question list tracks decisions that need evidence.", 6),
+      "## Ship Plan",
+      repeatSentences("The ship plan records release gates and rollback notes.", 10),
+    ].join("\n\n"),
+  },
+  {
+    name: "code-reference",
+    expectedTitle: "Chunker Code Reference",
+    content: [
+      "---",
+      "title: Chunker Code Reference",
+      "---",
+      "# Reference",
+      "This note keeps one long fenced code block under a heading so the fixture can detect fence splits.",
+      "## Reference Implementation",
+      makeCodeBlock(44),
+      "## Release Checklist",
+      repeatSentences("Checklist items should not bleed into implementation chunks.", 7),
+    ].join("\n\n"),
+  },
+  {
+    name: "dense-meeting-log",
+    expectedTitle: "Daily Research Log / R&D Log",
+    content: [
+      "---",
+      "title: Daily Research Log",
+      "aliases: [R&D Log]",
+      "---",
+      "# Daily Research",
+      "## Morning Review",
+      repeatSentences("The morning review captures short operational notes.", 8),
+      "## Decisions",
+      repeatSentences("Decision paragraphs stay dense enough to force paragraph grouping without losing heading context.", 16),
+      "### Follow-ups",
+      "- [ ] Re-run the retrieval fixture.",
+      "- [ ] Compare semantic hit snippets.",
+      "- [ ] Record the decision before changing runtime behavior.",
+    ].join("\n\n"),
+  },
+];
+
+function countFenceMarkers(text) {
+  return text.match(/^```/gm)?.length ?? 0;
+}
+
+function scoreFixture(note, chunks) {
+  let headingChunks = 0;
+  let headingPrefixHits = 0;
+  let titledChunks = 0;
+  let titlePrefixHits = 0;
+  let codeFenceFractures = 0;
+  let oversizeChunks = 0;
+  let totalChunkChars = 0;
+
+  for (const chunk of chunks) {
+    totalChunkChars += chunk.text.length;
+    if (chunk.text.length > OPTIONS.targetChars * 1.1) {
+      oversizeChunks++;
+    }
+    if (note.expectedTitle) {
+      titledChunks++;
+      if (chunk.text.startsWith(note.expectedTitle)) {
+        titlePrefixHits++;
+      }
+    }
+    if (chunk.headingPath.length > 0) {
+      headingChunks++;
+      const headingPrefix = `${chunk.headingPath.join(" / ")}\n\n`;
+      if (chunk.text.includes(headingPrefix)) {
+        headingPrefixHits++;
+      }
+    }
+    if (countFenceMarkers(chunk.text) % 2 !== 0) {
+      codeFenceFractures++;
+    }
+  }
+
+  const missingHeadingPrefixes = headingChunks - headingPrefixHits;
+  const missingTitlePrefixes = titledChunks - titlePrefixHits;
+  const score = Math.max(
+    0,
+    100
+      - codeFenceFractures * 18
+      - oversizeChunks * 10
+      - missingHeadingPrefixes * 8
+      - missingTitlePrefixes * 6,
+  );
+
+  return {
+    chunks: chunks.length,
+    score,
+    codeFenceFractures,
+    oversizeChunks,
+    headingPrefixCoverage: headingChunks === 0 ? 1 : headingPrefixHits / headingChunks,
+    titlePrefixCoverage: titledChunks === 0 ? 1 : titlePrefixHits / titledChunks,
+    tokenLoadRatio: totalChunkChars / note.content.length,
+  };
+}
+
+export async function runChunkerQualityBench() {
+  const { chunkNote } = await import(pathToFileURL(chunkerEntry).href);
+  const start = performance.now();
+  const rows = fixtures.map((note) => {
+    const chunks = chunkNote(note.content, OPTIONS);
+    return {
+      fixture: note.name,
+      ...scoreFixture(note, chunks),
+    };
+  });
+  const elapsedMs = performance.now() - start;
+  const totalChunks = rows.reduce((sum, row) => sum + row.chunks, 0);
+  const weightedScore = rows.reduce((sum, row) => sum + row.score * row.chunks, 0) / totalChunks;
+  const codeFenceFractures = rows.reduce((sum, row) => sum + row.codeFenceFractures, 0);
+  const oversizeChunks = rows.reduce((sum, row) => sum + row.oversizeChunks, 0);
+  const tokenLoadRatio = rows.reduce((sum, row) => sum + row.tokenLoadRatio, 0) / rows.length;
+
+  return {
+    options: OPTIONS,
+    notes: fixtures.length,
+    chunks: totalChunks,
+    elapsedMs,
+    boundaryScore: weightedScore,
+    codeFenceFractures,
+    oversizeChunks,
+    meanTokenLoadRatio: tokenLoadRatio,
+    rows,
+  };
+}
+
+const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (invokedDirectly) {
+  if (!existsSync(chunkerEntry)) {
+    console.error("build/lib/chunker.js missing - run `npm run build` first.");
+    process.exit(1);
+  }
+  const asJson = process.argv.includes("--json");
+  const result = await runChunkerQualityBench();
+  if (asJson) {
+    console.log(JSON.stringify(result));
+  } else {
+    console.log(`boundary score ${result.boundaryScore.toFixed(1)}`);
+    console.log(`chunks ${result.chunks}`);
+    console.log(`code fence fractures ${result.codeFenceFractures}`);
+    console.log(`oversize chunks ${result.oversizeChunks}`);
+    console.log(`mean token load ratio ${result.meanTokenLoadRatio.toFixed(2)}x`);
+    console.log(`elapsed ${result.elapsedMs.toFixed(2)}ms`);
+    console.log("\n| fixture | chunks | score | fence fractures | oversize | heading prefix | title prefix | token load |");
+    console.log("|---|---:|---:|---:|---:|---:|---:|---:|");
+    for (const row of result.rows) {
+      console.log(
+        `| ${row.fixture} | ${row.chunks} | ${row.score.toFixed(1)} | ${row.codeFenceFractures} | ${row.oversizeChunks} | ${(row.headingPrefixCoverage * 100).toFixed(0)}% | ${(row.titlePrefixCoverage * 100).toFixed(0)}% | ${row.tokenLoadRatio.toFixed(2)}x |`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
Adds a chunker boundary-quality R&D fixture and records the current semantic chunking baseline. The fixture scores title/heading prefix coverage, oversize chunks, fenced-code fractures, token load, and chunk count so future retrieval changes have a measured target.

Score: 1 severity x 3 reach / 1 effort = 3. Semantic chunking feeds every indexed note, and this gives retrieval work a measured target without changing runtime behavior.

Risk: low; docs and benchmark only, no public API change.

Tests: npm run verify; node scripts/bench-chunker-quality.mjs --json.

Greptile skipped because the review quota is exhausted.