### PR TITLE
fix: run npm publish helper on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Token-based npm release helper now invokes npm through PowerShell on Windows, avoiding direct `npm.cmd` spawn failures.
 - Updated the transitive Hono lockfile entry to 4.12.23, clearing the moderate audit advisories in the MCP HTTP dependency path.
 - HTTP server tests now retry OS-assigned ports that Node's `fetch` rejects, avoiding a flaky `bad port` failure during the verify gate.
 - `obsidian://tags` now escapes control characters in generated tag keys and note-path values before returning its JSON index.

--- a/scripts/publish-npm-from-env.mjs
+++ b/scripts/publish-npm-from-env.mjs
@@ -7,7 +7,6 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const args = process.argv.slice(2);
 
 function usage() {
@@ -51,6 +50,22 @@ function run(command, commandArgs, options = {}) {
 
 function runQuiet(command, commandArgs) {
   return run(command, commandArgs, { encoding: "utf-8", stdio: "pipe" }).stdout.trim();
+}
+
+function npmArgs(commandArgs) {
+  if (process.platform !== "win32") {
+    return { command: "npm", args: commandArgs };
+  }
+
+  return {
+    command: "powershell.exe",
+    args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "npm", ...commandArgs],
+  };
+}
+
+function runNpm(commandArgs, options = {}) {
+  const npm = npmArgs(commandArgs);
+  return run(npm.command, npm.args, options);
 }
 
 function withoutUserconfig(commandArgs) {
@@ -107,17 +122,17 @@ writeFileSync(
 
 try {
   console.log("> npm run verify");
-  run(npmCommand, ["run", "verify"]);
+  runNpm(["run", "verify"]);
 
   console.log("> npm whoami");
-  run(npmCommand, ["whoami", "--userconfig", userconfig], { env: publishEnv });
+  runNpm(["whoami", "--userconfig", userconfig], { env: publishEnv });
 
   const publishArgs = ["publish", "--access", "public", "--userconfig", userconfig];
   if (distTag) publishArgs.push("--tag", distTag);
   if (dryRun) publishArgs.push("--dry-run");
 
   console.log(`> npm ${withoutUserconfig(publishArgs).join(" ")}`);
-  run(npmCommand, publishArgs, { env: publishEnv });
+  runNpm(publishArgs, { env: publishEnv });
 } finally {
   rmSync(tempDir, { recursive: true, force: true });
 }


### PR DESCRIPTION
Runs npm through PowerShell on Windows so the env-token publish helper does not fail on direct `npm.cmd` spawning.

Score: 2 severity x 2 reach / 1 effort = 4. The release helper was blocked on Windows before it could reach npm auth checks.

Risk: maintainer-only script path; token handling, temp npm userconfig, dirty-tree guard, branch guard, and publish args stay the same.

Tests: node --check scripts/publish-npm-from-env.mjs; node scripts/publish-npm-from-env.mjs --help; missing-token failure path; fake-token branch-guard path; npm run verify.

Greptile could not review because the account hit the 50-review trial cap.