### PR TITLE
fix: collapse duplicate search snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `search_notes` now renders repeated matches on the same line as one snippet row while preserving repeated-hit ranking signals.
 - `search_notes` now ranks literal matches with title/path focus and repeated-line dampening, so noisy repeated mentions are less likely to outrank focused notes.
 - `find_similar_notes` now builds its source query vector from chunks aligned with the source note's opening topic, so unrelated appendices are less likely to dominate similar-note ranking.
 - Semantic search now ranks note-level results with a small focus signal from each note's top chunks, so one incidental high-scoring chunk is less likely to outrank notes that are consistently about the query.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Search Snippet Quality](search-snippet-quality.md) | retrieval quality | active | Baseline duplicate snippet rows are 6 because repeated hits on one line are rendered as separate rows; next step is a duplicate-line collapse prototype. |
+| [Search Snippet Quality](search-snippet-quality.md) | retrieval quality | shipped | Duplicate snippet rows fell from 6 to 0, unique-line coverage rose from 0.667 to 1.000, and each matching note still keeps at least one visible snippet line. |
 | [Search Ranking Quality](search-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and repeated incidental mentions no longer rank ahead of focused lexical matches. |
 | [Similar Notes Quality](similar-notes-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.418 to 1.000, precision@3 rose from 0.667 to 1.000, and unrelated source appendices no longer push an off-topic kitchen note into first place. |
 | [Semantic Ranking Quality](semantic-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and grade-1 incidental matches no longer rank ahead of focused grade-3 notes. |

--- a/docs/rnd/search-ranking-quality.md
+++ b/docs/rnd/search-ranking-quality.md
@@ -63,13 +63,13 @@ After command samples:
 
 Current top five:
 
-| rank | note | rel | matches | score |
+| rank | note | rel | snippet lines | score |
 |---:|---|---:|---:|---:|
-| 1 | `migration-checklist.md` | 3 | 3 | 9.847 |
-| 2 | `migration-plan.md` | 3 | 4 | 9.402 |
+| 1 | `migration-checklist.md` | 3 | 2 | 9.847 |
+| 2 | `migration-plan.md` | 3 | 2 | 9.402 |
 | 3 | `release-notes.md` | 2 | 1 | 1.173 |
 | 4 | `zz-glossary.md` | 0 | 1 | 1.173 |
-| 5 | `meeting-transcript.md` | 1 | 8 | 0.000 |
+| 5 | `meeting-transcript.md` | 1 | 2 | 0.000 |
 
 ## Safety review
 
@@ -90,4 +90,5 @@ line snippets that explain each lexical hit.
 Shipped. `search_notes` now scores literal matches with a small focus signal from
 note paths and headings, plus dampening for repeated matches on the same line.
 The fixture clears the ship bar while preserving tool names, parameters, result
-shape, literal matching, and the matched line snippets shown for each hit.
+shape, literal matching, and the matched line snippets shown for each matching
+line.

--- a/docs/rnd/search-snippet-quality.md
+++ b/docs/rnd/search-snippet-quality.md
@@ -1,7 +1,7 @@
 # Search Snippet Quality
 
-_Status: active_
-_Started: 2026-06-04 - Decided: pending_
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -33,10 +33,10 @@ visible snippet line.
 
 | metric | before | after |
 |---|---:|---:|
-| Duplicate snippet rows | 6 | |
-| Unique line coverage | 0.667 | |
-| Total snippet rows | 18 | |
-| Unique snippet lines | 12 | |
+| Duplicate snippet rows | 6 | 0 |
+| Unique line coverage | 0.667 | 1.000 |
+| Total snippet rows | 18 | 12 |
+| Unique snippet lines | 12 | 12 |
 
 Baseline command samples:
 
@@ -44,6 +44,13 @@ Baseline command samples:
   6, unique line coverage 0.667, total snippet rows 18, unique snippet lines 12.
 - `node scripts/bench-search-snippet-quality.mjs --json`: duplicate snippet rows
   6, unique line coverage 0.667, total snippet rows 18, unique snippet lines 12.
+
+After command samples:
+
+- `node scripts/bench-search-snippet-quality.mjs --json`: duplicate snippet rows
+  0, unique line coverage 1.000, total snippet rows 12, unique snippet lines 12.
+- `node scripts/bench-search-snippet-quality.mjs --json`: duplicate snippet rows
+  0, unique line coverage 1.000, total snippet rows 12, unique snippet lines 12.
 
 Current rows:
 
@@ -53,7 +60,7 @@ Current rows:
 | `migration-plan.md` | 4 | 4 | 0 |
 | `release-notes.md` | 1 | 1 | 0 |
 | `zz-glossary.md` | 1 | 1 | 0 |
-| `meeting-transcript.md` | 8 | 2 | 6 |
+| `meeting-transcript.md` | 2 | 2 | 0 |
 
 ## Safety review
 
@@ -71,6 +78,7 @@ public parameter or result format.
 
 ## Decision
 
-Active. The next step is a narrow rendering or matcher prototype that collapses
-duplicate same-line snippets while keeping at least one snippet per matching
-line and preserving the current ranking behavior.
+Shipped. `search_notes` now keeps raw literal hit counts for ranking, then
+collapses returned matches to one snippet per source line. The fixture clears
+the ship bar without changing tool names, parameters, result format, ranking
+order, case sensitivity, folder filtering, or max-result handling.

--- a/scripts/bench-search-ranking-quality.mjs
+++ b/scripts/bench-search-ranking-quality.mjs
@@ -138,7 +138,7 @@ if (invokedDirectly) {
     console.log(`precision@3 ${result.precisionAt3.toFixed(3)}`);
     console.log(`top relevance ${result.topRelevance}`);
     console.log(`incidental before focused ${result.incidentalBeforeFocused}`);
-    console.log("\n| rank | note | rel | matches | score |");
+    console.log("\n| rank | note | rel | snippet lines | score |");
     console.log("|---:|---|---:|---:|---:|");
     for (const row of result.rows) {
       console.log(`| ${row.rank} | ${row.notePath} | ${row.relevance} | ${row.matchCount} | ${row.score.toFixed(3)} |`);

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -84,6 +84,25 @@ describe("read handlers — search_notes", () => {
     ]);
   });
 
+  it("renders repeated same-line matches as one snippet row", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, "repeat.md"),
+      "alpha alpha alpha\nbeta alpha\n",
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "search_notes",
+      arguments: { query: "alpha", maxResults: 1 },
+    });
+
+    const lineRows = textContent(result).split("\n").filter((line) => line.includes("Line "));
+    expect(lineRows).toEqual([
+      "  Line 1: alpha alpha alpha",
+      "  Line 2: beta alpha",
+    ]);
+  });
+
   it("restricts scan to a folder when folder= is set", async () => {
     const result = await env.client.callTool({
       name: "search_notes",

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -418,6 +418,19 @@ describe("searchInContents", () => {
     ]);
   });
 
+  it("collapses repeated same-line matches into one visible snippet", () => {
+    const contents = new Map([
+      ["alpha.md", "alpha alpha alpha\nbeta alpha"],
+    ]);
+
+    const results = searchInContents(["alpha.md"], contents, "alpha");
+
+    expect(results[0].matches).toEqual([
+      { line: 1, content: "alpha alpha alpha", column: 0 },
+      { line: 2, content: "beta alpha", column: 5 },
+    ]);
+  });
+
   it("ranks focused title matches ahead of repeated incidental mentions", () => {
     const contents = new Map([
       [
@@ -460,7 +473,7 @@ describe("searchInContents", () => {
       "release-notes.md",
       "meeting-transcript.md",
     ]);
-    expect(results.at(-1)?.matches).toHaveLength(8);
+    expect(results.at(-1)?.matches).toHaveLength(2);
   });
 });
 
@@ -522,12 +535,14 @@ describe("searchNotes", () => {
     expect(match.column).toBe(6); // "Hello world" -> index 6
   });
 
-  it("should find multiple matches on the same line", async () => {
+  it("should collapse multiple matches on the same line", async () => {
     await writeNote(vaultDir, "repeat.md", "foo bar foo baz foo");
     const results = await searchNotes(vaultDir, "foo");
     const repeatResult = results.find((r) => r.relativePath === "repeat.md");
     expect(repeatResult).toBeDefined();
-    expect(repeatResult!.matches.length).toBe(3);
+    expect(repeatResult!.matches).toEqual([
+      { line: 1, content: "foo bar foo baz foo", column: 0 },
+    ]);
   });
 
   it("should return empty array when nothing matches", async () => {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -918,7 +918,7 @@ export function searchInContents(
     if (content === undefined) continue;
 
     const lines = content.split("\n");
-    const matches: SearchMatch[] = [];
+    const rawMatches: SearchMatch[] = [];
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!;
       const compareLine = caseSensitive ? line : line.toLowerCase();
@@ -926,16 +926,16 @@ export function searchInContents(
       while (true) {
         const col = compareLine.indexOf(searchQuery, startIndex);
         if (col === -1) break;
-        matches.push({ line: i + 1, content: line.trim(), column: col });
+        rawMatches.push({ line: i + 1, content: line.trim(), column: col });
         startIndex = col + searchQuery.length;
       }
     }
-    if (matches.length === 0) continue;
+    if (rawMatches.length === 0) continue;
     results.push({
       path: notePath,
       relativePath: notePath,
-      matches,
-      score: scoreLexicalMatches(notePath, lines, matches, searchQuery, caseSensitive),
+      matches: collapseSearchLineMatches(rawMatches),
+      score: scoreLexicalMatches(notePath, lines, rawMatches, searchQuery, caseSensitive),
     });
   }
   // Primary: lexical focus score (desc). Secondary: relative path (asc) — otherwise
@@ -943,6 +943,15 @@ export function searchInContents(
   // equal-score queries non-deterministic between runs.
   results.sort((a, b) => b.score - a.score || a.relativePath.localeCompare(b.relativePath));
   return results.slice(0, maxResults);
+}
+
+function collapseSearchLineMatches(matches: readonly SearchMatch[]): SearchMatch[] {
+  const seenLines = new Set<number>();
+  return matches.filter((match) => {
+    if (seenLines.has(match.line)) return false;
+    seenLines.add(match.line);
+    return true;
+  });
 }
 
 function scoreLexicalMatches(

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -36,7 +36,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
     {
       title: "Search Notes",
       description:
-        "Full-text search across all notes in the vault. Ranks literal matches with title/path focus and repeated-line dampening, then returns matching note paths grouped with the line numbers and snippet content of each hit. Use to locate notes containing a phrase, keyword, or code fragment; pair with get_note to retrieve full bodies.",
+        "Full-text search across all notes in the vault. Ranks literal matches with title/path focus and repeated-line dampening, then returns matching note paths grouped with the line numbers and snippet content of each matching line. Use to locate notes containing a phrase, keyword, or code fragment; pair with get_note to retrieve full bodies.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,


### PR DESCRIPTION
Collapses repeated same-line `search_notes` matches to one visible snippet row while keeping raw literal hits in the ranking score. The Search Snippet Quality fixture moved from 6 duplicate snippet rows and 0.667 unique-line coverage to 0 duplicate rows and 1.000 coverage; the Search Ranking Quality fixture stayed at NDCG@3 1.000 / precision@3 1.000.

Score: 2 severity x 3 reach / 1 effort = 6. Risk: output is less repetitive but still one snippet per matching line; tool names, parameters, result format, ranking order, case sensitivity, folder filtering, and max-result handling stay the same.

Tested with `npx vitest run src/__tests__/vault.test.ts src/__tests__/handlers/read.test.ts`, `node scripts/bench-search-snippet-quality.mjs --json` twice, `node scripts/bench-search-ranking-quality.mjs --json` twice, and `npm run verify`.

Greptile review is unavailable because the trial review limit is exhausted.