### PR TITLE
fix: anchor similar note queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Active R&D experiment for similar-note quality, with a synthetic embedding-store fixture in `scripts/bench-similar-notes-quality.mjs` and ship/kill metric in `docs/rnd/similar-notes-quality.md`.
+- R&D experiment for similar-note quality, with a synthetic embedding-store fixture in `scripts/bench-similar-notes-quality.mjs` and ship/kill metric in `docs/rnd/similar-notes-quality.md`.
 - R&D experiment for semantic ranking quality, with a synthetic embedding-store fixture in `scripts/bench-semantic-ranking-quality.mjs` and ship/kill metric in `docs/rnd/semantic-ranking-quality.md`.
 - R&D experiment for chunker boundary quality, with a synthetic fixture in `scripts/bench-chunker-quality.mjs` and ship/kill metric in `docs/rnd/chunker-boundary-quality.md`.
 - Active R&D experiment for `get_daily_note` warm-path performance, with a synthetic benchmark harness in `scripts/bench-daily-notes.mjs` and ship/kill metric in `docs/rnd/daily-note-warm-path.md`.
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `find_similar_notes` now builds its source query vector from chunks aligned with the source note's opening topic, so unrelated appendices are less likely to dominate similar-note ranking.
 - Semantic search now ranks note-level results with a small focus signal from each note's top chunks, so one incidental high-scoring chunk is less likely to outrank notes that are consistently about the query.
 - Semantic chunking now keeps oversized fenced code blocks fence-balanced when splitting them for embeddings, preserving title and heading prefixes while leaving non-code chunking behavior unchanged.
 - `list_sections` now reuses a small mtime-validated rendered heading cache, cutting the 1,000-heading warm bench below the R&D ship bar while preserving heading escaping and write freshness.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Give AI assistants deep, structured access to your Obsidian knowledge base. Read
 ### Semantic Search (optional, Ollama or OpenAI)
 - `index_vault` chunks each note (heading-aware), embeds via the configured provider, persists vectors to `<vault>/.obsidian/cache/`, and incrementally re-embeds only changed notes
 - `search_semantic` ranks notes by cosine similarity against an embedded query
-- `find_similar_notes` reuses an existing note's embeddings to surface neighbors without a live API call
+- `find_similar_notes` reuses an existing note's embeddings, with source-topic anchoring, to surface neighbors without a live API call
 
 ### MCP Resources
 - `obsidian://note/{path}` reads any note by its vault-relative path
@@ -449,7 +449,7 @@ Tag extraction is similarly case-tolerant: `tags`, `Tags`, `TAGS`, `tag`, and `T
 |------|-------------|----------------|
 | `index_vault` | Build / refresh the embedding index (incremental, progress events) | `force`, `folder` |
 | `search_semantic` | Cosine search the embedding index for a natural-language query | `query`, `limit`, `folder`, `includeSnippet` |
-| `find_similar_notes` | Surface notes most similar to a source note (no live API call) | `path`, `limit` |
+| `find_similar_notes` | Surface notes most similar to a source note, anchored to its opening topic (no live API call) | `path`, `limit` |
 
 ---
 

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Similar Notes Quality](similar-notes-quality.md) | retrieval quality | active | Baseline NDCG@3 is 0.418 because unrelated source appendices pull `find_similar_notes` toward an off-topic kitchen note; next step is a source-anchoring prototype. |
+| [Similar Notes Quality](similar-notes-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.418 to 1.000, precision@3 rose from 0.667 to 1.000, and unrelated source appendices no longer push an off-topic kitchen note into first place. |
 | [Semantic Ranking Quality](semantic-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and grade-1 incidental matches no longer rank ahead of focused grade-3 notes. |
 | [Chunker Boundary Quality](chunker-boundary-quality.md) | retrieval quality | shipped | Score rose from 88.0 to 100.0, fenced-code fractures fell from two to zero, chunk count stayed at 21, and mean token load fell to 1.15x. |
 | [Daily Note Warm Path](daily-note-warm-path.md) | performance / agent workflows | stopped | Config and rendered-response cache prototypes missed the warm ship bar or exceeded guardrails, so no runtime change shipped. |

--- a/docs/rnd/similar-notes-quality.md
+++ b/docs/rnd/similar-notes-quality.md
@@ -1,15 +1,15 @@
 # Similar Notes Quality
 
-_Status: active_
-_Started: 2026-06-04 - Decided: pending_
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
-`find_similar_notes` computes one centroid from every source-note chunk. If a source
-note has unrelated appendices or copied material, that centroid can drift away from
-the note's main topic and return off-topic notes first. A measured fixture can test
-whether source-note anchoring or top-chunk selection improves similar-note quality
-without adding provider calls during search.
+`find_similar_notes` used to compute one centroid from every source-note chunk. If
+a source note had unrelated appendices or copied material, that centroid could drift
+away from the note's main topic and return off-topic notes first. Source-note
+anchoring should improve similar-note quality without adding provider calls during
+search.
 
 ## Fixture
 
@@ -41,10 +41,10 @@ and no off-topic top result.
 
 | metric | before | after |
 |---|---:|---:|
-| NDCG@3 | 0.418 | |
-| Precision@3 | 0.667 | |
-| Top relevance grade | 0 | |
-| Off-topic top result | true | |
+| NDCG@3 | 0.418 | 1.000 |
+| Precision@3 | 0.667 | 1.000 |
+| Top relevance grade | 0 | 3 |
+| Off-topic top result | true | false |
 
 Baseline command samples:
 
@@ -53,23 +53,30 @@ Baseline command samples:
 - `node scripts/bench-similar-notes-quality.mjs --json`: NDCG@3 0.418,
   precision@3 0.667, top relevance 0, off-topic top result true.
 
+After command samples:
+
+- `node scripts/bench-similar-notes-quality.mjs --json`: NDCG@3 1.000,
+  precision@3 1.000, top relevance 3, off-topic top result false.
+- `node scripts/bench-similar-notes-quality.mjs --json`: NDCG@3 1.000,
+  precision@3 1.000, top relevance 3, off-topic top result false.
+
 Current top five:
 
 | rank | note | rel | score | chunk |
 |---:|---|---:|---:|---:|
-| 1 | `kitchen-recipes.md` | 0 | 0.857 | 1 |
-| 2 | `pet-overview.md` | 2 | 0.759 | 1 |
-| 3 | `cats-care.md` | 3 | 0.581 | 2 |
-| 4 | `cat-health.md` | 3 | 0.549 | 1 |
+| 1 | `cats-care.md` | 3 | 1.000 | 2 |
+| 2 | `cat-health.md` | 3 | 0.998 | 1 |
+| 3 | `pet-overview.md` | 2 | 0.975 | 1 |
+| 4 | `kitchen-recipes.md` | 0 | 0.099 | 1 |
 | 5 | `dogs.md` | 0 | 0.000 | 1 |
 
 ## Safety review
 
 The fixture creates a temporary vault path and writes no note files. It calls the
 compiled embedding store with synthetic chunks and vectors, computes the same
-source centroid used by `find_similar_notes`, then clears the store and removes
-the temp directory. It performs no provider calls, no network calls, and no real
-vault reads or writes.
+source-anchored query vector used by `find_similar_notes`, then clears the store
+and removes the temp directory. It performs no provider calls, no network calls,
+and no real vault reads or writes.
 
 ## Kill criterion
 
@@ -79,5 +86,7 @@ or hiding the current best matching candidate chunk.
 
 ## Decision
 
-Active. The next step is a prototype that anchors the source representation to
-the source note's focused chunks while preserving the existing result shape.
+Shipped. `find_similar_notes` now builds a source-anchored query vector by giving
+chunks that align with the source note's opening chunk more weight. The fixture
+clears the ship bar while preserving tool names, parameters, result shape, and the
+best matching candidate chunk shown for each note.

--- a/scripts/bench-similar-notes-quality.mjs
+++ b/scripts/bench-similar-notes-quality.mjs
@@ -1,5 +1,5 @@
 // Similar-note quality benchmark: populate the embedding store with synthetic
-// vectors, run the same source-centroid search used by find_similar_notes, and
+// vectors, run the same source-anchored search used by find_similar_notes, and
 // score the returned note order.
 //
 // Direct use: node scripts/bench-similar-notes-quality.mjs [--json]
@@ -85,27 +85,13 @@ function ndcgAt(results, k) {
   return idealDcg === 0 ? 0 : dcg(actual) / idealDcg;
 }
 
-function centroid(chunks) {
-  const first = chunks[0];
-  const out = first.vector.slice();
-  for (let i = 1; i < chunks.length; i++) {
-    const vector = chunks[i].vector;
-    for (let d = 0; d < out.length; d++) {
-      out[d] += vector[d];
-    }
-  }
-  for (let d = 0; d < out.length; d++) {
-    out[d] /= chunks.length;
-  }
-  return out;
-}
-
 export async function runSimilarNotesQualityBench() {
   const {
     loadStore,
     setNoteChunks,
     searchEmbeddings,
     getNoteEmbeddings,
+    buildSimilarNotesQueryVector,
     hashText,
     clearStore,
   } = await import(pathToFileURL(storeEntry).href);
@@ -132,7 +118,7 @@ export async function runSimilarNotesQualityBench() {
     }
 
     const ownChunks = getNoteEmbeddings(vault, SOURCE_NOTE);
-    const queryVector = centroid(ownChunks);
+    const queryVector = buildSimilarNotesQueryVector(ownChunks);
     const hits = searchEmbeddings(vault, queryVector, {
       limit: LIMIT,
       excludeNotes: new Set([SOURCE_NOTE]),

--- a/src/__tests__/embedding-store.test.ts
+++ b/src/__tests__/embedding-store.test.ts
@@ -11,6 +11,8 @@ import {
   pruneMissingNotes,
   searchEmbeddings,
   cosineSimilarity,
+  getNoteEmbeddings,
+  buildSimilarNotesQueryVector,
   clearStore,
   snapshotForTests,
   invalidateIfIncompatible,
@@ -158,6 +160,45 @@ describe("setNoteChunks / searchEmbeddings", () => {
     ], "test", "m");
     const hits = searchEmbeddings(vaultDir, [1, 0], { excludeNotes: new Set(["self.md"]) });
     expect(hits.map((h) => h.notePath)).toEqual(["other.md"]);
+  });
+
+  it("anchors similar-note queries to the source note's opening topic", async () => {
+    await loadStore(vaultDir);
+    setNoteChunks(vaultDir, "source-cat-care.md", hashText("source"), [
+      { notePath: "source-cat-care.md", chunkIndex: 1, headingPath: ["Cats", "Care"], text: "cat care", hash: "h1", vector: [1, 0, 0] },
+      { notePath: "source-cat-care.md", chunkIndex: 2, headingPath: ["Appendix"], text: "recipe appendix", hash: "h2", vector: [0.1, 1, 0] },
+      { notePath: "source-cat-care.md", chunkIndex: 3, headingPath: ["Appendix"], text: "kitchen appendix", hash: "h3", vector: [0.1, 1, 0] },
+    ], "test", "m");
+    setNoteChunks(vaultDir, "cats-care.md", hashText("cats"), [
+      { notePath: "cats-care.md", chunkIndex: 1, headingPath: ["Cats", "Care"], text: "focused cat care", hash: "h4", vector: [0.98, 0.05, 0] },
+      { notePath: "cats-care.md", chunkIndex: 2, headingPath: ["Cats", "Behavior"], text: "cat behavior", hash: "h5", vector: [0.96, 0.08, 0] },
+    ], "test", "m");
+    setNoteChunks(vaultDir, "cat-health.md", hashText("health"), [
+      { notePath: "cat-health.md", chunkIndex: 1, headingPath: ["Cats", "Health"], text: "cat health", hash: "h6", vector: [0.97, 0.04, 0] },
+    ], "test", "m");
+    setNoteChunks(vaultDir, "pet-overview.md", hashText("pets"), [
+      { notePath: "pet-overview.md", chunkIndex: 1, headingPath: ["Pets"], text: "mixed pets", hash: "h7", vector: [0.75, 0.25, 0] },
+    ], "test", "m");
+    setNoteChunks(vaultDir, "kitchen-recipes.md", hashText("kitchen"), [
+      { notePath: "kitchen-recipes.md", chunkIndex: 1, headingPath: ["Kitchen"], text: "recipes", hash: "h8", vector: [0, 1, 0] },
+    ], "test", "m");
+
+    const queryVector = buildSimilarNotesQueryVector(
+      getNoteEmbeddings(vaultDir, "source-cat-care.md"),
+    );
+    const hits = searchEmbeddings(vaultDir, queryVector, {
+      limit: 4,
+      excludeNotes: new Set(["source-cat-care.md"]),
+    });
+
+    expect(queryVector[0]).toBeGreaterThan(queryVector[1]!);
+    expect(hits.map((hit) => hit.notePath)).toEqual([
+      "cats-care.md",
+      "cat-health.md",
+      "pet-overview.md",
+      "kitchen-recipes.md",
+    ]);
+    expect(hits[0].headingPath[0]).toBe("Cats");
   });
 });
 

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -31,6 +31,8 @@ const STORE_VERSION = 1;
 const NOTE_BEST_CHUNK_WEIGHT = 0.8;
 const NOTE_FOCUS_WEIGHT = 0.2;
 const NOTE_FOCUS_CHUNKS = 3;
+const SIMILAR_SOURCE_MIN_CHUNK_WEIGHT = 0.05;
+const SIMILAR_SOURCE_ANCHOR_POWER = 2;
 // Hard cap on the on-disk snapshot size. A 50k-note vault with 768-dim
 // vectors can produce a multi-GB JSON blob, at which point persisting it
 // each pass costs more than the cold-start re-embed it saves. When the
@@ -534,6 +536,33 @@ function noteFocusScore(scores: number[]): number {
   const best = top[0] ?? 0;
   const focus = top.reduce((sum, score) => sum + score, 0) / top.length;
   return NOTE_BEST_CHUNK_WEIGHT * best + NOTE_FOCUS_WEIGHT * focus;
+}
+
+export function buildSimilarNotesQueryVector(chunks: readonly ChunkEmbedding[]): number[] {
+  const firstChunk = chunks[0];
+  if (!firstChunk) return [];
+
+  const dim = firstChunk.vector.length;
+  const anchor = firstChunk.vector;
+  const out = new Array<number>(dim).fill(0);
+  let totalWeight = 0;
+
+  for (const chunk of chunks) {
+    const anchorSimilarity = Math.max(0, cosineSimilarity(anchor, chunk.vector));
+    const weight = chunk === firstChunk
+      ? 1
+      : Math.max(SIMILAR_SOURCE_MIN_CHUNK_WEIGHT, anchorSimilarity ** SIMILAR_SOURCE_ANCHOR_POWER);
+    for (let d = 0; d < dim; d++) {
+      out[d] = out[d]! + chunk.vector[d]! * weight;
+    }
+    totalWeight += weight;
+  }
+
+  if (totalWeight === 0) return out;
+  for (let d = 0; d < dim; d++) {
+    out[d] = out[d]! / totalWeight;
+  }
+  return out;
 }
 
 /** Get the embeddings owned by a specific note (used by find_similar). */

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -13,6 +13,7 @@ import {
   pruneMissingNotes,
   searchEmbeddings,
   getNoteEmbeddings,
+  buildSimilarNotesQueryVector,
   snapshotForTests,
   invalidateIfIncompatible,
   type ChunkEmbedding,
@@ -350,7 +351,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
     {
       title: "Find Similar Notes",
       description:
-        "Given a note path, return the K most semantically similar notes from the index (excluding the source note). Uses the source note's existing chunk embeddings — no live API call to the embedding provider, so this is fast and free. Run `index_vault` first to populate embeddings for both the source and the candidates.",
+        "Given a note path, return the K most semantically similar notes from the index (excluding the source note). Uses the source note's existing chunk embeddings and anchors the source query to chunks aligned with the note's opening topic — no live API call to the embedding provider, so this is fast and free. Run `index_vault` first to populate embeddings for both the source and the candidates.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,
@@ -388,32 +389,9 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
             `No embeddings found for "${displaySemanticValue(notePath)}". Run \`index_vault\` first (or check the path is correct).`,
           );
         }
-        // Compute a centroid (mean) vector from all of the source note's
-        // chunk embeddings, then run a single searchEmbeddings pass over
-        // the store. This is O(totalChunks) instead of the previous
-        // O(ownChunks * totalChunks) which compared every source chunk
-        // against every stored chunk. The centroid is a standard
-        // document-level representation; searchEmbeddings already
-        // deduplicates per note (keeping the best-scoring chunk), so the
-        // ranking quality stays high.
-        const firstChunk = ownChunks[0]!;
-        const dim = firstChunk.vector.length;
-        // Build centroid: average all chunk vectors element-wise. Start
-        // from a copy of the first vector, accumulate the rest, then
-        // divide by count. This avoids strict-mode indexed-access issues
-        // with typed arrays while keeping the logic straightforward.
-        const centroid = firstChunk.vector.slice();
-        for (let ci = 1; ci < ownChunks.length; ci++) {
-          const vec = ownChunks[ci]!.vector;
-          for (let d = 0; d < dim; d++) {
-            centroid[d] = centroid[d]! + vec[d]!;
-          }
-        }
-        for (let d = 0; d < dim; d++) {
-          centroid[d] = centroid[d]! / ownChunks.length;
-        }
+        const queryVector = buildSimilarNotesQueryVector(ownChunks);
         const exclude = new Set([notePath]);
-        const hits = searchEmbeddings(vaultPath, centroid, {
+        const hits = searchEmbeddings(vaultPath, queryVector, {
           limit,
           excludeNotes: exclude,
         });


### PR DESCRIPTION
Changes `find_similar_notes` to build its source query vector from chunks aligned with the source note's opening topic, which keeps unrelated appendices from dominating similar-note ranking. The R&D fixture moved from NDCG@3 0.418 / precision@3 0.667 to 1.000 / 1.000 while keeping the same tool schema and result shape.

Score: 2 severity x 3 reach / 1 effort = 6. Risk: low; the change stays inside existing embedding-store ranking and keeps the best matching candidate chunk visible for each returned note.

Tests: `npx vitest run src/__tests__/embedding-store.test.ts src/__tests__/handlers/semantic.test.ts`; `node scripts/bench-similar-notes-quality.mjs --json` twice; `npm run verify`.
Greptile: skipped because the trial review quota is exhausted.