### PR TITLE
chore: start semantic ranking rnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Active R&D experiment for semantic ranking quality, with a synthetic embedding-store fixture in `scripts/bench-semantic-ranking-quality.mjs` and ship/kill metric in `docs/rnd/semantic-ranking-quality.md`.
 - R&D experiment for chunker boundary quality, with a synthetic fixture in `scripts/bench-chunker-quality.mjs` and ship/kill metric in `docs/rnd/chunker-boundary-quality.md`.
 - Active R&D experiment for `get_daily_note` warm-path performance, with a synthetic benchmark harness in `scripts/bench-daily-notes.mjs` and ship/kill metric in `docs/rnd/daily-note-warm-path.md`.
 - Active R&D experiment for `get_note` section-read performance, with a synthetic benchmark harness in `scripts/bench-section-reads.mjs` and ship/kill metric in `docs/rnd/section-read-warm-path.md`.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,6 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
+| [Semantic Ranking Quality](semantic-ranking-quality.md) | retrieval quality | active | Baseline NDCG@3 is 0.690 because a grade-1 incidental match ranks ahead of focused grade-3 cat notes; next step is a ranking prototype that accounts for note-level focus. |
 | [Chunker Boundary Quality](chunker-boundary-quality.md) | retrieval quality | shipped | Score rose from 88.0 to 100.0, fenced-code fractures fell from two to zero, chunk count stayed at 21, and mean token load fell to 1.15x. |
 | [Daily Note Warm Path](daily-note-warm-path.md) | performance / agent workflows | stopped | Config and rendered-response cache prototypes missed the warm ship bar or exceeded guardrails, so no runtime change shipped. |
 | [Section Read Warm Path](section-read-warm-path.md) | performance / agent workflows | stopped | Cache and streaming-parser prototypes missed the cold or warm ship bar, so no runtime change shipped. |

--- a/docs/rnd/semantic-ranking-quality.md
+++ b/docs/rnd/semantic-ranking-quality.md
@@ -1,0 +1,82 @@
+# Semantic Ranking Quality
+
+_Status: active_
+_Started: 2026-06-04 - Decided: pending_
+
+## Hypothesis
+
+`search_semantic` returns note-level results, but the store currently ranks each
+note by its single best chunk. That can let a note with one incidental matching
+chunk outrank notes that are focused on the query. A measured ranking fixture can
+test whether note-level focus improves result order without changing tool names,
+schemas, or result shapes.
+
+## Fixture
+
+The fixture is `scripts/bench-semantic-ranking-quality.mjs`.
+
+It populates the embedding store with synthetic vectors for six notes:
+
+- two focused cat notes with grade-3 relevance,
+- one mixed pet overview with grade-2 relevance,
+- one kitchen note with a single perfect cat chunk but grade-1 note relevance,
+- dog and weather distractors with grade-0 relevance.
+
+Run:
+
+```powershell
+npm run build
+node scripts/bench-semantic-ranking-quality.mjs --json
+```
+
+## Metric
+
+Primary metric: NDCG@3 for the `cat care` query. Secondary guardrails are
+precision@3, the top result's relevance grade, and whether an incidental grade-1
+note ranks ahead of a focused grade-3 note.
+
+Ship bar: NDCG@3 at or above 0.900, precision@3 at 1.000, top relevance grade 3,
+and no incidental grade-1 note ahead of a focused grade-3 note.
+
+| metric | before | after |
+|---|---:|---:|
+| NDCG@3 | 0.690 | |
+| Precision@3 | 0.667 | |
+| Top relevance grade | 1 | |
+| Incidental before focused | true | |
+
+Baseline command samples:
+
+- `node scripts/bench-semantic-ranking-quality.mjs --json`: NDCG@3 0.690,
+  precision@3 0.667, top relevance 1, incidental before focused true.
+- `node scripts/bench-semantic-ranking-quality.mjs --json`: NDCG@3 0.690,
+  precision@3 0.667, top relevance 1, incidental before focused true.
+
+Current top five:
+
+| rank | note | rel | score | chunk |
+|---:|---|---:|---:|---:|
+| 1 | `kitchen-with-cat.md` | 1 | 1.000 | 1 |
+| 2 | `cats-care.md` | 3 | 0.999 | 1 |
+| 3 | `cat-health.md` | 3 | 0.998 | 1 |
+| 4 | `pet-overview.md` | 2 | 0.973 | 1 |
+| 5 | `dogs.md` | 0 | 0.105 | 1 |
+
+## Safety review
+
+The fixture creates a temporary vault path and writes no note files. It calls the
+compiled embedding store with synthetic in-memory chunks and vectors, then clears
+the store and removes the temp directory. It performs no provider calls, no
+network calls, and no real vault reads or writes. Output contains only synthetic
+note names, heading labels, scores, and aggregate metrics.
+
+## Kill criterion
+
+Stop if a ranking prototype cannot clear the ship bar without changing the public
+semantic tool surface, hiding the best matching snippet, or adding a provider/API
+call during search.
+
+## Decision
+
+Active. The next step is a ranking prototype that accounts for note-level focus
+while preserving the existing best-chunk snippet shown to clients.

--- a/scripts/bench-semantic-ranking-quality.mjs
+++ b/scripts/bench-semantic-ranking-quality.mjs
@@ -1,0 +1,170 @@
+// Semantic ranking-quality benchmark: populate the embedding store with
+// synthetic vectors and score note-level search order.
+//
+// Direct use: node scripts/bench-semantic-ranking-quality.mjs [--json]
+// Run after `npm run build`.
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const storeEntry = join(root, "build", "lib", "embedding-store.js");
+
+const QUERY_VECTOR = [1, 0, 0];
+const LIMIT = 5;
+
+const notes = [
+  {
+    path: "kitchen-with-cat.md",
+    relevance: 1,
+    chunks: [
+      { heading: ["Kitchen"], text: "A kitchen remodel note with one cat anecdote.", vector: [1, 0, 0] },
+      { heading: ["Recipes"], text: "Recipe planning and pantry notes.", vector: [0, 1, 0] },
+      { heading: ["Oven"], text: "Oven cleaning checklist.", vector: [0, 1, 0] },
+    ],
+  },
+  {
+    path: "cats-care.md",
+    relevance: 3,
+    chunks: [
+      { heading: ["Cats", "Care"], text: "Focused cat care guidance.", vector: [0.98, 0.05, 0] },
+      { heading: ["Cats", "Behavior"], text: "Focused feline behavior notes.", vector: [0.96, 0.08, 0] },
+    ],
+  },
+  {
+    path: "cat-health.md",
+    relevance: 3,
+    chunks: [
+      { heading: ["Cats", "Health"], text: "Vaccines, food, and vet care for cats.", vector: [0.97, 0.06, 0] },
+      { heading: ["Cats", "Symptoms"], text: "Symptoms to track before a vet visit.", vector: [0.93, 0.1, 0] },
+    ],
+  },
+  {
+    path: "pet-overview.md",
+    relevance: 2,
+    chunks: [
+      { heading: ["Pets"], text: "Mixed cat and dog household notes.", vector: [0.85, 0.2, 0] },
+      { heading: ["Budget"], text: "Pet supplies and monthly budget.", vector: [0.75, 0.25, 0] },
+    ],
+  },
+  {
+    path: "dogs.md",
+    relevance: 0,
+    chunks: [
+      { heading: ["Dogs"], text: "Dog training and puppy notes.", vector: [0.1, 0.95, 0] },
+    ],
+  },
+  {
+    path: "weather.md",
+    relevance: 0,
+    chunks: [
+      { heading: ["Weather"], text: "Storm tracking and weather notes.", vector: [0, 0, 1] },
+    ],
+  },
+];
+
+function gain(relevance) {
+  return (2 ** relevance) - 1;
+}
+
+function dcg(relevances) {
+  return relevances.reduce((sum, relevance, index) => {
+    return sum + gain(relevance) / Math.log2(index + 2);
+  }, 0);
+}
+
+function ndcgAt(results, k) {
+  const actual = results.slice(0, k).map((row) => row.relevance);
+  const ideal = [...notes].sort((a, b) => b.relevance - a.relevance).slice(0, k).map((row) => row.relevance);
+  const idealDcg = dcg(ideal);
+  return idealDcg === 0 ? 0 : dcg(actual) / idealDcg;
+}
+
+function hasIncidentalBeforeFocused(results) {
+  const firstFocused = results.findIndex((row) => row.relevance === 3);
+  const firstIncidental = results.findIndex((row) => row.relevance === 1);
+  return firstIncidental !== -1 && firstFocused !== -1 && firstIncidental < firstFocused;
+}
+
+export async function runSemanticRankingQualityBench() {
+  const {
+    loadStore,
+    setNoteChunks,
+    searchEmbeddings,
+    hashText,
+    clearStore,
+  } = await import(pathToFileURL(storeEntry).href);
+
+  const vault = mkdtempSync(join(tmpdir(), "ompro-semantic-ranking-"));
+  try {
+    await loadStore(vault);
+    for (const note of notes) {
+      setNoteChunks(
+        vault,
+        note.path,
+        hashText(note.path),
+        note.chunks.map((chunk, index) => ({
+          notePath: note.path,
+          chunkIndex: index + 1,
+          headingPath: chunk.heading,
+          text: chunk.text,
+          hash: "",
+          vector: chunk.vector,
+        })),
+        "fixture",
+        "ranking-quality",
+      );
+    }
+
+    const hits = searchEmbeddings(vault, QUERY_VECTOR, { limit: LIMIT });
+    const relevanceByPath = new Map(notes.map((note) => [note.path, note.relevance]));
+    const rows = hits.map((hit, index) => ({
+      rank: index + 1,
+      notePath: hit.notePath,
+      chunkIndex: hit.chunkIndex,
+      score: hit.score,
+      relevance: relevanceByPath.get(hit.notePath) ?? 0,
+      headingPath: hit.headingPath,
+    }));
+    const topK = rows.slice(0, 3);
+
+    return {
+      query: "cat care",
+      limit: LIMIT,
+      ndcgAt3: ndcgAt(rows, 3),
+      precisionAt3: topK.filter((row) => row.relevance >= 2).length / 3,
+      topRelevance: rows[0]?.relevance ?? 0,
+      incidentalBeforeFocused: hasIncidentalBeforeFocused(rows),
+      rows,
+    };
+  } finally {
+    await clearStore(vault, { removeSnapshot: true });
+    rmSync(vault, { recursive: true, force: true });
+  }
+}
+
+const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (invokedDirectly) {
+  if (!existsSync(storeEntry)) {
+    console.error("build/lib/embedding-store.js missing - run `npm run build` first.");
+    process.exit(1);
+  }
+  const result = await runSemanticRankingQualityBench();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(result));
+  } else {
+    console.log(`NDCG@3 ${result.ndcgAt3.toFixed(3)}`);
+    console.log(`precision@3 ${result.precisionAt3.toFixed(3)}`);
+    console.log(`top relevance ${result.topRelevance}`);
+    console.log(`incidental before focused ${result.incidentalBeforeFocused}`);
+    console.log("\n| rank | note | rel | score | chunk | heading |");
+    console.log("|---:|---|---:|---:|---:|---|");
+    for (const row of result.rows) {
+      console.log(
+        `| ${row.rank} | ${row.notePath} | ${row.relevance} | ${row.score.toFixed(3)} | ${row.chunkIndex} | ${row.headingPath.join(" / ")} |`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
Adds an active semantic ranking-quality R&D fixture for note-level search order. The baseline shows NDCG@3 at 0.690 because a grade-1 incidental match ranks ahead of focused grade-3 cat notes.

Score: 1 severity x 3 reach / 1 effort = 3. Semantic ranking affects every search_semantic result, and this gives the next ranking change a measured target without changing runtime behavior yet.

Risk: low; docs and benchmark only, no public API change.

Tests: node scripts/bench-semantic-ranking-quality.mjs --json twice; npm run verify.

Greptile skipped because the review quota is exhausted.