### PR TITLE
chore: start search ranking quality rnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Active R&D experiment for lexical search ranking quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-ranking-quality.mjs` and ship/kill metric in `docs/rnd/search-ranking-quality.md`.
 - R&D experiment for similar-note quality, with a synthetic embedding-store fixture in `scripts/bench-similar-notes-quality.mjs` and ship/kill metric in `docs/rnd/similar-notes-quality.md`.
 - R&D experiment for semantic ranking quality, with a synthetic embedding-store fixture in `scripts/bench-semantic-ranking-quality.mjs` and ship/kill metric in `docs/rnd/semantic-ranking-quality.md`.
 - R&D experiment for chunker boundary quality, with a synthetic fixture in `scripts/bench-chunker-quality.mjs` and ship/kill metric in `docs/rnd/chunker-boundary-quality.md`.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,6 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
+| [Search Ranking Quality](search-ranking-quality.md) | retrieval quality | active | Baseline NDCG@3 is 0.690 because repeated incidental mentions can outrank focused lexical matches; next step is a focused-match ranking prototype. |
 | [Similar Notes Quality](similar-notes-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.418 to 1.000, precision@3 rose from 0.667 to 1.000, and unrelated source appendices no longer push an off-topic kitchen note into first place. |
 | [Semantic Ranking Quality](semantic-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and grade-1 incidental matches no longer rank ahead of focused grade-3 notes. |
 | [Chunker Boundary Quality](chunker-boundary-quality.md) | retrieval quality | shipped | Score rose from 88.0 to 100.0, fenced-code fractures fell from two to zero, chunk count stayed at 21, and mean token load fell to 1.15x. |

--- a/docs/rnd/search-ranking-quality.md
+++ b/docs/rnd/search-ranking-quality.md
@@ -1,0 +1,84 @@
+# Search Ranking Quality
+
+_Status: active_
+_Started: 2026-06-04 - Decided: pending_
+
+## Hypothesis
+
+`search_notes` ranks lexical matches by raw match count. A long or noisy note with
+many incidental mentions can outrank shorter notes whose title and body are more
+focused on the user's query. A measured fixture can test whether a lightweight
+focus signal improves lexical search ranking without changing the tool schema or
+adding provider calls.
+
+## Fixture
+
+The fixture is `scripts/bench-search-ranking-quality.mjs`.
+
+It calls `searchInContents` with synthetic note bodies for query `migration`:
+
+- `meeting-transcript.md`: grade-1 relevance, eight incidental mentions,
+- `migration-plan.md`: grade-3 relevance, four focused mentions,
+- `migration-checklist.md`: grade-3 relevance, three focused mentions,
+- `release-notes.md`: grade-2 relevance, one related mention,
+- `zz-glossary.md`: grade-0 relevance, one generic definition,
+- `cooking.md`: grade-0 relevance, no match.
+
+Run:
+
+```powershell
+npm run build
+node scripts/bench-search-ranking-quality.mjs --json
+```
+
+## Metric
+
+Primary metric: NDCG@3 for lexical `search_notes` ordering. Secondary guardrails
+are precision@3, the top result's relevance grade, and whether an incidental
+grade-1 note ranks before focused grade-3 notes.
+
+Ship bar: NDCG@3 at or above 0.900, precision@3 at 1.000, top relevance grade 3,
+and no incidental-before-focused ordering.
+
+| metric | before | after |
+|---|---:|---:|
+| NDCG@3 | 0.690 | |
+| Precision@3 | 0.667 | |
+| Top relevance grade | 1 | |
+| Incidental before focused | true | |
+
+Baseline command samples:
+
+- `node scripts/bench-search-ranking-quality.mjs --json`: NDCG@3 0.690,
+  precision@3 0.667, top relevance 1, incidental before focused true.
+- `node scripts/bench-search-ranking-quality.mjs --json`: NDCG@3 0.690,
+  precision@3 0.667, top relevance 1, incidental before focused true.
+
+Current top five:
+
+| rank | note | rel | matches | score |
+|---:|---|---:|---:|---:|
+| 1 | `meeting-transcript.md` | 1 | 8 | 8 |
+| 2 | `migration-plan.md` | 3 | 4 | 4 |
+| 3 | `migration-checklist.md` | 3 | 3 | 3 |
+| 4 | `release-notes.md` | 2 | 1 | 1 |
+| 5 | `zz-glossary.md` | 0 | 1 | 1 |
+
+## Safety review
+
+The fixture uses in-memory synthetic note bodies and calls the compiled pure
+scanner directly. It performs no filesystem writes, no provider calls, no network
+calls, and no real vault reads. Any prototype must preserve escaped output,
+literal string matching, case-sensitivity behavior, folder handling, and
+`maxResults` bounds.
+
+## Kill criterion
+
+Stop if a prototype cannot clear the ship bar without changing `search_notes`
+tool parameters or return shape, adding semantic/provider calls, or hiding the
+line snippets that explain each lexical hit.
+
+## Decision
+
+Active. The next step is a ranking prototype that rewards focused title/body
+matches without making long repeated notes disappear from the result set.

--- a/scripts/bench-search-ranking-quality.mjs
+++ b/scripts/bench-search-ranking-quality.mjs
@@ -1,0 +1,147 @@
+// Lexical search ranking benchmark: run searchInContents over synthetic note
+// bodies and score whether focused notes outrank noisy repeated mentions.
+//
+// Direct use: node scripts/bench-search-ranking-quality.mjs [--json]
+// Run after `npm run build`.
+
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const vaultEntry = join(root, "build", "lib", "vault.js");
+const QUERY = "migration";
+const LIMIT = 5;
+
+const notes = [
+  {
+    path: "meeting-transcript.md",
+    relevance: 1,
+    content: [
+      "# Meeting Transcript",
+      "",
+      "Migration came up repeatedly while the group was discussing unrelated staffing updates.",
+      "Migration migration migration migration migration migration migration.",
+    ].join("\n"),
+  },
+  {
+    path: "migration-plan.md",
+    relevance: 3,
+    content: [
+      "# Migration Plan",
+      "",
+      "Migration scope, migration rollback, and migration owner decisions for the database cutover.",
+    ].join("\n"),
+  },
+  {
+    path: "migration-checklist.md",
+    relevance: 3,
+    content: [
+      "# Migration Checklist",
+      "",
+      "Migration prerequisites and migration verification steps for the production cutover.",
+    ].join("\n"),
+  },
+  {
+    path: "release-notes.md",
+    relevance: 2,
+    content: [
+      "# Release Notes",
+      "",
+      "The migration is mentioned as one part of the release, with links to the plan.",
+    ].join("\n"),
+  },
+  {
+    path: "zz-glossary.md",
+    relevance: 0,
+    content: [
+      "# Glossary",
+      "",
+      "Migration: a term that appears in a generic vocabulary list.",
+    ].join("\n"),
+  },
+  {
+    path: "cooking.md",
+    relevance: 0,
+    content: [
+      "# Cooking",
+      "",
+      "Pantry planning and recipe notes.",
+    ].join("\n"),
+  },
+];
+
+function gain(relevance) {
+  return (2 ** relevance) - 1;
+}
+
+function dcg(relevances) {
+  return relevances.reduce((sum, relevance, index) => {
+    return sum + gain(relevance) / Math.log2(index + 2);
+  }, 0);
+}
+
+function ndcgAt(results, k) {
+  const actual = results.slice(0, k).map((row) => row.relevance);
+  const ideal = [...notes]
+    .sort((a, b) => b.relevance - a.relevance)
+    .slice(0, k)
+    .map((row) => row.relevance);
+  const idealDcg = dcg(ideal);
+  return idealDcg === 0 ? 0 : dcg(actual) / idealDcg;
+}
+
+function hasIncidentalBeforeFocused(results) {
+  const firstFocused = results.findIndex((row) => row.relevance === 3);
+  const firstIncidental = results.findIndex((row) => row.relevance === 1);
+  return firstIncidental !== -1 && firstFocused !== -1 && firstIncidental < firstFocused;
+}
+
+export async function runSearchRankingQualityBench() {
+  const { searchInContents } = await import(pathToFileURL(vaultEntry).href);
+  const notePaths = notes.map((note) => note.path);
+  const contents = new Map(notes.map((note) => [note.path, note.content]));
+  const hits = searchInContents(notePaths, contents, QUERY, { maxResults: LIMIT });
+  const relevanceByPath = new Map(notes.map((note) => [note.path, note.relevance]));
+  const rows = hits.map((hit, index) => ({
+    rank: index + 1,
+    notePath: hit.relativePath,
+    score: hit.score,
+    matchCount: hit.matches.length,
+    firstLine: hit.matches[0]?.line ?? null,
+    relevance: relevanceByPath.get(hit.relativePath) ?? 0,
+  }));
+  const topK = rows.slice(0, 3);
+
+  return {
+    query: QUERY,
+    limit: LIMIT,
+    ndcgAt3: ndcgAt(rows, 3),
+    precisionAt3: topK.filter((row) => row.relevance >= 2).length / 3,
+    topRelevance: rows[0]?.relevance ?? 0,
+    incidentalBeforeFocused: hasIncidentalBeforeFocused(rows),
+    rows,
+  };
+}
+
+const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (invokedDirectly) {
+  if (!existsSync(vaultEntry)) {
+    console.error("build/lib/vault.js missing - run `npm run build` first.");
+    process.exit(1);
+  }
+  const result = await runSearchRankingQualityBench();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(result));
+  } else {
+    console.log(`NDCG@3 ${result.ndcgAt3.toFixed(3)}`);
+    console.log(`precision@3 ${result.precisionAt3.toFixed(3)}`);
+    console.log(`top relevance ${result.topRelevance}`);
+    console.log(`incidental before focused ${result.incidentalBeforeFocused}`);
+    console.log("\n| rank | note | rel | matches | score |");
+    console.log("|---:|---|---:|---:|---:|");
+    for (const row of result.rows) {
+      console.log(`| ${row.rank} | ${row.notePath} | ${row.relevance} | ${row.matchCount} | ${row.score} |`);
+    }
+  }
+}


### PR DESCRIPTION
Adds an active lexical search ranking experiment with a synthetic `searchInContents` fixture showing repeated incidental mentions outranking focused migration notes. Baseline NDCG@3 is 0.690, precision@3 is 0.667, and the grade-1 transcript ranks first.

Score: 1 severity x 3 reach / 1 effort = 3. Low risk: docs and benchmark only, no public API change.

Tests: `node scripts/bench-search-ranking-quality.mjs --json` twice; `npm run verify`.
Greptile: skipped because the trial review quota is exhausted.