### PR TITLE
chore: start search snippet length rnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - R&D experiment for lexical search ranking quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-ranking-quality.mjs` and ship/kill metric in `docs/rnd/search-ranking-quality.md`.
 - R&D experiment for lexical search snippet quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-snippet-quality.mjs` and ship/kill metric in `docs/rnd/search-snippet-quality.md`.
+- R&D experiment for lexical search snippet length, with a synthetic `searchInContents` fixture in `scripts/bench-search-snippet-length.mjs` and ship/kill metric in `docs/rnd/search-snippet-length.md`.
 - R&D experiment for similar-note quality, with a synthetic embedding-store fixture in `scripts/bench-similar-notes-quality.mjs` and ship/kill metric in `docs/rnd/similar-notes-quality.md`.
 - R&D experiment for semantic ranking quality, with a synthetic embedding-store fixture in `scripts/bench-semantic-ranking-quality.mjs` and ship/kill metric in `docs/rnd/semantic-ranking-quality.md`.
 - R&D experiment for chunker boundary quality, with a synthetic fixture in `scripts/bench-chunker-quality.mjs` and ship/kill metric in `docs/rnd/chunker-boundary-quality.md`.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,6 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
+| [Search Snippet Length](search-snippet-length.md) | retrieval quality | active | Baseline max snippet chars are 2152 and total snippet chars are 2285 because one long matching line dominates the visible search output. |
 | [Search Snippet Quality](search-snippet-quality.md) | retrieval quality | shipped | Duplicate snippet rows fell from 6 to 0, unique-line coverage rose from 0.667 to 1.000, and each matching note still keeps at least one visible snippet line. |
 | [Search Ranking Quality](search-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and repeated incidental mentions no longer rank ahead of focused lexical matches. |
 | [Similar Notes Quality](similar-notes-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.418 to 1.000, precision@3 rose from 0.667 to 1.000, and unrelated source appendices no longer push an off-topic kitchen note into first place. |

--- a/docs/rnd/search-snippet-length.md
+++ b/docs/rnd/search-snippet-length.md
@@ -1,0 +1,76 @@
+# Search Snippet Length
+
+_Status: active_
+_Started: 2026-06-04 - Decided: pending_
+
+## Hypothesis
+
+`search_notes` now collapses repeated same-line hits, but a single matching line
+can still be very long. A copied status line, minified blob, or pasted log line
+can dominate the result text even when the useful evidence is near the query. A
+measured fixture can test whether query-centered snippets reduce output load
+without hiding the matching line or changing the tool schema.
+
+## Fixture
+
+`scripts/bench-search-snippet-length.mjs` builds three synthetic notes and calls
+`searchInContents` for query `migration` with `maxResults: 5`:
+
+- `migration-status.md` has one very long matching status line
+- `migration-plan.md` has short focused matches
+- `release-notes.md` has one short related match
+
+The fixture measures the visible snippet strings returned by the matcher, which
+are the same strings `search_notes` renders to clients.
+
+## Metric
+
+Primary metric: max snippet chars. Secondary guardrails are total snippet chars,
+oversized snippet rows, and whether every snippet still contains the query.
+
+Ship bar: max snippet chars at or below 240, total snippet chars at or below 640,
+zero oversized snippet rows, and every snippet still contains the query.
+
+| metric | before | after |
+|---|---:|---:|
+| Max snippet chars | 2152 | |
+| Total snippet chars | 2285 | |
+| Oversized snippet rows | 1 | |
+| Snippets keep query | true | |
+| Clears length bars | false | |
+
+Baseline command samples:
+
+- `node scripts/bench-search-snippet-length.mjs --json`: max snippet chars 2152,
+  total snippet chars 2285, oversized snippet rows 1, snippets keep query true,
+  clears length bars false.
+- `node scripts/bench-search-snippet-length.mjs --json`: max snippet chars 2152,
+  total snippet chars 2285, oversized snippet rows 1, snippets keep query true,
+  clears length bars false.
+
+Current rows:
+
+| note | rows | snippet chars | max snippet chars | oversized rows |
+|---|---:|---:|---:|---:|
+| `migration-plan.md` | 2 | 61 | 45 | 0 |
+| `migration-status.md` | 2 | 2170 | 2152 | 1 |
+| `release-notes.md` | 1 | 54 | 54 | 0 |
+
+## Safety review
+
+The fixture uses in-memory synthetic note bodies and reads the built
+`searchInContents` implementation. It performs no vault I/O, writes no notes,
+does not touch permissions, and emits only aggregate size metrics. Any prototype
+must keep literal matching, case sensitivity, ranking order, folder filtering,
+max-result handling, and at least one visible query occurrence per snippet.
+
+## Kill criterion
+
+Stop without a runtime change if a snippet-length prototype hides the query,
+changes result ordering, adds a new public parameter or result shape, or makes
+short normal snippets worse.
+
+## Decision
+
+Active. The next step is a query-centered snippet prototype that caps long
+matching lines while keeping enough context around the first visible match.

--- a/scripts/bench-search-snippet-length.mjs
+++ b/scripts/bench-search-snippet-length.mjs
@@ -1,0 +1,110 @@
+// Lexical search snippet-length benchmark: run searchInContents over synthetic
+// note bodies and measure whether a single matching line can dominate output.
+//
+// Direct use: node scripts/bench-search-snippet-length.mjs [--json]
+// Run after `npm run build`.
+
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const vaultEntry = join(root, "build", "lib", "vault.js");
+const QUERY = "migration";
+const LIMIT = 5;
+const MAX_SNIPPET_CHARS_BAR = 240;
+const MAX_TOTAL_SNIPPET_CHARS_BAR = 640;
+
+const longTail = Array.from({ length: 180 }, (_, index) => `context-${index + 1}`).join(" ");
+
+const notes = [
+  {
+    path: "migration-status.md",
+    content: [
+      "# Migration Status",
+      "",
+      `Migration status: ${longTail}. Owner, rollback, and validation notes are buried after a long copied status line.`,
+    ].join("\n"),
+  },
+  {
+    path: "migration-plan.md",
+    content: [
+      "# Migration Plan",
+      "",
+      "Migration owner and rollback scope are ready.",
+      "Validation follows the release checklist.",
+    ].join("\n"),
+  },
+  {
+    path: "release-notes.md",
+    content: [
+      "# Release Notes",
+      "",
+      "The migration is mentioned as one part of the release.",
+    ].join("\n"),
+  },
+];
+
+function summarizeHit(hit) {
+  const snippetChars = hit.matches.reduce((sum, match) => sum + match.content.length, 0);
+  const maxSnippetChars = hit.matches.reduce((max, match) => Math.max(max, match.content.length), 0);
+  const queryPresentRows = hit.matches.filter((match) => match.content.toLowerCase().includes(QUERY)).length;
+  return {
+    notePath: hit.relativePath,
+    snippetRows: hit.matches.length,
+    snippetChars,
+    maxSnippetChars,
+    oversizedSnippetRows: hit.matches.filter((match) => match.content.length > MAX_SNIPPET_CHARS_BAR).length,
+    queryPresentRows,
+  };
+}
+
+export async function runSearchSnippetLengthBench() {
+  const { searchInContents } = await import(pathToFileURL(vaultEntry).href);
+  const notePaths = notes.map((note) => note.path);
+  const contents = new Map(notes.map((note) => [note.path, note.content]));
+  const hits = searchInContents(notePaths, contents, QUERY, { maxResults: LIMIT });
+  const rows = hits.map(summarizeHit);
+  const totalSnippetChars = rows.reduce((sum, row) => sum + row.snippetChars, 0);
+  const maxSnippetChars = rows.reduce((max, row) => Math.max(max, row.maxSnippetChars), 0);
+  const oversizedSnippetRows = rows.reduce((sum, row) => sum + row.oversizedSnippetRows, 0);
+  const snippetsKeepQuery = rows.every((row) => row.queryPresentRows === row.snippetRows);
+
+  return {
+    query: QUERY,
+    limit: LIMIT,
+    totalSnippetChars,
+    maxSnippetChars,
+    oversizedSnippetRows,
+    snippetsKeepQuery,
+    clearsLengthBars:
+      maxSnippetChars <= MAX_SNIPPET_CHARS_BAR &&
+      totalSnippetChars <= MAX_TOTAL_SNIPPET_CHARS_BAR &&
+      oversizedSnippetRows === 0 &&
+      snippetsKeepQuery,
+    rows,
+  };
+}
+
+const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (invokedDirectly) {
+  if (!existsSync(vaultEntry)) {
+    console.error("build/lib/vault.js missing - run `npm run build` first.");
+    process.exit(1);
+  }
+  const result = await runSearchSnippetLengthBench();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(result));
+  } else {
+    console.log(`max snippet chars ${result.maxSnippetChars}`);
+    console.log(`total snippet chars ${result.totalSnippetChars}`);
+    console.log(`oversized snippet rows ${result.oversizedSnippetRows}`);
+    console.log(`snippets keep query ${result.snippetsKeepQuery}`);
+    console.log(`clears length bars ${result.clearsLengthBars}`);
+    console.log("\n| note | rows | snippet chars | max snippet chars | oversized rows |");
+    console.log("|---|---:|---:|---:|---:|");
+    for (const row of result.rows) {
+      console.log(`| ${row.notePath} | ${row.snippetRows} | ${row.snippetChars} | ${row.maxSnippetChars} | ${row.oversizedSnippetRows} |`);
+    }
+  }
+}


### PR DESCRIPTION
Starts an active Search Snippet Length experiment with a synthetic `searchInContents` fixture for long matching lines. The baseline records max snippet chars at 2152, total snippet chars at 2285, one oversized snippet row, and query retention still true.

Score: 1 severity x 3 reach / 1 effort = 3. Risk: docs and benchmark only; no runtime behavior or public surface changes.

Tested with `npm run build`, `node scripts/bench-search-snippet-length.mjs --json` twice, and `npm run verify`.

Greptile review is unavailable because the trial review limit is exhausted.