### PR TITLE
fix normalize canvas link schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Canvas link nodes now reject dangerous URL schemes after URL normalization, catching control-character-obfuscated `javascript:`, `data:`, and `vbscript:` inputs.
 - HTTP transport now refuses non-loopback binds unless bearer auth is configured, preventing accidental unauthenticated LAN exposure.
 - `replace_in_note` now rejects nested-quantifier regex shapes before matching, reducing catastrophic-backtracking risk on smaller notes.
 - `get_attachment` now percent-encodes vault resource URIs for blob/SVG responses, keeping control characters out of MCP resource identifiers while preserving plain paths for ordinary attachment names.

--- a/src/__tests__/handlers/canvas.test.ts
+++ b/src/__tests__/handlers/canvas.test.ts
@@ -233,6 +233,45 @@ describe("canvas handlers — add_canvas_node", () => {
     expect(isError(result)).toBe(false);
   });
 
+  it("rejects dangerous link URL schemes after URL normalization", async () => {
+    const canvasPath = path.join(env.vaultDir, "boards/test.canvas");
+    const before = await fs.readFile(canvasPath, "utf-8");
+
+    const result = await env.client.callTool({
+      name: "add_canvas_node",
+      arguments: {
+        canvasPath: "boards/test.canvas",
+        type: "link",
+        content: "java\nscript:alert(1)",
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/invalid url scheme|javascript/i);
+
+    const after = await fs.readFile(canvasPath, "utf-8");
+    expect(after).toBe(before);
+  });
+
+  it("accepts ordinary HTTPS link URLs", async () => {
+    const result = await env.client.callTool({
+      name: "add_canvas_node",
+      arguments: {
+        canvasPath: "boards/test.canvas",
+        type: "link",
+        content: "https://example.com/deep/path?q=1",
+      },
+    });
+
+    expect(isError(result)).toBe(false);
+    const canvasRaw = await fs.readFile(
+      path.join(env.vaultDir, "boards/test.canvas"),
+      "utf-8",
+    );
+    const canvas = JSON.parse(canvasRaw) as { nodes: Array<{ url?: string }> };
+    expect(canvas.nodes.some((n) => n.url === "https://example.com/deep/path?q=1")).toBe(true);
+  });
+
   it("rejects color values that don't match the palette regex", async () => {
     const result = await env.client.callTool({
       name: "add_canvas_node",

--- a/src/tools/canvas.ts
+++ b/src/tools/canvas.ts
@@ -27,6 +27,27 @@ function displayCanvasValue(value: string): string {
   return escapeControlChars(value);
 }
 
+const BLOCKED_CANVAS_LINK_PROTOCOLS = new Set(["javascript:", "data:", "vbscript:"]);
+
+function blockedCanvasLinkProtocol(value: string): string | null {
+  try {
+    const parsed = new URL(value.trim());
+    return BLOCKED_CANVAS_LINK_PROTOCOLS.has(parsed.protocol)
+      ? parsed.protocol.slice(0, -1)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function hasUrlControlChars(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
 function canvasReadCacheKey(vaultPath: string, canvasPath: string): string {
   return `${path.resolve(vaultPath)}\0${canvasPath}`;
 }
@@ -294,11 +315,17 @@ export function registerCanvasTools(server: McpServer, vaultPath: string): void 
         }
 
         if (type === "link") {
-          // Reject dangerous URI schemes that could execute code when the
-          // canvas is opened in Obsidian or exported to HTML.
-          if (/^(javascript|data|vbscript):/i.test(content)) {
+          // WHATWG URL parsing normalizes leading spaces and C0 whitespace
+          // inside schemes, so check the parsed protocol instead of raw text.
+          const blockedProtocol = blockedCanvasLinkProtocol(content);
+          if (blockedProtocol) {
             return errorResult(
-              `Invalid URL scheme in "${displayCanvasValue(content)}". javascript:, data:, and vbscript: URIs are not allowed.`,
+              `Invalid URL scheme in "${displayCanvasValue(content)}". ${blockedProtocol}: URIs are not allowed.`,
+            );
+          }
+          if (hasUrlControlChars(content)) {
+            return errorResult(
+              `Invalid URL in "${displayCanvasValue(content)}". Control characters are not allowed in canvas link URLs.`,
             );
           }
         }


### PR DESCRIPTION
Normalize canvas link-node URLs before checking blocked schemes, so C0-obfuscated `javascript:`, `data:`, and `vbscript:` inputs are refused before they are persisted. Ordinary HTTPS link nodes still pass, and the change follows the JSON Canvas link-node shape where `url` is the node's URL field: https://jsoncanvas.org/spec/1.0/

Risk: low; only dangerous schemes and control-character link URLs are rejected. Score: 2 severity x 3 reach / 1 effort = 6.

Tested: `npm run test -- src/__tests__/handlers/canvas.test.ts src/__tests__/regression-tools-canvas.test.ts`; `npm run verify`.