### PR TITLE
fix require auth for external http binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- HTTP transport now refuses non-loopback binds unless bearer auth is configured, preventing accidental unauthenticated LAN exposure.
 - `replace_in_note` now rejects nested-quantifier regex shapes before matching, reducing catastrophic-backtracking risk on smaller notes.
 - `get_attachment` now percent-encodes vault resource URIs for blob/SVG responses, keeping control characters out of MCP resource identifiers while preserving plain paths for ordinary attachment names.
 - Persistent index-cache snapshots now use owner-only file permissions when written on POSIX systems, matching the embedding cache's private snapshot behavior.

--- a/README.md
+++ b/README.md
@@ -189,9 +189,11 @@ npx -y obsidian-mcp-pro --transport=http --token=your-secret
 ```
 
 The HTTP server binds to `127.0.0.1` by default with DNS rebinding protection enabled.
+If `--host` is set to a non-loopback address, startup requires `--token=<secret>` or
+`MCP_HTTP_TOKEN`.
 
 > [!WARNING]
-> **Never bind `--host=0.0.0.0` directly to the public internet.** Doing so exposes your entire Obsidian vault to anyone who can reach the port. If you need remote access:
+> **Never bind `--host=0.0.0.0` directly to the public internet.** Doing so exposes your entire Obsidian vault to anyone who can reach the port. The server refuses non-loopback binds without a bearer token, but if you need remote access:
 > - Put the server behind a reverse proxy (nginx, Caddy, Cloudflare Tunnel) that terminates TLS, **and**
 > - Require `--token=<secret>` (or `MCP_HTTP_TOKEN`), **and**
 > - Restrict `--allow-origin` to the specific origins you trust, **and**
@@ -203,7 +205,7 @@ Additional hardening flags:
 
 | Flag | Purpose |
 |------|---------|
-| `--allow-origin=<csv>` | Restrict CORS to an allowlist (e.g. `https://claude.ai,https://chat.openai.com`). Default is `*`. |
+| `--allow-origin=<csv>` | Restrict CORS to an allowlist (e.g. `https://claude.ai,https://chat.openai.com`). Default is localhost-only. |
 | `--rate-limit=<n>` | Cap requests per minute per client IP. `/health` and `/version` are exempt. Default is unlimited. |
 
 Operational endpoints (no auth required):

--- a/src/__tests__/regression-http-fixes.test.ts
+++ b/src/__tests__/regression-http-fixes.test.ts
@@ -365,4 +365,37 @@ describe("regression: HTTP bearer token must not be empty", () => {
   it("rejects whitespace-only programmatic tokens", async () => {
     await expect(startOnEphemeral({ bearerToken: "   " })).rejects.toThrow(/token.*empty/i);
   });
+
+  it("rejects non-loopback binds without bearer auth", async () => {
+    let leaked: HttpServerHandle | undefined;
+    let err: unknown;
+    try {
+      leaked = await startHttpServer({
+        host: "0.0.0.0",
+        port: 0,
+        buildMcpServer: buildNoopServer,
+        installSignalHandlers: false,
+      });
+    } catch (caught) {
+      err = caught;
+    } finally {
+      if (leaked) await leaked.stop();
+    }
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/bearer token.*non-loopback/i);
+  });
+
+  it("allows non-loopback binds when bearer auth is configured", async () => {
+    const handle = await startHttpServer({
+      host: "0.0.0.0",
+      port: 0,
+      bearerToken: "secret",
+      buildMcpServer: buildNoopServer,
+      installSignalHandlers: false,
+    });
+    handles.push(handle);
+
+    expect(handle.host).toBe("0.0.0.0");
+  });
 });

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -220,10 +220,32 @@ function clientIp(req: IncomingMessage): string {
   return addr.startsWith("::ffff:") ? addr.slice(7) : addr;
 }
 
+function normalizedBindHost(host: string): string {
+  const trimmed = host.trim().toLowerCase();
+  return trimmed.startsWith("[") && trimmed.endsWith("]")
+    ? trimmed.slice(1, -1)
+    : trimmed;
+}
+
+function isLoopbackBindHost(host: string): boolean {
+  const normalized = normalizedBindHost(host);
+  return (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized.startsWith("127.") ||
+    normalized.startsWith("::ffff:127.")
+  );
+}
+
 export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServerHandle> {
   const bearerToken = opts.bearerToken?.trim();
   if (opts.bearerToken !== undefined && !bearerToken) {
     throw new Error("HTTP bearer token cannot be empty");
+  }
+  if (!bearerToken && !isLoopbackBindHost(opts.host)) {
+    throw new Error(
+      "HTTP bearer token is required when binding to a non-loopback host. Set MCP_HTTP_TOKEN or pass --token, or bind to 127.0.0.1.",
+    );
   }
   const transports = new Map<string, StreamableHTTPServerTransport>();
   const lastActivity = new Map<string, number>();


### PR DESCRIPTION
Refuse HTTP startup on a non-loopback host unless bearer auth is configured, closing accidental unauthenticated LAN exposure. Local loopback no-token use is unchanged; token-backed `0.0.0.0` still starts, and the README now documents the requirement plus the localhost-only CORS default.

Risk: medium; users binding a LAN or wildcard host without auth must set `MCP_HTTP_TOKEN` or pass `--token`. Score: 3 severity x 3 reach / 1 effort = 9.

Tested: `npm run test -- src/__tests__/regression-http-fixes.test.ts src/__tests__/http-server.test.ts`; `npm run verify`.