### PR TITLE
fix: read npm token from Windows user env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Token-based npm release helper can now read `NPM_TOKEN` from the Windows user environment, so Codex can publish after the owner stores the token once.
 - Token-based npm release helper now invokes npm through PowerShell on Windows, avoiding direct `npm.cmd` spawn failures.
 - Updated the transitive Hono lockfile entry to 4.12.23, clearing the moderate audit advisories in the MCP HTTP dependency path.
 - HTTP server tests now retry OS-assigned ports that Node's `fetch` rejects, avoiding a flaky `bad port` failure during the verify gate.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -33,9 +33,10 @@ Or set it for future PowerShell sessions:
 [Environment]::SetEnvironmentVariable("NPM_TOKEN", "npm_xxx", "User")
 ```
 
-Restart the terminal after setting a user-level variable. Never paste the token
-into `.npmrc`, `.env`, shell history comments, GitHub comments, issues, PRs, or
-agent-visible notes.
+The publish helper reads this Windows user-level value directly when its process
+environment does not include `NPM_TOKEN`, so Codex can publish later without a
+restart after the variable is set. Never paste the token into `.npmrc`, `.env`,
+shell history comments, GitHub comments, issues, PRs, or agent-visible notes.
 
 `NODE_AUTH_TOKEN` is accepted as a fallback name, but `NPM_TOKEN` is the primary
 one used by this repository.
@@ -77,4 +78,10 @@ not needed:
 
 ```powershell
 Remove-Item Env:NPM_TOKEN
+```
+
+To remove the persistent Windows user-level token:
+
+```powershell
+[Environment]::SetEnvironmentVariable("NPM_TOKEN", $null, "User")
 ```

--- a/scripts/publish-npm-from-env.mjs
+++ b/scripts/publish-npm-from-env.mjs
@@ -52,6 +52,36 @@ function runQuiet(command, commandArgs) {
   return run(command, commandArgs, { encoding: "utf-8", stdio: "pipe" }).stdout.trim();
 }
 
+function readWindowsUserEnv(name) {
+  if (process.platform !== "win32") return "";
+  const result = spawnSync(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      `[Environment]::GetEnvironmentVariable('${name}', 'User')`,
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: "utf-8",
+      stdio: "pipe",
+    },
+  );
+  if (result.status !== 0 || result.error) return "";
+  return result.stdout.trim();
+}
+
+function readToken() {
+  return (
+    process.env.NPM_TOKEN ||
+    process.env.NODE_AUTH_TOKEN ||
+    readWindowsUserEnv("NPM_TOKEN") ||
+    readWindowsUserEnv("NODE_AUTH_TOKEN")
+  );
+}
+
 function npmArgs(commandArgs) {
   if (process.platform !== "win32") {
     return { command: "npm", args: commandArgs };
@@ -85,7 +115,7 @@ for (const arg of args) {
 
 const dryRun = args.includes("--dry-run");
 const distTag = readOption("--tag");
-const token = process.env.NPM_TOKEN || process.env.NODE_AUTH_TOKEN;
+const token = readToken();
 
 if (!token) {
   fail("Set NPM_TOKEN or NODE_AUTH_TOKEN before publishing.");


### PR DESCRIPTION
Lets the npm publish helper read `NPM_TOKEN` or `NODE_AUTH_TOKEN` from the Windows user environment when the current process did not inherit the token. This lets a token stored once with `[Environment]::SetEnvironmentVariable(..., User)` work for later Codex publish runs without pasting secrets into chat or repo files.

Score: 2 severity x 2 reach / 1 effort = 4. The token path existed, but Codex processes could miss variables set in a separate terminal.

Risk: maintainer-only publish helper. The token still only goes into the temporary npm child-process environment and the generated npmrc still contains `${NPM_TOKEN}`, not the token value.

Tests: node --check scripts/publish-npm-from-env.mjs; node scripts/publish-npm-from-env.mjs --help; process-env-cleared token discovery reached the branch guard via Windows user env; npm run verify.

Greptile could not review because the account hit the 50-review trial cap.