### PR TITLE
fix: cap search snippet length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `search_notes` now caps very long matching lines with query-centered snippets, keeping result output focused without changing ranking inputs.
 - `search_notes` now renders repeated matches on the same line as one snippet row while preserving repeated-hit ranking signals.
 - `search_notes` now ranks literal matches with title/path focus and repeated-line dampening, so noisy repeated mentions are less likely to outrank focused notes.
 - `find_similar_notes` now builds its source query vector from chunks aligned with the source note's opening topic, so unrelated appendices are less likely to dominate similar-note ranking.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Give AI assistants deep, structured access to your Obsidian knowledge base. Read
 ## Features
 
 ### Read & Search
-- Focus-ranked full-text search across all vault notes (cached: re-runs only re-read changed files)
+- Focus-ranked full-text search across all vault notes, with query-centered snippets (cached: re-runs only re-read changed files)
 - Read individual notes whole, or as a fragment by heading path, block id, or line range
 - List and filter notes by folder, date, or pattern
 - Search by frontmatter fields and values
@@ -369,7 +369,7 @@ Tag extraction is similarly case-tolerant: `tags`, `Tags`, `TAGS`, `tag`, and `T
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `search_notes` | Focus-ranked full-text search across all notes (cached) | `query`, `caseSensitive`, `maxResults`, `folder` |
+| `search_notes` | Focus-ranked full-text search with query-centered snippets (cached) | `query`, `caseSensitive`, `maxResults`, `folder` |
 | `get_note` | Read a note whole, or by `section` / `block` / `lines` | `path`, `section`, `block`, `lines` |
 | `list_notes` | List notes in the vault or a folder | `folder`, `limit` |
 | `get_daily_note` | Get today's (or a specific date's) daily note | `date` |

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Search Snippet Length](search-snippet-length.md) | retrieval quality | active | Baseline max snippet chars are 2152 and total snippet chars are 2285 because one long matching line dominates the visible search output. |
+| [Search Snippet Length](search-snippet-length.md) | retrieval quality | shipped | Max snippet chars fell from 2152 to 237, total snippet chars fell from 2285 to 370, oversized snippet rows fell to zero, and every snippet still contains the query. |
 | [Search Snippet Quality](search-snippet-quality.md) | retrieval quality | shipped | Duplicate snippet rows fell from 6 to 0, unique-line coverage rose from 0.667 to 1.000, and each matching note still keeps at least one visible snippet line. |
 | [Search Ranking Quality](search-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and repeated incidental mentions no longer rank ahead of focused lexical matches. |
 | [Similar Notes Quality](similar-notes-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.418 to 1.000, precision@3 rose from 0.667 to 1.000, and unrelated source appendices no longer push an off-topic kitchen note into first place. |

--- a/docs/rnd/search-snippet-length.md
+++ b/docs/rnd/search-snippet-length.md
@@ -1,7 +1,7 @@
 # Search Snippet Length
 
-_Status: active_
-_Started: 2026-06-04 - Decided: pending_
+_Status: shipped_
+_Started: 2026-06-04 - Decided: 2026-06-04_
 
 ## Hypothesis
 
@@ -33,11 +33,11 @@ zero oversized snippet rows, and every snippet still contains the query.
 
 | metric | before | after |
 |---|---:|---:|
-| Max snippet chars | 2152 | |
-| Total snippet chars | 2285 | |
-| Oversized snippet rows | 1 | |
-| Snippets keep query | true | |
-| Clears length bars | false | |
+| Max snippet chars | 2152 | 237 |
+| Total snippet chars | 2285 | 370 |
+| Oversized snippet rows | 1 | 0 |
+| Snippets keep query | true | true |
+| Clears length bars | false | true |
 
 Baseline command samples:
 
@@ -48,12 +48,21 @@ Baseline command samples:
   total snippet chars 2285, oversized snippet rows 1, snippets keep query true,
   clears length bars false.
 
+After command samples:
+
+- `node scripts/bench-search-snippet-length.mjs --json`: max snippet chars 237,
+  total snippet chars 370, oversized snippet rows 0, snippets keep query true,
+  clears length bars true.
+- `node scripts/bench-search-snippet-length.mjs --json`: max snippet chars 237,
+  total snippet chars 370, oversized snippet rows 0, snippets keep query true,
+  clears length bars true.
+
 Current rows:
 
 | note | rows | snippet chars | max snippet chars | oversized rows |
 |---|---:|---:|---:|---:|
 | `migration-plan.md` | 2 | 61 | 45 | 0 |
-| `migration-status.md` | 2 | 2170 | 2152 | 1 |
+| `migration-status.md` | 2 | 255 | 237 | 0 |
 | `release-notes.md` | 1 | 54 | 54 | 0 |
 
 ## Safety review
@@ -72,5 +81,7 @@ short normal snippets worse.
 
 ## Decision
 
-Active. The next step is a query-centered snippet prototype that caps long
-matching lines while keeping enough context around the first visible match.
+Shipped. `search_notes` now caps long matching lines with query-centered
+snippets. The fixture clears the length bars while preserving literal matching,
+ranking order, case sensitivity, folder filtering, max-result handling, and a
+visible query occurrence in every snippet.

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -103,6 +103,23 @@ describe("read handlers — search_notes", () => {
     ]);
   });
 
+  it("renders long matching lines as query-centered snippets", async () => {
+    const before = Array.from({ length: 80 }, (_, index) => `before-${index + 1}`).join(" ");
+    const after = Array.from({ length: 80 }, (_, index) => `after-${index + 1}`).join(" ");
+    await fs.writeFile(path.join(env.vaultDir, "long.md"), `${before} alpha ${after}\n`, "utf-8");
+
+    const result = await env.client.callTool({
+      name: "search_notes",
+      arguments: { query: "alpha", maxResults: 1 },
+    });
+
+    const lineRow = textContent(result).split("\n").find((line) => line.includes("Line 1:"));
+    expect(lineRow).toBeDefined();
+    expect(lineRow!.length).toBeLessThanOrEqual("  Line 1: ".length + 240);
+    expect(lineRow).toContain("alpha");
+    expect(lineRow).toContain("...");
+  });
+
   it("restricts scan to a folder when folder= is set", async () => {
     const result = await env.client.callTool({
       name: "search_notes",

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -431,6 +431,22 @@ describe("searchInContents", () => {
     ]);
   });
 
+  it("centers long snippets around the first visible match", () => {
+    const before = Array.from({ length: 80 }, (_, index) => `before-${index + 1}`).join(" ");
+    const after = Array.from({ length: 80 }, (_, index) => `after-${index + 1}`).join(" ");
+    const contents = new Map([
+      ["alpha.md", `${before} alpha target ${after}`],
+    ]);
+
+    const results = searchInContents(["alpha.md"], contents, "alpha");
+    const snippet = results[0].matches[0].content;
+
+    expect(snippet.length).toBeLessThanOrEqual(240);
+    expect(snippet).toContain("alpha");
+    expect(snippet.startsWith("...")).toBe(true);
+    expect(snippet.endsWith("...")).toBe(true);
+  });
+
   it("ranks focused title matches ahead of repeated incidental mentions", () => {
     const contents = new Map([
       [
@@ -543,6 +559,21 @@ describe("searchNotes", () => {
     expect(repeatResult!.matches).toEqual([
       { line: 1, content: "foo bar foo baz foo", column: 0 },
     ]);
+  });
+
+  it("should cap long snippets while preserving the source column", async () => {
+    const before = Array.from({ length: 80 }, (_, index) => `before-${index + 1}`).join(" ");
+    const after = Array.from({ length: 80 }, (_, index) => `after-${index + 1}`).join(" ");
+    const line = `${before} needle ${after}`;
+    await writeNote(vaultDir, "long.md", line);
+
+    const results = await searchNotes(vaultDir, "needle");
+    const longResult = results.find((r) => r.relativePath === "long.md");
+
+    expect(longResult).toBeDefined();
+    expect(longResult!.matches[0].content.length).toBeLessThanOrEqual(240);
+    expect(longResult!.matches[0].content).toContain("needle");
+    expect(longResult!.matches[0].column).toBe(line.indexOf("needle"));
   });
 
   it("should return empty array when nothing matches", async () => {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -15,6 +15,8 @@ const SEARCH_PATH_MATCH_BOOST = 4;
 const SEARCH_HEADING_MATCH_BOOST = 4;
 const SEARCH_MATCH_COUNT_WEIGHT = 0.25;
 const SEARCH_REPEATED_SAME_LINE_PENALTY = 0.5;
+const SEARCH_SNIPPET_MAX_CHARS = 240;
+const SEARCH_SNIPPET_OMISSION = "...";
 
 const EXCLUDED_DIRS = [".obsidian", ".trash", ".git"];
 const EXCLUDED_SET = new Set(EXCLUDED_DIRS);
@@ -926,7 +928,11 @@ export function searchInContents(
       while (true) {
         const col = compareLine.indexOf(searchQuery, startIndex);
         if (col === -1) break;
-        rawMatches.push({ line: i + 1, content: line.trim(), column: col });
+        rawMatches.push({
+          line: i + 1,
+          content: formatSearchSnippet(line, col, searchQuery.length),
+          column: col,
+        });
         startIndex = col + searchQuery.length;
       }
     }
@@ -952,6 +958,29 @@ function collapseSearchLineMatches(matches: readonly SearchMatch[]): SearchMatch
     seenLines.add(match.line);
     return true;
   });
+}
+
+function formatSearchSnippet(line: string, column: number, queryLength: number): string {
+  const trimmedStart = line.trimStart();
+  const leadingTrimmedChars = line.length - trimmedStart.length;
+  const trimmedLine = trimmedStart.trimEnd();
+  const maxSnippetChars = Math.max(
+    SEARCH_SNIPPET_MAX_CHARS,
+    queryLength + SEARCH_SNIPPET_OMISSION.length * 2,
+  );
+
+  if (trimmedLine.length <= maxSnippetChars) return trimmedLine;
+
+  const snippetColumn = Math.max(0, column - leadingTrimmedChars);
+  const queryStart = Math.min(snippetColumn, trimmedLine.length);
+  const bodyMaxChars = maxSnippetChars - SEARCH_SNIPPET_OMISSION.length * 2;
+  let start = Math.max(0, queryStart - Math.floor((bodyMaxChars - queryLength) / 2));
+  const end = Math.min(trimmedLine.length, start + bodyMaxChars);
+  if (end === trimmedLine.length) start = Math.max(0, end - bodyMaxChars);
+
+  const prefix = start > 0 ? SEARCH_SNIPPET_OMISSION : "";
+  const suffix = end < trimmedLine.length ? SEARCH_SNIPPET_OMISSION : "";
+  return `${prefix}${trimmedLine.slice(start, end)}${suffix}`;
 }
 
 function scoreLexicalMatches(

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -36,7 +36,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
     {
       title: "Search Notes",
       description:
-        "Full-text search across all notes in the vault. Ranks literal matches with title/path focus and repeated-line dampening, then returns matching note paths grouped with the line numbers and snippet content of each matching line. Use to locate notes containing a phrase, keyword, or code fragment; pair with get_note to retrieve full bodies.",
+        "Full-text search across all notes in the vault. Ranks literal matches with title/path focus and repeated-line dampening, then returns matching note paths grouped with the line numbers and query-centered snippet content of each matching line. Use to locate notes containing a phrase, keyword, or code fragment; pair with get_note to retrieve full bodies.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,


### PR DESCRIPTION
Caps very long search_notes matching lines with query-centered snippets, while keeping ranking inputs, source columns, and existing search filters intact.

Score: 2 severity x 3 reach / 1 effort = 6. Long matches could drown small MCP responses, but the fix is local to presentation.

Risk: callers see shorter content for long matching lines; tool names, params, result shape, ranking, literal matching, case sensitivity, folder filtering, and max-result behavior stay the same.

Tests: npx vitest run src/__tests__/vault.test.ts src/__tests__/handlers/read.test.ts; node scripts/bench-search-snippet-length.mjs --json twice; node scripts/bench-search-snippet-quality.mjs --json; node scripts/bench-search-ranking-quality.mjs --json; npm run verify.

Greptile could not review because the account hit the 50-review trial cap.