### PR TITLE
chore: start frontmatter key quality R&D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Active R&D experiment for frontmatter key quality, with a synthetic `search_by_frontmatter` fixture in `scripts/bench-frontmatter-key-quality.mjs` and ship/kill metric in `docs/rnd/frontmatter-key-quality.md`.
 - R&D experiment for lexical search ranking quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-ranking-quality.mjs` and ship/kill metric in `docs/rnd/search-ranking-quality.md`.
 - R&D experiment for lexical search snippet quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-snippet-quality.mjs` and ship/kill metric in `docs/rnd/search-snippet-quality.md`.
 - R&D experiment for lexical search snippet length, with a synthetic `searchInContents` fixture in `scripts/bench-search-snippet-length.mjs` and ship/kill metric in `docs/rnd/search-snippet-length.md`.
@@ -65,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated the transitive Hono lockfile entry to 4.12.23, clearing the moderate audit advisories in the MCP HTTP dependency path.
 - HTTP server tests now retry OS-assigned ports that Node's `fetch` rejects, avoiding a flaky `bad port` failure during the verify gate.
 - `obsidian://tags` now escapes control characters in generated tag keys and note-path values before returning its JSON index.
 - Empty `get_vault_stats` folder output and missing daily-resource errors now escape control characters in displayed configured paths.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,6 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
+| [Frontmatter Key Quality](frontmatter-key-quality.md) | retrieval quality | active | Baseline `search_by_frontmatter` recall across `status` / `Status` / `STATUS` key variants is 0.333, with two relevant notes missed and zero wrong-key matches. |
 | [Search Snippet Length](search-snippet-length.md) | retrieval quality | shipped | Max snippet chars fell from 2152 to 237, total snippet chars fell from 2285 to 370, oversized snippet rows fell to zero, and every snippet still contains the query. |
 | [Search Snippet Quality](search-snippet-quality.md) | retrieval quality | shipped | Duplicate snippet rows fell from 6 to 0, unique-line coverage rose from 0.667 to 1.000, and each matching note still keeps at least one visible snippet line. |
 | [Search Ranking Quality](search-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and repeated incidental mentions no longer rank ahead of focused lexical matches. |

--- a/docs/rnd/frontmatter-key-quality.md
+++ b/docs/rnd/frontmatter-key-quality.md
@@ -1,0 +1,83 @@
+# Frontmatter Key Quality
+
+_Status: active_
+_Started: 2026-06-05 - Decided: _
+
+## Hypothesis
+
+People and agents often ask for normalized metadata names such as `status` even
+when a vault has notes written with `Status` or `STATUS`. A key-normalized
+`search_by_frontmatter` lookup may improve recall without changing value
+matching, result shape, folder filtering, truncation, or displayed frontmatter.
+
+## Fixture
+
+Bench command:
+
+```powershell
+node scripts\bench-frontmatter-key-quality.mjs --json
+```
+
+The fixture creates a temporary five-note vault and calls
+`search_by_frontmatter` through a real stdio MCP client with
+`property: "status"`, `value: "ready"`, and `maxResults: 10`.
+
+Relevant notes:
+
+- `lower-status.md` has `status: ready`
+- `title-status.md` has `Status: ready`
+- `upper-status.md` has `STATUS: ready`
+
+Guardrail notes:
+
+- `blocked-status.md` has `status: blocked`
+- `owner-ready.md` has `owner: ready`
+
+## Metric
+
+Primary metric: recall across relevant frontmatter key-case variants.
+
+Ship bar: recall 1.000, zero wrong-key matches, zero duplicate paths, and the
+exact lowercase-key hit still present. Existing scalar, array, folder,
+`maxResults`, no-match, and rendered-frontmatter behavior must stay unchanged.
+
+| | before | after |
+|---|---:|---:|
+| case-variant recall | 0.333 | |
+| matched relevant notes | 1 / 3 | |
+| case-variant misses | 2 | |
+| wrong-key matches | 0 | |
+| duplicate paths | 0 | |
+
+Current rows:
+
+| result | paths |
+|---|---|
+| matched | `lower-status.md` |
+| missed variants | `title-status.md`, `upper-status.md` |
+| wrong-key matches | _none_ |
+
+## Safety review
+
+Data accessed: synthetic frontmatter and note names generated in a temporary
+vault by `scripts/bench-frontmatter-key-quality.mjs`. No real vault content,
+secrets, network calls, or persistent cache files are used.
+
+Writes performed: temporary fixture vault creation and deletion only.
+
+Logs emitted: normal stdio server startup logging with the temporary vault path.
+
+Rollback path: delete the benchmark and mark this experiment stopped; no runtime
+behavior changes are part of the baseline.
+
+## Kill criterion
+
+Stop if key-normalized lookup causes wrong-key matches, duplicate rows, unstable
+ordering, stale frontmatter after writes, folder-scope regressions, or changed
+rendering of returned frontmatter.
+
+## Decision
+
+Active. The baseline shows `search_by_frontmatter` finds the exact lowercase
+`status` key but misses `Status` and `STATUS`, leaving recall at 0.333 with zero
+wrong-key matches.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2035,9 +2035,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/scripts/bench-frontmatter-key-quality.mjs
+++ b/scripts/bench-frontmatter-key-quality.mjs
@@ -1,0 +1,143 @@
+// Frontmatter key-quality benchmark: measure whether search_by_frontmatter
+// misses notes when the YAML key casing differs from the requested property.
+//
+// Direct use: node scripts/bench-frontmatter-key-quality.mjs [--json]
+// Run after `npm run build`.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const entry = join(root, "build", "index.js");
+const QUERY_PROPERTY = "status";
+const QUERY_VALUE = "ready";
+
+const notes = [
+  {
+    path: "lower-status.md",
+    relevant: true,
+    content: "---\nstatus: ready\n---\n# Lower Status\n",
+  },
+  {
+    path: "title-status.md",
+    relevant: true,
+    content: "---\nStatus: ready\n---\n# Title Status\n",
+  },
+  {
+    path: "upper-status.md",
+    relevant: true,
+    content: "---\nSTATUS: ready\n---\n# Upper Status\n",
+  },
+  {
+    path: "blocked-status.md",
+    relevant: false,
+    content: "---\nstatus: blocked\n---\n# Blocked Status\n",
+  },
+  {
+    path: "owner-ready.md",
+    relevant: false,
+    content: "---\nowner: ready\n---\n# Owner Ready\n",
+  },
+];
+
+const expectedRelevantPaths = notes.filter((note) => note.relevant).map((note) => note.path);
+
+export function makeFrontmatterKeyQualityVault() {
+  const dir = mkdtempSync(join(tmpdir(), "ompro-frontmatter-key-quality-"));
+  mkdirSync(join(dir, ".obsidian"));
+  for (const note of notes) {
+    writeFileSync(join(dir, note.path), note.content, "utf-8");
+  }
+  return dir;
+}
+
+function textFromResult(result) {
+  return result.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
+}
+
+function extractResultPaths(text) {
+  return [...text.matchAll(/^## (.+)$/gm)].map((match) => match[1]);
+}
+
+async function searchFrontmatter(vault) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [entry],
+    cwd: root,
+    env: { ...process.env, OBSIDIAN_VAULT_PATH: vault },
+  });
+  const client = new Client({ name: "frontmatter-key-quality-bench", version: "1.0.0" });
+  await client.connect(transport);
+  try {
+    const result = await client.callTool({
+      name: "search_by_frontmatter",
+      arguments: {
+        property: QUERY_PROPERTY,
+        value: QUERY_VALUE,
+        maxResults: 10,
+      },
+    });
+    return extractResultPaths(textFromResult(result));
+  } finally {
+    await client.close();
+  }
+}
+
+export async function runFrontmatterKeyQualityBench() {
+  const vault = makeFrontmatterKeyQualityVault();
+  try {
+    const matchedPaths = await searchFrontmatter(vault);
+    const matchedSet = new Set(matchedPaths);
+    const relevantMatchedPaths = expectedRelevantPaths.filter((path) => matchedSet.has(path));
+    const missedVariantPaths = expectedRelevantPaths.filter((path) => !matchedSet.has(path));
+    const falsePositivePaths = matchedPaths.filter((path) => !expectedRelevantPaths.includes(path));
+    const duplicatePathCount = matchedPaths.length - new Set(matchedPaths).size;
+
+    return {
+      query: { property: QUERY_PROPERTY, value: QUERY_VALUE },
+      expectedRelevant: expectedRelevantPaths.length,
+      matchedRelevant: relevantMatchedPaths.length,
+      caseVariantRecall: relevantMatchedPaths.length / expectedRelevantPaths.length,
+      exactKeyMatches: matchedSet.has("lower-status.md") ? 1 : 0,
+      caseVariantMatches: relevantMatchedPaths.filter((path) => path !== "lower-status.md").length,
+      caseVariantMisses: missedVariantPaths.length,
+      wrongKeyMatches: falsePositivePaths.length,
+      duplicatePathCount,
+      matchedPaths,
+      missedVariantPaths,
+      falsePositivePaths,
+    };
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+}
+
+const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (invokedDirectly) {
+  if (!existsSync(entry)) {
+    console.error("build/index.js missing - run `npm run build` first.");
+    process.exit(1);
+  }
+  const result = await runFrontmatterKeyQualityBench();
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify(result));
+  } else {
+    console.log(`case-variant recall ${result.caseVariantRecall.toFixed(3)}`);
+    console.log(`matched relevant ${result.matchedRelevant}/${result.expectedRelevant}`);
+    console.log(`case-variant misses ${result.caseVariantMisses}`);
+    console.log(`wrong-key matches ${result.wrongKeyMatches}`);
+    console.log(`duplicate paths ${result.duplicatePathCount}`);
+    console.log("\n| result | paths |");
+    console.log("|---|---|");
+    console.log(`| matched | ${result.matchedPaths.join(", ") || "-"} |`);
+    console.log(`| missed variants | ${result.missedVariantPaths.join(", ") || "-"} |`);
+    console.log(`| wrong-key matches | ${result.falsePositivePaths.join(", ") || "-"} |`);
+  }
+}


### PR DESCRIPTION
Adds an active Frontmatter Key Quality experiment with a stdio fixture for `search_by_frontmatter` key-case recall. The baseline finds 1 of 3 relevant `status` / `Status` / `STATUS` notes, for recall 0.333 with zero wrong-key matches.

The lockfile also moves transitive Hono from 4.12.18 to 4.12.23, clearing the moderate audit advisories that blocked `npm run verify`.

Score: 2 severity x 3 reach / 1 effort = 6. The audit advisory affects the HTTP dependency path, and the R&D fixture targets a common metadata lookup gap.

Risk: no tool names, params, result shapes, scripts, package files list, engines, or runtime behavior change. The dependency change is a non-major transitive Hono patch update.

Tests: node scripts/bench-frontmatter-key-quality.mjs --json twice; npm run verify.

Greptile could not review because the account hit the 50-review trial cap.