### PR TITLE
chore: start search snippet quality rnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - R&D experiment for lexical search ranking quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-ranking-quality.mjs` and ship/kill metric in `docs/rnd/search-ranking-quality.md`.
+- R&D experiment for lexical search snippet quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-snippet-quality.mjs` and ship/kill metric in `docs/rnd/search-snippet-quality.md`.
 - R&D experiment for similar-note quality, with a synthetic embedding-store fixture in `scripts/bench-similar-notes-quality.mjs` and ship/kill metric in `docs/rnd/similar-notes-quality.md`.
 - R&D experiment for semantic ranking quality, with a synthetic embedding-store fixture in `scripts/bench-semantic-ranking-quality.mjs` and ship/kill metric in `docs/rnd/semantic-ranking-quality.md`.
 - R&D experiment for chunker boundary quality, with a synthetic fixture in `scripts/bench-chunker-quality.mjs` and ship/kill metric in `docs/rnd/chunker-boundary-quality.md`.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,6 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
+| [Search Snippet Quality](search-snippet-quality.md) | retrieval quality | active | Baseline duplicate snippet rows are 6 because repeated hits on one line are rendered as separate rows; next step is a duplicate-line collapse prototype. |
 | [Search Ranking Quality](search-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and repeated incidental mentions no longer rank ahead of focused lexical matches. |
 | [Similar Notes Quality](similar-notes-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.418 to 1.000, precision@3 rose from 0.667 to 1.000, and unrelated source appendices no longer push an off-topic kitchen note into first place. |
 | [Semantic Ranking Quality](semantic-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and grade-1 incidental matches no longer rank ahead of focused grade-3 notes. |

--- a/docs/rnd/search-snippet-quality.md
+++ b/docs/rnd/search-snippet-quality.md
@@ -1,0 +1,76 @@
+# Search Snippet Quality
+
+_Status: active_
+_Started: 2026-06-04 - Decided: pending_
+
+## Hypothesis
+
+`search_notes` now ranks focused notes ahead of repeated incidental mentions, but
+the snippet rows can still repeat the same line once per literal hit. A noisy line
+with the query repeated many times can spend result space on duplicate evidence.
+A measured fixture can test whether duplicate same-line snippets can be collapsed
+without changing tool names, parameters, or the note ranking logic.
+
+## Fixture
+
+`scripts/bench-search-snippet-quality.mjs` builds five synthetic notes and calls
+`searchInContents` for query `migration` with `maxResults: 5`:
+
+- two focused migration notes with query hits spread across separate lines
+- one release note with a single mention
+- one glossary note with a generic mention
+- one meeting transcript with eight hits across two lines
+
+The matcher output is the source that `search_notes` renders into text rows, so
+the fixture measures visible snippet duplication without adding a tool surface.
+
+## Metric
+
+Primary metric: duplicate snippet rows, counted as `matches.length - unique line
+count` for each returned note, summed across results. Ship only if duplicate
+snippet rows fall to zero while every matching note still has at least one
+visible snippet line.
+
+| metric | before | after |
+|---|---:|---:|
+| Duplicate snippet rows | 6 | |
+| Unique line coverage | 0.667 | |
+| Total snippet rows | 18 | |
+| Unique snippet lines | 12 | |
+
+Baseline command samples:
+
+- `node scripts/bench-search-snippet-quality.mjs --json`: duplicate snippet rows
+  6, unique line coverage 0.667, total snippet rows 18, unique snippet lines 12.
+- `node scripts/bench-search-snippet-quality.mjs --json`: duplicate snippet rows
+  6, unique line coverage 0.667, total snippet rows 18, unique snippet lines 12.
+
+Current rows:
+
+| note | matches | unique lines | duplicate rows |
+|---|---:|---:|---:|
+| `migration-checklist.md` | 4 | 4 | 0 |
+| `migration-plan.md` | 4 | 4 | 0 |
+| `release-notes.md` | 1 | 1 | 0 |
+| `zz-glossary.md` | 1 | 1 | 0 |
+| `meeting-transcript.md` | 8 | 2 | 6 |
+
+## Safety review
+
+The fixture uses in-memory synthetic note bodies and reads the built
+`searchInContents` implementation. It performs no vault I/O, writes no notes,
+does not touch permissions, and emits only aggregate metric rows. Any prototype
+must keep raw matching case sensitivity, note order, max-result caps, and folder
+filter behavior intact.
+
+## Kill criterion
+
+Stop without a runtime change if collapsing duplicate snippet rows hides the
+fact that a returned note matched the query, changes ranking, or requires a new
+public parameter or result format.
+
+## Decision
+
+Active. The next step is a narrow rendering or matcher prototype that collapses
+duplicate same-line snippets while keeping at least one snippet per matching
+line and preserving the current ranking behavior.

--- a/scripts/bench-search-snippet-quality.mjs
+++ b/scripts/bench-search-snippet-quality.mjs
@@ -1,0 +1,116 @@
+// Lexical search snippet-quality benchmark: run searchInContents over synthetic
+// note bodies and measure repeated same-line snippet rows.
+//
+// Direct use: node scripts/bench-search-snippet-quality.mjs [--json]
+// Run after `npm run build`.
+
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const vaultEntry = join(root, "build", "lib", "vault.js");
+const QUERY = "migration";
+const LIMIT = 5;
+
+const notes = [
+  {
+    path: "migration-checklist.md",
+    content: [
+      "# Migration Checklist",
+      "",
+      "Migration prerequisites are ready.",
+      "Rollback owners review the migration checklist.",
+      "Post-deploy validation tracks migration health.",
+    ].join("\n"),
+  },
+  {
+    path: "migration-plan.md",
+    content: [
+      "# Migration Plan",
+      "",
+      "Migration scope is ready.",
+      "Rollback owners handle the migration window.",
+      "Validation tracks migration health.",
+    ].join("\n"),
+  },
+  {
+    path: "release-notes.md",
+    content: [
+      "# Release Notes",
+      "",
+      "The migration is one part of the release.",
+    ].join("\n"),
+  },
+  {
+    path: "zz-glossary.md",
+    content: [
+      "# Glossary",
+      "",
+      "Migration: a generic vocabulary entry.",
+    ].join("\n"),
+  },
+  {
+    path: "meeting-transcript.md",
+    content: [
+      "# Meeting Transcript",
+      "",
+      "Migration came up during unrelated staffing notes.",
+      "Migration migration migration migration migration migration migration.",
+    ].join("\n"),
+  },
+];
+
+function summarizeHit(hit) {
+  const lineKeys = new Set(hit.matches.map((match) => match.line));
+  const duplicateLineRows = hit.matches.length - lineKeys.size;
+  return {
+    notePath: hit.relativePath,
+    matchCount: hit.matches.length,
+    uniqueLineCount: lineKeys.size,
+    duplicateLineRows,
+  };
+}
+
+export async function runSearchSnippetQualityBench() {
+  const { searchInContents } = await import(pathToFileURL(vaultEntry).href);
+  const notePaths = notes.map((note) => note.path);
+  const contents = new Map(notes.map((note) => [note.path, note.content]));
+  const hits = searchInContents(notePaths, contents, QUERY, { maxResults: LIMIT });
+  const rows = hits.map(summarizeHit);
+  const totalSnippetRows = rows.reduce((sum, row) => sum + row.matchCount, 0);
+  const uniqueSnippetLines = rows.reduce((sum, row) => sum + row.uniqueLineCount, 0);
+  const duplicateSnippetRows = rows.reduce((sum, row) => sum + row.duplicateLineRows, 0);
+
+  return {
+    query: QUERY,
+    limit: LIMIT,
+    totalSnippetRows,
+    uniqueSnippetLines,
+    duplicateSnippetRows,
+    uniqueLineCoverage: totalSnippetRows === 0 ? 1 : uniqueSnippetLines / totalSnippetRows,
+    rows,
+  };
+}
+
+const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (invokedDirectly) {
+  if (!existsSync(vaultEntry)) {
+    console.error("build/lib/vault.js missing - run `npm run build` first.");
+    process.exit(1);
+  }
+  const result = await runSearchSnippetQualityBench();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(result));
+  } else {
+    console.log(`duplicate snippet rows ${result.duplicateSnippetRows}`);
+    console.log(`unique line coverage ${result.uniqueLineCoverage.toFixed(3)}`);
+    console.log(`total snippet rows ${result.totalSnippetRows}`);
+    console.log(`unique snippet lines ${result.uniqueSnippetLines}`);
+    console.log("\n| note | matches | unique lines | duplicate rows |");
+    console.log("|---|---:|---:|---:|");
+    for (const row of result.rows) {
+      console.log(`| ${row.notePath} | ${row.matchCount} | ${row.uniqueLineCount} | ${row.duplicateLineRows} |`);
+    }
+  }
+}


### PR DESCRIPTION
Starts an active Search Snippet Quality experiment with a synthetic `searchInContents` fixture for repeated same-line hits. The baseline records 6 duplicate snippet rows, 0.667 unique-line coverage, 18 total snippet rows, and 12 unique snippet lines.

Score: 1 severity x 3 reach / 1 effort = 3. Risk: docs and benchmark only; no runtime behavior or public surface changes.

Tested with `npm run build`, `node scripts/bench-search-snippet-quality.mjs --json` twice, and `npm run verify`.

Greptile review is unavailable because the trial review limit is exhausted.