### PR TITLE
fix: rank search notes by focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Active R&D experiment for lexical search ranking quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-ranking-quality.mjs` and ship/kill metric in `docs/rnd/search-ranking-quality.md`.
+- R&D experiment for lexical search ranking quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-ranking-quality.mjs` and ship/kill metric in `docs/rnd/search-ranking-quality.md`.
 - R&D experiment for similar-note quality, with a synthetic embedding-store fixture in `scripts/bench-similar-notes-quality.mjs` and ship/kill metric in `docs/rnd/similar-notes-quality.md`.
 - R&D experiment for semantic ranking quality, with a synthetic embedding-store fixture in `scripts/bench-semantic-ranking-quality.mjs` and ship/kill metric in `docs/rnd/semantic-ranking-quality.md`.
 - R&D experiment for chunker boundary quality, with a synthetic fixture in `scripts/bench-chunker-quality.mjs` and ship/kill metric in `docs/rnd/chunker-boundary-quality.md`.
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `search_notes` now ranks literal matches with title/path focus and repeated-line dampening, so noisy repeated mentions are less likely to outrank focused notes.
 - `find_similar_notes` now builds its source query vector from chunks aligned with the source note's opening topic, so unrelated appendices are less likely to dominate similar-note ranking.
 - Semantic search now ranks note-level results with a small focus signal from each note's top chunks, so one incidental high-scoring chunk is less likely to outrank notes that are consistently about the query.
 - Semantic chunking now keeps oversized fenced code blocks fence-balanced when splitting them for embeddings, preserving title and heading prefixes while leaving non-code chunking behavior unchanged.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Give AI assistants deep, structured access to your Obsidian knowledge base. Read
 ## Features
 
 ### Read & Search
-- Full-text search across all vault notes (cached: re-runs only re-read changed files)
+- Focus-ranked full-text search across all vault notes (cached: re-runs only re-read changed files)
 - Read individual notes whole, or as a fragment by heading path, block id, or line range
 - List and filter notes by folder, date, or pattern
 - Search by frontmatter fields and values
@@ -369,7 +369,7 @@ Tag extraction is similarly case-tolerant: `tags`, `Tags`, `TAGS`, `tag`, and `T
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `search_notes` | Full-text search across all notes (cached) | `query`, `caseSensitive`, `maxResults`, `folder` |
+| `search_notes` | Focus-ranked full-text search across all notes (cached) | `query`, `caseSensitive`, `maxResults`, `folder` |
 | `get_note` | Read a note whole, or by `section` / `block` / `lines` | `path`, `section`, `block`, `lines` |
 | `list_notes` | List notes in the vault or a folder | `folder`, `limit` |
 | `get_daily_note` | Get today's (or a specific date's) daily note | `date` |

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Search Ranking Quality](search-ranking-quality.md) | retrieval quality | active | Baseline NDCG@3 is 0.690 because repeated incidental mentions can outrank focused lexical matches; next step is a focused-match ranking prototype. |
+| [Search Ranking Quality](search-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and repeated incidental mentions no longer rank ahead of focused lexical matches. |
 | [Similar Notes Quality](similar-notes-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.418 to 1.000, precision@3 rose from 0.667 to 1.000, and unrelated source appendices no longer push an off-topic kitchen note into first place. |
 | [Semantic Ranking Quality](semantic-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and grade-1 incidental matches no longer rank ahead of focused grade-3 notes. |
 | [Chunker Boundary Quality](chunker-boundary-quality.md) | retrieval quality | shipped | Score rose from 88.0 to 100.0, fenced-code fractures fell from two to zero, chunk count stayed at 21, and mean token load fell to 1.15x. |

--- a/docs/rnd/search-ranking-quality.md
+++ b/docs/rnd/search-ranking-quality.md
@@ -1,15 +1,15 @@
 # Search Ranking Quality
 
-_Status: active_
-_Started: 2026-06-04 - Decided: pending_
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
-`search_notes` ranks lexical matches by raw match count. A long or noisy note with
-many incidental mentions can outrank shorter notes whose title and body are more
-focused on the user's query. A measured fixture can test whether a lightweight
-focus signal improves lexical search ranking without changing the tool schema or
-adding provider calls.
+`search_notes` used to rank lexical matches by raw match count. A long or noisy
+note with many incidental mentions could outrank shorter notes whose title and
+body are more focused on the user's query. A lightweight focus signal should
+improve lexical search ranking without changing the tool schema or adding
+provider calls.
 
 ## Fixture
 
@@ -42,10 +42,10 @@ and no incidental-before-focused ordering.
 
 | metric | before | after |
 |---|---:|---:|
-| NDCG@3 | 0.690 | |
-| Precision@3 | 0.667 | |
-| Top relevance grade | 1 | |
-| Incidental before focused | true | |
+| NDCG@3 | 0.690 | 1.000 |
+| Precision@3 | 0.667 | 1.000 |
+| Top relevance grade | 1 | 3 |
+| Incidental before focused | true | false |
 
 Baseline command samples:
 
@@ -54,15 +54,22 @@ Baseline command samples:
 - `node scripts/bench-search-ranking-quality.mjs --json`: NDCG@3 0.690,
   precision@3 0.667, top relevance 1, incidental before focused true.
 
+After command samples:
+
+- `node scripts/bench-search-ranking-quality.mjs --json`: NDCG@3 1.000,
+  precision@3 1.000, top relevance 3, incidental before focused false.
+- `node scripts/bench-search-ranking-quality.mjs --json`: NDCG@3 1.000,
+  precision@3 1.000, top relevance 3, incidental before focused false.
+
 Current top five:
 
 | rank | note | rel | matches | score |
 |---:|---|---:|---:|---:|
-| 1 | `meeting-transcript.md` | 1 | 8 | 8 |
-| 2 | `migration-plan.md` | 3 | 4 | 4 |
-| 3 | `migration-checklist.md` | 3 | 3 | 3 |
-| 4 | `release-notes.md` | 2 | 1 | 1 |
-| 5 | `zz-glossary.md` | 0 | 1 | 1 |
+| 1 | `migration-checklist.md` | 3 | 3 | 9.847 |
+| 2 | `migration-plan.md` | 3 | 4 | 9.402 |
+| 3 | `release-notes.md` | 2 | 1 | 1.173 |
+| 4 | `zz-glossary.md` | 0 | 1 | 1.173 |
+| 5 | `meeting-transcript.md` | 1 | 8 | 0.000 |
 
 ## Safety review
 
@@ -80,5 +87,7 @@ line snippets that explain each lexical hit.
 
 ## Decision
 
-Active. The next step is a ranking prototype that rewards focused title/body
-matches without making long repeated notes disappear from the result set.
+Shipped. `search_notes` now scores literal matches with a small focus signal from
+note paths and headings, plus dampening for repeated matches on the same line.
+The fixture clears the ship bar while preserving tool names, parameters, result
+shape, literal matching, and the matched line snippets shown for each hit.

--- a/scripts/bench-search-ranking-quality.mjs
+++ b/scripts/bench-search-ranking-quality.mjs
@@ -141,7 +141,7 @@ if (invokedDirectly) {
     console.log("\n| rank | note | rel | matches | score |");
     console.log("|---:|---|---:|---:|---:|");
     for (const row of result.rows) {
-      console.log(`| ${row.rank} | ${row.notePath} | ${row.relevance} | ${row.matchCount} | ${row.score} |`);
+      console.log(`| ${row.rank} | ${row.notePath} | ${row.relevance} | ${row.matchCount} | ${row.score.toFixed(3)} |`);
     }
   }
 }

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -50,6 +50,40 @@ describe("read handlers — search_notes", () => {
     expect(Number(headerMatch![1])).toBeLessThanOrEqual(2);
   });
 
+  it("orders focused title matches before repeated incidental mentions", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, "meeting-transcript.md"),
+      [
+        "# Meeting Transcript",
+        "Migration came up during staffing notes.",
+        "Migration migration migration migration migration migration migration.",
+      ].join("\n"),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(env.vaultDir, "migration-plan.md"),
+      "# Migration Plan\nMigration scope and rollback owner decisions.",
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(env.vaultDir, "release-notes.md"),
+      "# Release Notes\nThe migration is one part of the release.",
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "search_notes",
+      arguments: { query: "migration", maxResults: 3 },
+    });
+
+    const headings = textContent(result).split("\n").filter((line) => line.startsWith("## "));
+    expect(headings).toEqual([
+      "## migration-plan.md",
+      "## release-notes.md",
+      "## meeting-transcript.md",
+    ]);
+  });
+
   it("restricts scan to a folder when folder= is set", async () => {
     const result = await env.client.callTool({
       name: "search_notes",

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -417,6 +417,51 @@ describe("searchInContents", () => {
       { line: 3, content: "Alpha beta", column: 0 },
     ]);
   });
+
+  it("ranks focused title matches ahead of repeated incidental mentions", () => {
+    const contents = new Map([
+      [
+        "meeting-transcript.md",
+        [
+          "# Meeting Transcript",
+          "Migration came up during staffing notes.",
+          "Migration migration migration migration migration migration migration.",
+        ].join("\n"),
+      ],
+      [
+        "migration-plan.md",
+        "# Migration Plan\nMigration scope and rollback owner decisions.",
+      ],
+      [
+        "migration-checklist.md",
+        "# Migration Checklist\nMigration prerequisites and verification.",
+      ],
+      [
+        "release-notes.md",
+        "# Release Notes\nThe migration is one part of the release.",
+      ],
+    ]);
+
+    const results = searchInContents(
+      [
+        "meeting-transcript.md",
+        "migration-plan.md",
+        "migration-checklist.md",
+        "release-notes.md",
+      ],
+      contents,
+      "migration",
+      { maxResults: 4 },
+    );
+
+    expect(results.map((result) => result.relativePath)).toEqual([
+      "migration-checklist.md",
+      "migration-plan.md",
+      "release-notes.md",
+      "meeting-transcript.md",
+    ]);
+    expect(results.at(-1)?.matches).toHaveLength(8);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -11,6 +11,10 @@ import type { SearchResult, SearchMatch, CanvasData } from "../types.js";
 // on spinning disks; lower values leave SSD throughput on the table. 8 is the
 // sweet spot on a typical developer workstation.
 const SCAN_CONCURRENCY = 8;
+const SEARCH_PATH_MATCH_BOOST = 4;
+const SEARCH_HEADING_MATCH_BOOST = 4;
+const SEARCH_MATCH_COUNT_WEIGHT = 0.25;
+const SEARCH_REPEATED_SAME_LINE_PENALTY = 0.5;
 
 const EXCLUDED_DIRS = [".obsidian", ".trash", ".git"];
 const EXCLUDED_SET = new Set(EXCLUDED_DIRS);
@@ -931,14 +935,34 @@ export function searchInContents(
       path: notePath,
       relativePath: notePath,
       matches,
-      score: matches.length,
+      score: scoreLexicalMatches(notePath, lines, matches, searchQuery, caseSensitive),
     });
   }
-  // Primary: match count (desc). Secondary: relative path (asc) — otherwise
+  // Primary: lexical focus score (desc). Secondary: relative path (asc) — otherwise
   // tie-breaking order depends on iteration timing, which makes results for
   // equal-score queries non-deterministic between runs.
   results.sort((a, b) => b.score - a.score || a.relativePath.localeCompare(b.relativePath));
   return results.slice(0, maxResults);
+}
+
+function scoreLexicalMatches(
+  notePath: string,
+  lines: readonly string[],
+  matches: readonly SearchMatch[],
+  searchQuery: string,
+  caseSensitive: boolean,
+): number {
+  const matchingLines = new Set(matches.map((match) => match.line)).size;
+  const repeatedSameLineMatches = matches.length - matchingLines;
+  const pathText = caseSensitive ? notePath : notePath.toLowerCase();
+  const firstHeading = lines.find((line) => line.trimStart().startsWith("#")) ?? "";
+  const headingText = caseSensitive ? firstHeading : firstHeading.toLowerCase();
+
+  let score = matchingLines + Math.log1p(matches.length) * SEARCH_MATCH_COUNT_WEIGHT;
+  if (pathText.includes(searchQuery)) score += SEARCH_PATH_MATCH_BOOST;
+  if (headingText.includes(searchQuery)) score += SEARCH_HEADING_MATCH_BOOST;
+  score -= repeatedSameLineMatches * SEARCH_REPEATED_SAME_LINE_PENALTY;
+  return Math.max(0, score);
 }
 
 export async function searchNotes(

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -36,7 +36,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
     {
       title: "Search Notes",
       description:
-        "Full-text search across all notes in the vault. Returns matching note paths grouped with the line numbers and snippet content of each hit. Use to locate notes containing a phrase, keyword, or code fragment; pair with get_note to retrieve full bodies.",
+        "Full-text search across all notes in the vault. Ranks literal matches with title/path focus and repeated-line dampening, then returns matching note paths grouped with the line numbers and snippet content of each hit. Use to locate notes containing a phrase, keyword, or code fragment; pair with get_note to retrieve full bodies.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,


### PR DESCRIPTION
Changes `search_notes` ranking to use title/path focus and repeated-line dampening instead of raw match count alone. The search ranking fixture moved from NDCG@3 0.690 / precision@3 0.667 to 1.000 / 1.000 while keeping the same tool schema and text result shape.

Score: 2 severity x 3 reach / 1 effort = 6. Risk: ordering-only change; literal matching, snippets, caps, case sensitivity, and folder behavior are preserved.

Tested with `npx vitest run src/__tests__/vault.test.ts src/__tests__/handlers/read.test.ts`, `node scripts/bench-search-ranking-quality.mjs --json` twice, and `npm run verify`.

Greptile review is unavailable because the trial review limit is exhausted.