### PR TITLE
fix: keep chunked code fences balanced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Active R&D experiment for chunker boundary quality, with a synthetic fixture in `scripts/bench-chunker-quality.mjs` and ship/kill metric in `docs/rnd/chunker-boundary-quality.md`.
+- R&D experiment for chunker boundary quality, with a synthetic fixture in `scripts/bench-chunker-quality.mjs` and ship/kill metric in `docs/rnd/chunker-boundary-quality.md`.
 - Active R&D experiment for `get_daily_note` warm-path performance, with a synthetic benchmark harness in `scripts/bench-daily-notes.mjs` and ship/kill metric in `docs/rnd/daily-note-warm-path.md`.
 - Active R&D experiment for `get_note` section-read performance, with a synthetic benchmark harness in `scripts/bench-section-reads.mjs` and ship/kill metric in `docs/rnd/section-read-warm-path.md`.
 - R&D experiment for `list_sections` warm-path performance, with a synthetic benchmark harness in `scripts/bench-sections.mjs` and ship/kill metric in `docs/rnd/section-list-warm-path.md`.
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Semantic chunking now keeps oversized fenced code blocks fence-balanced when splitting them for embeddings, preserving title and heading prefixes while leaving non-code chunking behavior unchanged.
 - `list_sections` now reuses a small mtime-validated rendered heading cache, cutting the 1,000-heading warm bench below the R&D ship bar while preserving heading escaping and write freshness.
 - The `get_daily_note` warm-path R&D experiment is stopped after config and rendered-response cache prototypes missed the warm ship bar or exceeded guardrails.
 - The `get_note` section-read warm-path R&D experiment is stopped after cache and streaming-parser prototypes missed the cold or warm ship bar.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Chunker Boundary Quality](chunker-boundary-quality.md) | retrieval quality | active | Baseline score is 88.0 with two fenced-code fractures; next step is a chunker prototype that keeps code fences intact without raising token load above 1.30x. |
+| [Chunker Boundary Quality](chunker-boundary-quality.md) | retrieval quality | shipped | Score rose from 88.0 to 100.0, fenced-code fractures fell from two to zero, chunk count stayed at 21, and mean token load fell to 1.15x. |
 | [Daily Note Warm Path](daily-note-warm-path.md) | performance / agent workflows | stopped | Config and rendered-response cache prototypes missed the warm ship bar or exceeded guardrails, so no runtime change shipped. |
 | [Section Read Warm Path](section-read-warm-path.md) | performance / agent workflows | stopped | Cache and streaming-parser prototypes missed the cold or warm ship bar, so no runtime change shipped. |
 | [Section List Warm Path](section-list-warm-path.md) | performance / agent workflows | shipped | Warm 1,000-heading `list_sections` fell from 3.2ms to 1.2ms while cold stayed under the guardrail. |

--- a/docs/rnd/chunker-boundary-quality.md
+++ b/docs/rnd/chunker-boundary-quality.md
@@ -1,7 +1,7 @@
 # Chunker Boundary Quality
 
-_Status: active_
-_Started: 2026-06-04 - Decided: pending_
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -38,13 +38,13 @@ at or below 1.30x, and no more than 24 chunks on the fixture.
 
 | metric | before | after |
 |---|---:|---:|
-| Boundary score | 88.0 | |
-| Fenced-code fractures | 2 | |
-| Oversize chunks | 0 | |
-| Heading prefix coverage | 100% | |
-| Title prefix coverage | 100% | |
-| Mean token-load ratio | 1.18x | |
-| Chunk count | 21 | |
+| Boundary score | 88.0 | 100.0 |
+| Fenced-code fractures | 2 | 0 |
+| Oversize chunks | 0 | 0 |
+| Heading prefix coverage | 100% | 100% |
+| Title prefix coverage | 100% | 100% |
+| Mean token-load ratio | 1.18x | 1.15x |
+| Chunk count | 21 | 21 |
 
 Baseline command samples:
 
@@ -67,5 +67,22 @@ Stop if fenced-code fractures cannot reach zero without pushing token load above
 
 ## Decision
 
-Active. The next step is a chunker prototype that preserves fenced-code boundaries
-while keeping the existing title and heading prefix behavior.
+Ship. Oversized fenced code blocks now split by lines into chunks that carry the
+original opening and closing fence. Non-code paragraphs keep the existing
+paragraph and character-window behavior. Code-block splits skip copied line
+overlap because the wrapper fences already preserve boundary context and the
+experiment's token/chunk-load bars are tighter without duplicate code lines.
+
+A regression test forces a large fenced block through the chunker and verifies
+every emitted code chunk has a balanced opening and closing fence.
+
+Measured after the prototype with:
+
+```powershell
+npm run build
+node scripts/bench-chunker-quality.mjs --json
+node scripts/bench-chunker-quality.mjs --json
+```
+
+Both runs scored 100.0 with zero fenced-code fractures, zero oversize chunks,
+21 chunks, and 1.15x mean token load.

--- a/src/__tests__/chunker.test.ts
+++ b/src/__tests__/chunker.test.ts
@@ -40,6 +40,37 @@ describe("chunkNote", () => {
     }
   });
 
+  it("keeps oversized fenced code chunks fence-balanced", () => {
+    const codeLines = ["```ts"];
+    for (let i = 1; i <= 40; i++) {
+      codeLines.push(`const value${i} = "line ${i}";`);
+    }
+    codeLines.push("```");
+    const chunks = chunkNote(`## Reference\n${codeLines.join("\n")}\n`, {
+      targetChars: 240,
+      overlapChars: 40,
+    });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    const codeChunks = chunks.filter((chunk) => chunk.text.includes("const value"));
+    expect(codeChunks.length).toBeGreaterThan(1);
+    for (const chunk of codeChunks) {
+      const fenceMarkers = chunk.text.match(/^```/gm) ?? [];
+      expect(fenceMarkers).toHaveLength(2);
+    }
+
+    const longLine = `const payload = "${"a".repeat(500)}";`;
+    const longLineChunks = chunkNote(`## Minified\n\`\`\`js\n${longLine}\n\`\`\`\n`, {
+      targetChars: 180,
+      overlapChars: 40,
+    }).filter((chunk) => chunk.text.includes("payload") || chunk.text.includes("aaaa"));
+    expect(longLineChunks.length).toBeGreaterThan(1);
+    for (const chunk of longLineChunks) {
+      const fenceMarkers = chunk.text.match(/^```/gm) ?? [];
+      expect(fenceMarkers).toHaveLength(2);
+    }
+  });
+
   it("preserves the heading path on each chunk", () => {
     const note = `# Project\n## Tasks\nbody\n### Sub\nmore\n`;
     const chunks = chunkNote(note);

--- a/src/lib/chunker.ts
+++ b/src/lib/chunker.ts
@@ -150,6 +150,78 @@ function headingLineEnd(_body: string, heading: Heading): number {
   return heading.lineEnd;
 }
 
+function splitFencedCodeBlock(text: string, target: number): string[] | null {
+  const lines = text.split("\n");
+  const opener = lines[0];
+  const closer = lines.at(-1);
+  if (!opener || !closer) return null;
+
+  const openerMatch = opener.match(/^(`{3,}|~{3,})(.*)$/);
+  if (!openerMatch) return null;
+  const fence = openerMatch[1]!;
+  const fenceChar = fence[0]!;
+  if (!isClosingFence(closer, fenceChar, fence.length)) return null;
+
+  const bodyLines = lines.slice(1, -1);
+  if (bodyLines.length === 0) return [text];
+
+  const out: string[] = [];
+  let start = 0;
+  while (start < bodyLines.length) {
+    const piece: string[] = [];
+    let emittedLongLine = false;
+    let end = start;
+    while (end < bodyLines.length) {
+      const line = bodyLines[end]!;
+      const candidate = formatFencedCodeChunk(opener, closer, [...piece, line]);
+      if (piece.length > 0 && candidate.length > target) break;
+      if (piece.length === 0 && candidate.length > target) {
+        const lineChunks = splitLongFencedCodeLine(opener, closer, line, target);
+        if (lineChunks.length === 0) return null;
+        out.push(...lineChunks);
+        emittedLongLine = true;
+        end++;
+        break;
+      }
+      piece.push(line);
+      end++;
+    }
+
+    if (!emittedLongLine) {
+      if (piece.length === 0) return null;
+      out.push(formatFencedCodeChunk(opener, closer, piece));
+    }
+    // The wrapper fences already carry boundary context. Avoid copying code
+    // lines across chunks so syntax-safe splits do not inflate token load.
+    start = end;
+  }
+
+  return out;
+}
+
+function isClosingFence(line: string, fenceChar: string, minLength: number): boolean {
+  const trimmed = line.trim();
+  if (trimmed.length < minLength) return false;
+  for (const ch of trimmed) {
+    if (ch !== fenceChar) return false;
+  }
+  return true;
+}
+
+function formatFencedCodeChunk(opener: string, closer: string, bodyLines: string[]): string {
+  return [opener, ...bodyLines, closer].join("\n");
+}
+
+function splitLongFencedCodeLine(opener: string, closer: string, line: string, target: number): string[] {
+  const bodyBudget = target - opener.length - closer.length - 2;
+  if (bodyBudget < 1) return [];
+  const out: string[] = [];
+  for (let i = 0; i < line.length; i += bodyBudget) {
+    out.push(formatFencedCodeChunk(opener, closer, [line.slice(i, i + bodyBudget)]));
+  }
+  return out;
+}
+
 /**
  * Sliding-window split for sections that exceed the target chunk size.
  * Splits on paragraph boundaries when possible, falls back to fixed-size
@@ -168,8 +240,13 @@ function splitOversized(text: string, targetChars: number, overlapChars: number)
     if (para.length > target) {
       // Flush buffer first, then character-window the giant paragraph.
       if (buffer) { out.push(buffer); buffer = ""; }
-      for (let i = 0; i < para.length; i += target - overlap) {
-        out.push(para.slice(i, Math.min(para.length, i + target)));
+      const fencedPieces = splitFencedCodeBlock(para, target);
+      if (fencedPieces) {
+        out.push(...fencedPieces);
+      } else {
+        for (let i = 0; i < para.length; i += target - overlap) {
+          out.push(para.slice(i, Math.min(para.length, i + target)));
+        }
       }
       continue;
     }


### PR DESCRIPTION
Keeps oversized fenced code blocks balanced when semantic chunking falls back to smaller pieces. Long code lines are wrapped in fence-balanced chunks too, and the chunker boundary R&D fixture is marked shipped after the score moved from 88.0 to 100.0 with zero fence fractures.

Score: 2 severity x 3 reach / 1 effort = 6. Semantic indexing touches every embedded note, and fractured code chunks weaken retrieval context and snippets.

Risk: low; this changes internal chunk text only and does not change tool names, schemas, or return shapes.

Tests: npx vitest run src/__tests__/chunker.test.ts; npm run build; node scripts/bench-chunker-quality.mjs --json twice; npm run verify.

Greptile skipped because the review quota is exhausted.