### PR TITLE
fix: rank semantic notes by focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Active R&D experiment for semantic ranking quality, with a synthetic embedding-store fixture in `scripts/bench-semantic-ranking-quality.mjs` and ship/kill metric in `docs/rnd/semantic-ranking-quality.md`.
+- R&D experiment for semantic ranking quality, with a synthetic embedding-store fixture in `scripts/bench-semantic-ranking-quality.mjs` and ship/kill metric in `docs/rnd/semantic-ranking-quality.md`.
 - R&D experiment for chunker boundary quality, with a synthetic fixture in `scripts/bench-chunker-quality.mjs` and ship/kill metric in `docs/rnd/chunker-boundary-quality.md`.
 - Active R&D experiment for `get_daily_note` warm-path performance, with a synthetic benchmark harness in `scripts/bench-daily-notes.mjs` and ship/kill metric in `docs/rnd/daily-note-warm-path.md`.
 - Active R&D experiment for `get_note` section-read performance, with a synthetic benchmark harness in `scripts/bench-section-reads.mjs` and ship/kill metric in `docs/rnd/section-read-warm-path.md`.
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Semantic search now ranks note-level results with a small focus signal from each note's top chunks, so one incidental high-scoring chunk is less likely to outrank notes that are consistently about the query.
 - Semantic chunking now keeps oversized fenced code blocks fence-balanced when splitting them for embeddings, preserving title and heading prefixes while leaving non-code chunking behavior unchanged.
 - `list_sections` now reuses a small mtime-validated rendered heading cache, cutting the 1,000-heading warm bench below the R&D ship bar while preserving heading escaping and write freshness.
 - The `get_daily_note` warm-path R&D experiment is stopped after config and rendered-response cache prototypes missed the warm ship bar or exceeded guardrails.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Semantic Ranking Quality](semantic-ranking-quality.md) | retrieval quality | active | Baseline NDCG@3 is 0.690 because a grade-1 incidental match ranks ahead of focused grade-3 cat notes; next step is a ranking prototype that accounts for note-level focus. |
+| [Semantic Ranking Quality](semantic-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and grade-1 incidental matches no longer rank ahead of focused grade-3 notes. |
 | [Chunker Boundary Quality](chunker-boundary-quality.md) | retrieval quality | shipped | Score rose from 88.0 to 100.0, fenced-code fractures fell from two to zero, chunk count stayed at 21, and mean token load fell to 1.15x. |
 | [Daily Note Warm Path](daily-note-warm-path.md) | performance / agent workflows | stopped | Config and rendered-response cache prototypes missed the warm ship bar or exceeded guardrails, so no runtime change shipped. |
 | [Section Read Warm Path](section-read-warm-path.md) | performance / agent workflows | stopped | Cache and streaming-parser prototypes missed the cold or warm ship bar, so no runtime change shipped. |

--- a/docs/rnd/semantic-ranking-quality.md
+++ b/docs/rnd/semantic-ranking-quality.md
@@ -1,7 +1,7 @@
 # Semantic Ranking Quality
 
-_Status: active_
-_Started: 2026-06-04 - Decided: pending_
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -40,10 +40,10 @@ and no incidental grade-1 note ahead of a focused grade-3 note.
 
 | metric | before | after |
 |---|---:|---:|
-| NDCG@3 | 0.690 | |
-| Precision@3 | 0.667 | |
-| Top relevance grade | 1 | |
-| Incidental before focused | true | |
+| NDCG@3 | 0.690 | 1.000 |
+| Precision@3 | 0.667 | 1.000 |
+| Top relevance grade | 1 | 3 |
+| Incidental before focused | true | false |
 
 Baseline command samples:
 
@@ -78,5 +78,24 @@ call during search.
 
 ## Decision
 
-Active. The next step is a ranking prototype that accounts for note-level focus
-while preserving the existing best-chunk snippet shown to clients.
+Ship. `searchEmbeddings` now keeps the best-scoring chunk as the returned snippet
+source, but ranks notes by a small focus signal from their top chunks:
+
+```text
+0.8 * bestChunkScore + 0.2 * averageTopThreeChunkScores
+```
+
+This preserves the existing note-level result shape and best-chunk snippet while
+preventing a note with one incidental perfect chunk from outranking focused notes.
+A regression test pins the fixture shape at the embedding-store layer.
+
+Measured after the prototype with:
+
+```powershell
+npm run build
+node scripts/bench-semantic-ranking-quality.mjs --json
+node scripts/bench-semantic-ranking-quality.mjs --json
+```
+
+Both runs reached NDCG@3 1.000, precision@3 1.000, top relevance grade 3, and no
+incidental-before-focused ordering.

--- a/src/__tests__/embedding-store.test.ts
+++ b/src/__tests__/embedding-store.test.ts
@@ -105,6 +105,36 @@ describe("setNoteChunks / searchEmbeddings", () => {
     expect(hits[0].chunkIndex).toBe(1);
   });
 
+  it("ranks focused multi-chunk notes ahead of incidental single-chunk matches", async () => {
+    await loadStore(vaultDir);
+    setNoteChunks(vaultDir, "kitchen-with-cat.md", hashText("kitchen"), [
+      { notePath: "kitchen-with-cat.md", chunkIndex: 1, headingPath: ["Kitchen"], text: "one cat anecdote", hash: "h1", vector: [1, 0, 0] },
+      { notePath: "kitchen-with-cat.md", chunkIndex: 2, headingPath: ["Recipes"], text: "recipes", hash: "h2", vector: [0, 1, 0] },
+      { notePath: "kitchen-with-cat.md", chunkIndex: 3, headingPath: ["Oven"], text: "oven", hash: "h3", vector: [0, 1, 0] },
+    ], "test", "m");
+    setNoteChunks(vaultDir, "cats-care.md", hashText("cats"), [
+      { notePath: "cats-care.md", chunkIndex: 1, headingPath: ["Cats", "Care"], text: "cat care", hash: "h4", vector: [0.98, 0.05, 0] },
+      { notePath: "cats-care.md", chunkIndex: 2, headingPath: ["Cats", "Behavior"], text: "cat behavior", hash: "h5", vector: [0.96, 0.08, 0] },
+    ], "test", "m");
+    setNoteChunks(vaultDir, "cat-health.md", hashText("health"), [
+      { notePath: "cat-health.md", chunkIndex: 1, headingPath: ["Cats", "Health"], text: "cat health", hash: "h6", vector: [0.97, 0.06, 0] },
+      { notePath: "cat-health.md", chunkIndex: 2, headingPath: ["Cats", "Symptoms"], text: "cat symptoms", hash: "h7", vector: [0.93, 0.1, 0] },
+    ], "test", "m");
+    setNoteChunks(vaultDir, "pet-overview.md", hashText("pets"), [
+      { notePath: "pet-overview.md", chunkIndex: 1, headingPath: ["Pets"], text: "mixed pets", hash: "h8", vector: [0.85, 0.2, 0] },
+      { notePath: "pet-overview.md", chunkIndex: 2, headingPath: ["Budget"], text: "pet budget", hash: "h9", vector: [0.75, 0.25, 0] },
+    ], "test", "m");
+
+    const hits = searchEmbeddings(vaultDir, [1, 0, 0], { limit: 4 });
+    expect(hits.map((hit) => hit.notePath)).toEqual([
+      "cats-care.md",
+      "cat-health.md",
+      "pet-overview.md",
+      "kitchen-with-cat.md",
+    ]);
+    expect(hits[0].chunkIndex).toBe(1);
+  });
+
   it("filters by folder prefix", async () => {
     await loadStore(vaultDir);
     setNoteChunks(vaultDir, "projects/alpha.md", hashText("a"), [

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -28,6 +28,9 @@ import { renameWithRetry } from "./fs-ops.js";
 
 const STORE_REL_PATH = ".obsidian/cache/mcp-pro-embeddings.json";
 const STORE_VERSION = 1;
+const NOTE_BEST_CHUNK_WEIGHT = 0.8;
+const NOTE_FOCUS_WEIGHT = 0.2;
+const NOTE_FOCUS_CHUNKS = 3;
 // Hard cap on the on-disk snapshot size. A 50k-note vault with 768-dim
 // vectors can produce a multi-GB JSON blob, at which point persisting it
 // each pass costs more than the cold-start re-embed it saves. When the
@@ -500,18 +503,37 @@ export function searchEmbeddings(
       score,
     });
   }
-  // Per-note dedup: keep the highest-scoring chunk per note. The semantic
-  // search tool surfaces note-level results; chunk-level granularity is
-  // available through the score breakdown but rarely useful for ranking.
-  const bestPerNote = new Map<string, SearchHit>();
+  // Per-note ranking: keep the highest-scoring chunk for the snippet, but
+  // sort notes with a small focus signal from their top chunks. This avoids
+  // one incidental perfect chunk outranking notes that are consistently about
+  // the query.
+  const byNote = new Map<string, { best: SearchHit; scores: number[] }>();
   for (const h of hits) {
-    const existing = bestPerNote.get(h.notePath);
-    if (!existing || h.score > existing.score) {
-      bestPerNote.set(h.notePath, h);
+    const existing = byNote.get(h.notePath);
+    if (!existing) {
+      byNote.set(h.notePath, { best: h, scores: [h.score] });
+    } else {
+      existing.scores.push(h.score);
+      if (h.score > existing.best.score) existing.best = h;
     }
   }
-  const out = Array.from(bestPerNote.values()).sort((a, b) => b.score - a.score);
+  const out = Array.from(byNote.values()).map(({ best, scores }) => {
+    const score = noteFocusScore(scores);
+    return { ...best, score };
+  }).sort((a, b) => {
+    const scoreDelta = b.score - a.score;
+    if (scoreDelta !== 0) return scoreDelta;
+    return a.notePath.localeCompare(b.notePath);
+  });
   return out.slice(0, limit);
+}
+
+function noteFocusScore(scores: number[]): number {
+  const sorted = scores.toSorted((a, b) => b - a);
+  const top = sorted.slice(0, NOTE_FOCUS_CHUNKS);
+  const best = top[0] ?? 0;
+  const focus = top.reduce((sum, score) => sum + score, 0) / top.length;
+  return NOTE_BEST_CHUNK_WEIGHT * best + NOTE_FOCUS_WEIGHT * focus;
 }
 
 /** Get the embeddings owned by a specific note (used by find_similar). */

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -266,7 +266,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
     {
       title: "Semantic Search",
       description:
-        "Search notes by meaning rather than keywords. Embeds the query with the configured provider, scores every chunk in the persisted index by cosine similarity, and returns the best-matching note per cluster (deduplicated to one hit per note). Run `index_vault` first to populate the index — this tool does not auto-index because the user should know they're paying the embedding cost. Pair with `get_note` to retrieve full bodies after picking a hit.",
+        "Search notes by meaning rather than keywords. Embeds the query with the configured provider, scores every chunk in the persisted index by cosine similarity, ranks one result per note using the best chunk plus a small top-chunk focus signal, and returns the best chunk as the snippet source. Run `index_vault` first to populate the index — this tool does not auto-index because the user should know they're paying the embedding cost. Pair with `get_note` to retrieve full bodies after picking a hit.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,


### PR DESCRIPTION
Ranks semantic note results with a small focus signal from each note's top chunks while keeping the best chunk as the snippet source. The ranking-quality fixture moves from NDCG@3 0.690 to 1.000 and stops a grade-1 incidental match from outranking focused grade-3 notes.

Score: 2 severity x 3 reach / 1 effort = 6. search_semantic is a core retrieval path, and this improves note-level relevance without changing tool names, schemas, or result shapes.

Risk: medium-low; ranking values change, but the public surface and snippet source stay stable.

Tests: npx vitest run src/__tests__/embedding-store.test.ts; node scripts/bench-semantic-ranking-quality.mjs --json twice; npm run verify.

Greptile skipped because the review quota is exhausted.