### PR TITLE
fix attachment resource uris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `get_attachment` now percent-encodes vault resource URIs for blob/SVG responses, keeping control characters out of MCP resource identifiers while preserving plain paths for ordinary attachment names.
 - Persistent index-cache snapshots now use owner-only file permissions when written on POSIX systems, matching the embedding cache's private snapshot behavior.
 - `search_semantic` and `find_similar_notes` now filter persisted embedding hits through the current read allowlist, preventing stale wider-scope cache entries from leaking private paths or snippets after permissions are narrowed.
 - Updated the transitive Hono lockfile entry to 4.12.23, clearing the moderate audit advisories in the MCP HTTP dependency path.

--- a/src/__tests__/attachments-display.test.ts
+++ b/src/__tests__/attachments-display.test.ts
@@ -133,4 +133,38 @@ describe("attachment display escaping", () => {
       await env.cleanup();
     }
   });
+
+  it("percent-encodes control characters in resource URIs", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "attachment-display-"));
+    tempDirs.push(dir);
+    const fullPath = path.join(dir, "dirty.pdf");
+    await fs.writeFile(fullPath, "PDF-dirty-name", "utf-8");
+
+    const env = await createAttachmentClient({
+      attachments: [],
+      resolvedPath: fullPath,
+    });
+    try {
+      const result = await env.client.callTool({
+        name: "get_attachment",
+        arguments: { path: "assets/bad\nname.pdf" },
+      });
+
+      expect(isError(result)).toBe(false);
+      const blocks = result.content as Array<{
+        type: string;
+        text?: string;
+        resource?: { uri?: string; mimeType?: string };
+      }>;
+      const resourceBlock = blocks.find((b) => b.type === "resource");
+      const textBlock = blocks.find((b) => b.type === "text");
+      expect(resourceBlock).toBeDefined();
+      expect(resourceBlock!.resource!.uri).toBe("vault://assets/bad%0Aname.pdf");
+      expect(resourceBlock!.resource!.uri).not.toContain("\n");
+      expect(textBlock!.text).toContain("bad\\nname.pdf");
+      expect(textBlock!.text).not.toContain("bad\nname.pdf");
+    } finally {
+      await env.cleanup();
+    }
+  });
 });

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -53,6 +53,10 @@ function errorResult(text: string) {
 /** Escape control characters in a value before embedding it in a display string. */
 const displayAttachmentValue = escapeControlChars;
 
+function vaultResourceUri(relPath: string): string {
+  return `vault://${relPath.replace(/\\/g, "/").split("/").map(encodeURIComponent).join("/")}`;
+}
+
 /** Group attachments by their lower-cased extension for the summary line. */
 function summarizeByExtension(paths: readonly string[]): Map<string, number> {
   const out = new Map<string, number>();
@@ -468,7 +472,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
               {
                 type: "resource" as const,
                 resource: {
-                  uri: `vault://${relPath}`,
+                  uri: vaultResourceUri(relPath),
                   mimeType: "text/plain",
                   text: svgText,
                 },
@@ -520,7 +524,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
               resource: {
                 // vault:// URI lets clients distinguish vault files from
                 // arbitrary URLs in their UI without leaking the host path.
-                uri: `vault://${relPath}`,
+                uri: vaultResourceUri(relPath),
                 mimeType: mime,
                 blob: data,
               },


### PR DESCRIPTION
`get_attachment` now percent-encodes vault resource URI path segments before returning blob or SVG resources. Normal paths like `assets/notes.pdf` keep their old URI text, while control characters and other unsafe URI bytes are encoded before they reach MCP clients.

Score: 2 severity x 3 reach / 1 effort = 6. Risk is low: returned bytes, MIME detection, size caps, and display text are unchanged; only the resource identifier is made URI-safe for unusual paths.

Tested with focused attachment handler/display tests and `npm run verify`.