### PR TITLE
chore: start similar notes quality rnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Active R&D experiment for similar-note quality, with a synthetic embedding-store fixture in `scripts/bench-similar-notes-quality.mjs` and ship/kill metric in `docs/rnd/similar-notes-quality.md`.
 - R&D experiment for semantic ranking quality, with a synthetic embedding-store fixture in `scripts/bench-semantic-ranking-quality.mjs` and ship/kill metric in `docs/rnd/semantic-ranking-quality.md`.
 - R&D experiment for chunker boundary quality, with a synthetic fixture in `scripts/bench-chunker-quality.mjs` and ship/kill metric in `docs/rnd/chunker-boundary-quality.md`.
 - Active R&D experiment for `get_daily_note` warm-path performance, with a synthetic benchmark harness in `scripts/bench-daily-notes.mjs` and ship/kill metric in `docs/rnd/daily-note-warm-path.md`.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,6 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
+| [Similar Notes Quality](similar-notes-quality.md) | retrieval quality | active | Baseline NDCG@3 is 0.418 because unrelated source appendices pull `find_similar_notes` toward an off-topic kitchen note; next step is a source-anchoring prototype. |
 | [Semantic Ranking Quality](semantic-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and grade-1 incidental matches no longer rank ahead of focused grade-3 notes. |
 | [Chunker Boundary Quality](chunker-boundary-quality.md) | retrieval quality | shipped | Score rose from 88.0 to 100.0, fenced-code fractures fell from two to zero, chunk count stayed at 21, and mean token load fell to 1.15x. |
 | [Daily Note Warm Path](daily-note-warm-path.md) | performance / agent workflows | stopped | Config and rendered-response cache prototypes missed the warm ship bar or exceeded guardrails, so no runtime change shipped. |

--- a/docs/rnd/similar-notes-quality.md
+++ b/docs/rnd/similar-notes-quality.md
@@ -1,0 +1,83 @@
+# Similar Notes Quality
+
+_Status: active_
+_Started: 2026-06-04 - Decided: pending_
+
+## Hypothesis
+
+`find_similar_notes` computes one centroid from every source-note chunk. If a source
+note has unrelated appendices or copied material, that centroid can drift away from
+the note's main topic and return off-topic notes first. A measured fixture can test
+whether source-note anchoring or top-chunk selection improves similar-note quality
+without adding provider calls during search.
+
+## Fixture
+
+The fixture is `scripts/bench-similar-notes-quality.mjs`.
+
+It populates the embedding store with synthetic vectors:
+
+- `source-cat-care.md`: one cat-care chunk plus two unrelated kitchen appendix
+  chunks, excluded from returned hits.
+- two focused cat notes with grade-3 relevance,
+- one mixed pet overview with grade-2 relevance,
+- one kitchen note and one dog note with grade-0 relevance.
+
+Run:
+
+```powershell
+npm run build
+node scripts/bench-similar-notes-quality.mjs --json
+```
+
+## Metric
+
+Primary metric: NDCG@3 for notes similar to `source-cat-care.md`. Secondary
+guardrails are precision@3, the top result's relevance grade, and whether an
+off-topic grade-0 note ranks first.
+
+Ship bar: NDCG@3 at or above 0.900, precision@3 at 1.000, top relevance grade 3,
+and no off-topic top result.
+
+| metric | before | after |
+|---|---:|---:|
+| NDCG@3 | 0.418 | |
+| Precision@3 | 0.667 | |
+| Top relevance grade | 0 | |
+| Off-topic top result | true | |
+
+Baseline command samples:
+
+- `node scripts/bench-similar-notes-quality.mjs --json`: NDCG@3 0.418,
+  precision@3 0.667, top relevance 0, off-topic top result true.
+- `node scripts/bench-similar-notes-quality.mjs --json`: NDCG@3 0.418,
+  precision@3 0.667, top relevance 0, off-topic top result true.
+
+Current top five:
+
+| rank | note | rel | score | chunk |
+|---:|---|---:|---:|---:|
+| 1 | `kitchen-recipes.md` | 0 | 0.857 | 1 |
+| 2 | `pet-overview.md` | 2 | 0.759 | 1 |
+| 3 | `cats-care.md` | 3 | 0.581 | 2 |
+| 4 | `cat-health.md` | 3 | 0.549 | 1 |
+| 5 | `dogs.md` | 0 | 0.000 | 1 |
+
+## Safety review
+
+The fixture creates a temporary vault path and writes no note files. It calls the
+compiled embedding store with synthetic chunks and vectors, computes the same
+source centroid used by `find_similar_notes`, then clears the store and removes
+the temp directory. It performs no provider calls, no network calls, and no real
+vault reads or writes.
+
+## Kill criterion
+
+Stop if a prototype cannot clear the ship bar without changing the public
+`find_similar_notes` surface, adding a live embedding/provider call during search,
+or hiding the current best matching candidate chunk.
+
+## Decision
+
+Active. The next step is a prototype that anchors the source representation to
+the source note's focused chunks while preserving the existing result shape.

--- a/scripts/bench-similar-notes-quality.mjs
+++ b/scripts/bench-similar-notes-quality.mjs
@@ -1,0 +1,193 @@
+// Similar-note quality benchmark: populate the embedding store with synthetic
+// vectors, run the same source-centroid search used by find_similar_notes, and
+// score the returned note order.
+//
+// Direct use: node scripts/bench-similar-notes-quality.mjs [--json]
+// Run after `npm run build`.
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const storeEntry = join(root, "build", "lib", "embedding-store.js");
+const SOURCE_NOTE = "source-cat-care.md";
+const LIMIT = 5;
+
+const notes = [
+  {
+    path: SOURCE_NOTE,
+    relevance: null,
+    chunks: [
+      { heading: ["Cats", "Care"], text: "Source note's main cat-care section.", vector: [1, 0, 0] },
+      { heading: ["Appendix", "Recipes"], text: "Unrelated recipe appendix copied into the source note.", vector: [0.1, 1, 0] },
+      { heading: ["Appendix", "Kitchen"], text: "Kitchen inventory copied into the source note.", vector: [0.1, 1, 0] },
+    ],
+  },
+  {
+    path: "cats-care.md",
+    relevance: 3,
+    chunks: [
+      { heading: ["Cats", "Care"], text: "Focused cat-care note.", vector: [0.98, 0.05, 0] },
+      { heading: ["Cats", "Behavior"], text: "Feline behavior and care routines.", vector: [0.96, 0.08, 0] },
+    ],
+  },
+  {
+    path: "cat-health.md",
+    relevance: 3,
+    chunks: [
+      { heading: ["Cats", "Health"], text: "Veterinary and cat health notes.", vector: [0.97, 0.04, 0] },
+    ],
+  },
+  {
+    path: "pet-overview.md",
+    relevance: 2,
+    chunks: [
+      { heading: ["Pets"], text: "Mixed pet overview with some cat material.", vector: [0.75, 0.25, 0] },
+    ],
+  },
+  {
+    path: "kitchen-recipes.md",
+    relevance: 0,
+    chunks: [
+      { heading: ["Kitchen"], text: "Recipes and pantry notes.", vector: [0, 1, 0] },
+      { heading: ["Oven"], text: "Kitchen appliance checklist.", vector: [0, 1, 0] },
+    ],
+  },
+  {
+    path: "dogs.md",
+    relevance: 0,
+    chunks: [
+      { heading: ["Dogs"], text: "Dog training notes.", vector: [0, 0, 1] },
+    ],
+  },
+];
+
+function gain(relevance) {
+  return (2 ** relevance) - 1;
+}
+
+function dcg(relevances) {
+  return relevances.reduce((sum, relevance, index) => {
+    return sum + gain(relevance) / Math.log2(index + 2);
+  }, 0);
+}
+
+function ndcgAt(results, k) {
+  const actual = results.slice(0, k).map((row) => row.relevance);
+  const ideal = notes
+    .filter((note) => typeof note.relevance === "number")
+    .sort((a, b) => b.relevance - a.relevance)
+    .slice(0, k)
+    .map((row) => row.relevance);
+  const idealDcg = dcg(ideal);
+  return idealDcg === 0 ? 0 : dcg(actual) / idealDcg;
+}
+
+function centroid(chunks) {
+  const first = chunks[0];
+  const out = first.vector.slice();
+  for (let i = 1; i < chunks.length; i++) {
+    const vector = chunks[i].vector;
+    for (let d = 0; d < out.length; d++) {
+      out[d] += vector[d];
+    }
+  }
+  for (let d = 0; d < out.length; d++) {
+    out[d] /= chunks.length;
+  }
+  return out;
+}
+
+export async function runSimilarNotesQualityBench() {
+  const {
+    loadStore,
+    setNoteChunks,
+    searchEmbeddings,
+    getNoteEmbeddings,
+    hashText,
+    clearStore,
+  } = await import(pathToFileURL(storeEntry).href);
+
+  const vault = mkdtempSync(join(tmpdir(), "ompro-similar-quality-"));
+  try {
+    await loadStore(vault);
+    for (const note of notes) {
+      setNoteChunks(
+        vault,
+        note.path,
+        hashText(note.path),
+        note.chunks.map((chunk, index) => ({
+          notePath: note.path,
+          chunkIndex: index + 1,
+          headingPath: chunk.heading,
+          text: chunk.text,
+          hash: "",
+          vector: chunk.vector,
+        })),
+        "fixture",
+        "similar-quality",
+      );
+    }
+
+    const ownChunks = getNoteEmbeddings(vault, SOURCE_NOTE);
+    const queryVector = centroid(ownChunks);
+    const hits = searchEmbeddings(vault, queryVector, {
+      limit: LIMIT,
+      excludeNotes: new Set([SOURCE_NOTE]),
+    });
+    const relevanceByPath = new Map(
+      notes
+        .filter((note) => typeof note.relevance === "number")
+        .map((note) => [note.path, note.relevance]),
+    );
+    const rows = hits.map((hit, index) => ({
+      rank: index + 1,
+      notePath: hit.notePath,
+      chunkIndex: hit.chunkIndex,
+      score: hit.score,
+      relevance: relevanceByPath.get(hit.notePath) ?? 0,
+      headingPath: hit.headingPath,
+    }));
+    const topK = rows.slice(0, 3);
+
+    return {
+      source: SOURCE_NOTE,
+      limit: LIMIT,
+      queryVector,
+      ndcgAt3: ndcgAt(rows, 3),
+      precisionAt3: topK.filter((row) => row.relevance >= 2).length / 3,
+      topRelevance: rows[0]?.relevance ?? 0,
+      offTopicTopResult: rows[0]?.relevance === 0,
+      rows,
+    };
+  } finally {
+    await clearStore(vault, { removeSnapshot: true });
+    rmSync(vault, { recursive: true, force: true });
+  }
+}
+
+const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (invokedDirectly) {
+  if (!existsSync(storeEntry)) {
+    console.error("build/lib/embedding-store.js missing - run `npm run build` first.");
+    process.exit(1);
+  }
+  const result = await runSimilarNotesQualityBench();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(result));
+  } else {
+    console.log(`NDCG@3 ${result.ndcgAt3.toFixed(3)}`);
+    console.log(`precision@3 ${result.precisionAt3.toFixed(3)}`);
+    console.log(`top relevance ${result.topRelevance}`);
+    console.log(`off-topic top result ${result.offTopicTopResult}`);
+    console.log("\n| rank | note | rel | score | chunk | heading |");
+    console.log("|---:|---|---:|---:|---:|---|");
+    for (const row of result.rows) {
+      console.log(
+        `| ${row.rank} | ${row.notePath} | ${row.relevance} | ${row.score.toFixed(3)} | ${row.chunkIndex} | ${row.headingPath.join(" / ")} |`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
Adds an active similar-note quality experiment with a synthetic embedding-store fixture that reproduces centroid drift toward unrelated source appendices.

Score: 1 severity x 3 reach / 1 effort = 3. Low risk: docs and benchmark only, no public API change.

Tests: `node scripts/bench-similar-notes-quality.mjs --json` twice; `npm run verify`.
Greptile: skipped because the trial review quota is exhausted.