### PR TITLE
fix index cache snapshot mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Persistent index-cache snapshots now use owner-only file permissions when written on POSIX systems, matching the embedding cache's private snapshot behavior.
 - `search_semantic` and `find_similar_notes` now filter persisted embedding hits through the current read allowlist, preventing stale wider-scope cache entries from leaking private paths or snippets after permissions are narrowed.
 - Updated the transitive Hono lockfile entry to 4.12.23, clearing the moderate audit advisories in the MCP HTTP dependency path.
 - HTTP server tests now retry OS-assigned ports that Node's `fetch` rejects, avoiding a flaky `bad port` failure during the verify gate.

--- a/src/__tests__/index-cache.test.ts
+++ b/src/__tests__/index-cache.test.ts
@@ -5,6 +5,7 @@ import os from "os";
 import { readAllCached, clearCache, cacheSize, flushNow } from "../lib/index-cache.js";
 
 let vaultDir: string;
+const itPosix = process.platform === "win32" ? it.skip : it;
 
 beforeEach(async () => {
   vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "cache-test-"));
@@ -109,6 +110,16 @@ describe("persistent cache", () => {
     const parsed = JSON.parse(raw);
     expect(parsed.version).toBe(1);
     expect(parsed.entries["a.md"].content).toBe("alpha");
+  });
+
+  itPosix("writes snapshots with owner-only permissions", async () => {
+    await write("a.md", "alpha");
+    await readAllCached(vaultDir, ["a.md"]);
+    await flushNow(vaultDir);
+
+    const snap = path.join(vaultDir, ".obsidian", "cache", "mcp-pro-index-cache.json");
+    const stat = await fs.stat(snap);
+    expect(stat.mode & 0o777).toBe(0o600);
   });
 
   it("rehydrates from disk on a fresh process (simulated via clearCache)", async () => {

--- a/src/lib/index-cache.ts
+++ b/src/lib/index-cache.ts
@@ -36,6 +36,7 @@ import { renameWithRetry } from "./fs-ops.js";
 const READ_CONCURRENCY = 16;
 const CACHE_FILE_VERSION = 1;
 const CACHE_REL_PATH = ".obsidian/cache/mcp-pro-index-cache.json";
+const CACHE_FILE_MODE = 0o600;
 const FLUSH_DEBOUNCE_MS = 5_000;
 const MAX_PERSISTED_BYTES = 64 * 1024 * 1024; // 64 MB safety cap
 
@@ -271,7 +272,7 @@ async function doFlush(vaultPath: string, state: VaultCacheState): Promise<void>
   try {
     await fs.mkdir(dir, { recursive: true });
     const tmp = `${file}.${process.pid}-${Date.now()}-${crypto.randomUUID().slice(0, 8)}.tmp`;
-    await fs.writeFile(tmp, JSON.stringify(snapshot), "utf-8");
+    await fs.writeFile(tmp, JSON.stringify(snapshot), { encoding: "utf-8", mode: CACHE_FILE_MODE });
     await renameWithRetry(tmp, file);
   } catch (err) {
     // Write failed - re-mark dirty so the next flush retries this data.


### PR DESCRIPTION
Index-cache snapshots contain note bodies, so the temp file now gets an explicit owner-only mode before the atomic rename. Node's `fsPromises.writeFile` docs list `mode` as the file creation permission and note that it only applies to newly created files, which fits this temp-file path: https://nodejs.org/api/fs.html#fspromiseswritefilefile-data-options

Score: 2 severity x 3 reach / 1 effort = 6. Risk is low: snapshot contents and cache invalidation are unchanged; only the POSIX file mode for newly written snapshots is narrowed.

Tested with focused index-cache tests and `npm run verify`. The mode assertion is POSIX-only and skips on Windows, where Node does not enforce POSIX permission bits the same way.