### PR TITLE
chore: publish npm from env token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 build/
 .env
 .env.local
+.npmrc
 *.tgz
 .DS_Store
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Token-based npm release helper in `scripts/publish-npm-from-env.mjs`, plus release docs for using `NPM_TOKEN` without committing npm credentials.
 - Active R&D experiment for frontmatter key quality, with a synthetic `search_by_frontmatter` fixture in `scripts/bench-frontmatter-key-quality.mjs` and ship/kill metric in `docs/rnd/frontmatter-key-quality.md`.
 - R&D experiment for lexical search ranking quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-ranking-quality.mjs` and ship/kill metric in `docs/rnd/search-ranking-quality.md`.
 - R&D experiment for lexical search snippet quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-snippet-quality.mjs` and ship/kill metric in `docs/rnd/search-snippet-quality.md`.

--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ OBSIDIAN_VAULT_PATH=/path/to/vault npm start
 ```
 
 For the company-grade maintenance and R&D operating plan, see [docs/DEVELOPMENT_GOAL.md](./docs/DEVELOPMENT_GOAL.md).
+For token-based npm publishing, see [docs/RELEASE.md](./docs/RELEASE.md).
 
 GitHub Actions workflows are manual-only in this repository. Use `npm run verify` as the required local gate before merging or publishing.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,80 @@
+# Release
+
+This repository publishes from a local, verified `master` checkout. GitHub
+Actions stay manual-only; local `npm run verify` is the release gate.
+
+## npm token setup
+
+Use a granular npm access token rather than `npm login` on this machine.
+
+Create the token on npmjs.com. npm documents access tokens as CLI/API
+authentication that can publish packages, and granular tokens can be restricted
+by package/scope, expiration, IP range, and write access:
+
+- permission: read and write
+- package access: `obsidian-mcp-pro` only, if available
+- expiration: short enough to rotate on purpose
+- 2FA: enable Bypass 2FA only when npm package/account policy would otherwise
+  reject token publishing
+- IP range: restrict if the current network is stable enough
+
+References: [About access tokens](https://docs.npmjs.com/about-access-tokens/),
+[Creating and viewing access tokens](https://docs.npmjs.com/creating-and-viewing-access-tokens/).
+
+Set it in the current shell:
+
+```powershell
+$env:NPM_TOKEN = "npm_xxx"
+```
+
+Or set it for future PowerShell sessions:
+
+```powershell
+[Environment]::SetEnvironmentVariable("NPM_TOKEN", "npm_xxx", "User")
+```
+
+Restart the terminal after setting a user-level variable. Never paste the token
+into `.npmrc`, `.env`, shell history comments, GitHub comments, issues, PRs, or
+agent-visible notes.
+
+`NODE_AUTH_TOKEN` is accepted as a fallback name, but `NPM_TOKEN` is the primary
+one used by this repository.
+
+## Publish command
+
+From a clean `master` checkout:
+
+```powershell
+node scripts\publish-npm-from-env.mjs --dry-run
+node scripts\publish-npm-from-env.mjs
+```
+
+The helper:
+
+- refuses to run outside `master`
+- refuses to run with uncommitted changes
+- runs `npm run verify`
+- checks `npm whoami` with the token
+- runs `npm publish --access public`
+- writes only a temporary npm userconfig file containing `${NPM_TOKEN}`, then
+  deletes it before exit
+
+npm's `.npmrc` format supports environment-variable substitution, and npm's
+`userconfig` setting can be supplied with `--userconfig`; the helper uses both
+so auth config stays temporary.
+
+References: [.npmrc](https://docs.npmjs.com/files/npmrc/),
+[npm config](https://docs.npmjs.com/cli/using-npm/config/).
+
+For a non-`latest` dist-tag:
+
+```powershell
+node scripts\publish-npm-from-env.mjs --tag next
+```
+
+After a successful publish, remove the variable from the current session if it is
+not needed:
+
+```powershell
+Remove-Item Env:NPM_TOKEN
+```

--- a/scripts/publish-npm-from-env.mjs
+++ b/scripts/publish-npm-from-env.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// Publish using an npm token from the environment without writing the token to
+// project files. The temp npmrc contains ${NPM_TOKEN}, not the token value.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const args = process.argv.slice(2);
+
+function usage() {
+  console.log(`Usage: node scripts/publish-npm-from-env.mjs [--dry-run] [--tag <dist-tag>]
+
+Requires NPM_TOKEN or NODE_AUTH_TOKEN in the environment.
+
+Examples:
+  $env:NPM_TOKEN = "npm_xxx"
+  node scripts/publish-npm-from-env.mjs --dry-run
+  node scripts/publish-npm-from-env.mjs
+`);
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function readOption(name) {
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) fail(`${name} requires a value.`);
+  return value;
+}
+
+function run(command, commandArgs, options = {}) {
+  const result = spawnSync(command, commandArgs, {
+    cwd: process.cwd(),
+    env: options.env ?? process.env,
+    encoding: options.encoding,
+    stdio: options.stdio ?? "inherit",
+  });
+  if (result.error) fail(`${command} failed: ${result.error.message}`);
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+  return result;
+}
+
+function runQuiet(command, commandArgs) {
+  return run(command, commandArgs, { encoding: "utf-8", stdio: "pipe" }).stdout.trim();
+}
+
+function withoutUserconfig(commandArgs) {
+  return commandArgs.filter((arg, index) => arg !== "--userconfig" && commandArgs[index - 1] !== "--userconfig");
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const allowedArgs = new Set(["--dry-run", "--tag"]);
+for (const arg of args) {
+  if (!arg.startsWith("--")) continue;
+  if (!allowedArgs.has(arg)) fail(`Unsupported option: ${arg}`);
+}
+
+const dryRun = args.includes("--dry-run");
+const distTag = readOption("--tag");
+const token = process.env.NPM_TOKEN || process.env.NODE_AUTH_TOKEN;
+
+if (!token) {
+  fail("Set NPM_TOKEN or NODE_AUTH_TOKEN before publishing.");
+}
+
+const branch = runQuiet("git", ["branch", "--show-current"]);
+if (branch !== "master") {
+  fail(`Refusing to publish from ${branch || "detached HEAD"}; switch to master first.`);
+}
+
+const dirty = runQuiet("git", ["status", "--porcelain"]);
+if (dirty) {
+  fail("Refusing to publish with uncommitted changes.");
+}
+
+const tempDir = mkdtempSync(join(tmpdir(), "ompro-npm-publish-"));
+const userconfig = join(tempDir, "npmrc");
+const publishEnv = {
+  ...process.env,
+  NPM_TOKEN: token,
+  NODE_AUTH_TOKEN: token,
+  NPM_CONFIG_USERCONFIG: userconfig,
+};
+
+writeFileSync(
+  userconfig,
+  [
+    "registry=https://registry.npmjs.org/",
+    "//registry.npmjs.org/:_authToken=${NPM_TOKEN}",
+    "",
+  ].join("\n"),
+  { encoding: "utf-8", mode: 0o600 },
+);
+
+try {
+  console.log("> npm run verify");
+  run(npmCommand, ["run", "verify"]);
+
+  console.log("> npm whoami");
+  run(npmCommand, ["whoami", "--userconfig", userconfig], { env: publishEnv });
+
+  const publishArgs = ["publish", "--access", "public", "--userconfig", userconfig];
+  if (distTag) publishArgs.push("--tag", distTag);
+  if (dryRun) publishArgs.push("--dry-run");
+
+  console.log(`> npm ${withoutUserconfig(publishArgs).join(" ")}`);
+  run(npmCommand, publishArgs, { env: publishEnv });
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
Adds a release helper that publishes with `NPM_TOKEN` or `NODE_AUTH_TOKEN` from the environment using a temporary npm userconfig. It refuses non-master and dirty publishes, runs `npm run verify`, checks `npm whoami`, and never writes the token value into project files.

Also documents granular npm token setup and ignores local `.npmrc` files so hand-written credential configs are harder to stage by accident.

Score: 2 severity x 3 reach / 1 effort = 6. This unblocks the currently blocked npm publish path while keeping the token out of the repo.

Risk: no package scripts, package files, engines, tool APIs, or runtime behavior changed. The helper is maintainer-only and requires an env token before it can publish.

Docs checked: npm access-token docs, npm token creation docs, npmrc env substitution docs, and npm `userconfig` docs.

Tests: node --check scripts/publish-npm-from-env.mjs; node scripts/publish-npm-from-env.mjs --help; missing-token failure path; npm run verify.

Greptile could not review because the account hit the 50-review trial cap.