### PR TITLE
fix semantic cache read filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `search_semantic` and `find_similar_notes` now filter persisted embedding hits through the current read allowlist, preventing stale wider-scope cache entries from leaking private paths or snippets after permissions are narrowed.
 - Updated the transitive Hono lockfile entry to 4.12.23, clearing the moderate audit advisories in the MCP HTTP dependency path.
 - HTTP server tests now retry OS-assigned ports that Node's `fetch` rejects, avoiding a flaky `bad port` failure during the verify gate.
 - `obsidian://tags` now escapes control characters in generated tag keys and note-path values before returning its JSON index.

--- a/src/__tests__/embedding-store.test.ts
+++ b/src/__tests__/embedding-store.test.ts
@@ -162,6 +162,23 @@ describe("setNoteChunks / searchEmbeddings", () => {
     expect(hits.map((h) => h.notePath)).toEqual(["other.md"]);
   });
 
+  it("applies the note filter before ranking and limiting", async () => {
+    await loadStore(vaultDir);
+    setNoteChunks(vaultDir, "private.md", hashText("private"), [
+      { notePath: "private.md", chunkIndex: 1, headingPath: [], text: "x", hash: "h", vector: [1, 0] },
+    ], "test", "m");
+    setNoteChunks(vaultDir, "public.md", hashText("public"), [
+      { notePath: "public.md", chunkIndex: 1, headingPath: [], text: "y", hash: "h", vector: [0.9, 0.1] },
+    ], "test", "m");
+
+    const hits = searchEmbeddings(vaultDir, [1, 0], {
+      limit: 1,
+      filterNote: (notePath) => notePath.startsWith("public"),
+    });
+
+    expect(hits.map((h) => h.notePath)).toEqual(["public.md"]);
+  });
+
   it("anchors similar-note queries to the source note's opening topic", async () => {
     await loadStore(vaultDir);
     setNoteChunks(vaultDir, "source-cat-care.md", hashText("source"), [

--- a/src/__tests__/handlers/semantic.test.ts
+++ b/src/__tests__/handlers/semantic.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
 import { setProviderForTests, resetProviderForTests, type EmbeddingProvider } from "../../lib/embedding-providers.js";
 import { clearStore } from "../../lib/embedding-store.js";
+import { setPermissions } from "../../lib/permissions.js";
 
 /**
  * Deterministic mock embedding provider for handler tests. Maps text to a
@@ -31,6 +32,7 @@ class MockProvider implements EmbeddingProvider {
 let env: TestEnv;
 
 beforeEach(async () => {
+  setPermissions({ readPaths: null, writePaths: null });
   setProviderForTests(new MockProvider());
   env = await createTestEnv({
     skipFixtures: true,
@@ -47,6 +49,7 @@ beforeEach(async () => {
 afterEach(async () => {
   await env.cleanup();
   await clearStore(env.vaultDir, { removeSnapshot: true });
+  setPermissions({ readPaths: null, writePaths: null });
   resetProviderForTests();
 });
 
@@ -169,6 +172,33 @@ describe("semantic handlers — search_semantic", () => {
     expect(text).not.toContain("Dirty\tHeading");
     expect(text).not.toContain("\x07");
   });
+
+  it("filters persisted embedding hits through the current read allowlist", async () => {
+    await env.cleanup();
+    await clearStore(env.vaultDir, { removeSnapshot: true });
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "public/cats.md": "# Public Cats\n\nCats are friendly companions.",
+        "private/secret.md": "# Private Cats\n\nCats guard the private launch notes.",
+        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+      },
+    });
+
+    await env.client.callTool({ name: "index_vault", arguments: {} });
+    setPermissions({ readPaths: ["public"], writePaths: null });
+
+    const result = await env.client.callTool({
+      name: "search_semantic",
+      arguments: { query: "cats", limit: 5 },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain("public/cats.md");
+    expect(text).not.toContain("private/secret.md");
+    expect(text).not.toContain("private launch notes");
+  });
 });
 
 describe("semantic handlers — find_similar_notes", () => {
@@ -228,6 +258,57 @@ describe("semantic handlers — find_similar_notes", () => {
     const text = textContent(result);
     expect(text).toContain("Dirty\\tHeading");
     expect(text).not.toContain("Dirty\tHeading");
+  });
+
+  it("rejects an unreadable source note from the persisted embedding store", async () => {
+    await env.cleanup();
+    await clearStore(env.vaultDir, { removeSnapshot: true });
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "public/cats.md": "# Public Cats\n\nCats are friendly companions.",
+        "private/secret.md": "# Private Cats\n\nCats guard the private launch notes.",
+        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+      },
+    });
+
+    await env.client.callTool({ name: "index_vault", arguments: {} });
+    setPermissions({ readPaths: ["public"], writePaths: null });
+
+    const result = await env.client.callTool({
+      name: "find_similar_notes",
+      arguments: { path: "private/secret.md", limit: 5 },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/Access denied/);
+  });
+
+  it("filters similar-note results through the current read allowlist", async () => {
+    await env.cleanup();
+    await clearStore(env.vaultDir, { removeSnapshot: true });
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "public/cats.md": "# Public Cats\n\nCats are friendly companions.",
+        "public/dogs.md": "# Public Dogs\n\nDogs are loyal companions.",
+        "private/secret.md": "# Private Cats\n\nCats guard the private launch notes.",
+        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+      },
+    });
+
+    await env.client.callTool({ name: "index_vault", arguments: {} });
+    setPermissions({ readPaths: ["public"], writePaths: null });
+
+    const result = await env.client.callTool({
+      name: "find_similar_notes",
+      arguments: { path: "public/cats.md", limit: 5 },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain("public/dogs.md");
+    expect(text).not.toContain("private/secret.md");
   });
 });
 

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -476,6 +476,8 @@ export interface SearchOptions {
   /** Excluded note paths — used by `find_similar_notes` to drop the source
    *  note from its own results. */
   excludeNotes?: ReadonlySet<string>;
+  /** Optional policy check applied before scoring/ranking each stored note. */
+  filterNote?: (notePath: string) => boolean;
 }
 
 export function searchEmbeddings(
@@ -489,6 +491,7 @@ export function searchEmbeddings(
     ? options.folder.replace(/^\/+|\/+$/g, "")
     : null;
   const exclude = options.excludeNotes ?? null;
+  const filterNote = options.filterNote ?? null;
 
   const hits: SearchHit[] = [];
   for (const entry of state.byKey.values()) {
@@ -496,6 +499,7 @@ export function searchEmbeddings(
       if (entry.notePath !== folder && !entry.notePath.startsWith(folder + "/")) continue;
     }
     if (exclude && exclude.has(entry.notePath)) continue;
+    if (filterNote && !filterNote(entry.notePath)) continue;
     const score = cosineSimilarity(queryVector, entry.vector);
     hits.push({
       notePath: entry.notePath,

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { listNotes, vaultRewriteLockKey, withFileLock } from "../lib/vault.js";
+import { listNotes, resolveVaultPath, vaultRewriteLockKey, withFileLock } from "../lib/vault.js";
 import { readAllCached } from "../lib/index-cache.js";
 import { chunkNote } from "../lib/chunker.js";
 import { getActiveProvider } from "../lib/embedding-providers.js";
@@ -42,6 +42,15 @@ const displaySemanticValue = escapeControlChars;
 
 function displayHeadingPath(path: readonly string[]): string {
   return path.map(displaySemanticValue).join(" / ");
+}
+
+function canReadStoredEmbeddingNote(vaultPath: string, notePath: string): boolean {
+  try {
+    resolveVaultPath(vaultPath, notePath, "read");
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 interface IndexProgress {
@@ -324,7 +333,11 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         if (!Array.isArray(vector)) {
           return errorResult("Provider did not return a vector for the query.");
         }
-        const hits = searchEmbeddings(vaultPath, vector, { limit, ...(folder ? { folder } : {}) });
+        const hits = searchEmbeddings(vaultPath, vector, {
+          limit,
+          ...(folder ? { folder } : {}),
+          filterNote: (notePath) => canReadStoredEmbeddingNote(vaultPath, notePath),
+        });
         if (hits.length === 0) {
           return textResult(`No matches for "${displaySemanticValue(query)}".`);
         }
@@ -383,6 +396,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         if (provider) {
           invalidateIfIncompatible(vaultPath, provider.id, provider.model);
         }
+        resolveVaultPath(vaultPath, notePath, "read");
         const ownChunks = getNoteEmbeddings(vaultPath, notePath);
         if (ownChunks.length === 0) {
           return errorResult(
@@ -394,6 +408,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         const hits = searchEmbeddings(vaultPath, queryVector, {
           limit,
           excludeNotes: exclude,
+          filterNote: (hitPath) => canReadStoredEmbeddingNote(vaultPath, hitPath),
         });
         const ranked = hits.map((h) => ({
           notePath: h.notePath,


### PR DESCRIPTION
`search_semantic` and `find_similar_notes` now apply the active vault read policy to persisted embedding hits before rendering paths, snippets, or similar-note rows. `find_similar_notes` also validates the source note path before using cached chunks as the query seed, so a stale wider-scope embedding snapshot cannot bypass narrowed `OBSIDIAN_READ_PATHS`.

Score: 3 severity x 3 reach / 1 effort = 9. Risk is low: this only removes unreadable cached hits from semantic outputs and keeps existing unrestricted behavior unchanged.

Tested with focused semantic/store regression tests and `npm run verify`.