### PR TITLE
fix elicit bulk rewrite confirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `move_note` reference rewrites and `rename_tag` bulk writes now ask elicitation-capable clients for a typed confirmation before rewriting across the vault, while keeping existing behavior for clients without elicitation and for dry runs.
 - Frontmatter parsing now accepts only Obsidian-style YAML delimiter lines, leaves oversized YAML blocks unparsed during vault-wide reads, and refuses metadata updates on oversized blocks.
 - Canvas link nodes now reject dangerous URL schemes after URL normalization, catching control-character-obfuscated `javascript:`, `data:`, and `vbscript:` inputs.
 - HTTP transport now refuses non-loopback binds unless bearer auth is configured, preventing accidental unauthenticated LAN exposure.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The server exposes five starter prompts that clients (Claude Desktop, Cursor) su
 - **Folder-scoped permissions**: `OBSIDIAN_READ_PATHS` / `OBSIDIAN_WRITE_PATHS` allowlists gate every tool at the path-resolution choke point
 - **Persistent mtime cache** at `<vault>/.obsidian/cache/mcp-pro-index-cache.json` survives restarts; subsequent vault scans serve from cache after one stat-pass
 - **Progress notifications** (`notifications/progress`) on `rename_tag`, `find_unused_attachments`, and `index_vault` when the client subscribes via `_meta.progressToken`
-- **Elicitation** prompts the user to retype the note path on `delete_note(permanent: true)` when the client supports it
+- **Elicitation** prompts the user for typed confirmation on `delete_note(permanent: true)`, `move_note` reference rewrites, and `rename_tag` bulk writes when the client supports it
 
 ---
 
@@ -346,6 +346,7 @@ The server also declares the MCP [`logging` capability](https://modelcontextprot
 - **HTTP transport** — binds to `127.0.0.1` by default with DNS rebinding protection (host-header allowlist). Optional `--token=<secret>` requires `Authorization: Bearer <secret>` on every `/mcp` request; compared in constant time.
 - **Error sanitization** — filesystem error messages are stripped of absolute host paths before being returned to MCP clients. Uncaught HTTP errors respond with a generic `Internal server error` body; full detail stays in the server log.
 - **YAML-only frontmatter** — Obsidian properties are parsed only from `---` YAML delimiter lines; non-YAML gray-matter language blocks stay as body text, and oversized frontmatter is skipped on reads and refused for metadata updates.
+- **Bulk-write confirmations** — clients that support MCP elicitation are asked to re-type the destination path or new tag before `move_note` rewrites references or `rename_tag` writes across the vault. Dry runs and clients without elicitation keep their existing behavior.
 - **Atomic writes** — every note write (`create_note`, `append`, `prepend`, `update_frontmatter`, canvas mutations) stages content to a sibling temp file then renames onto the target, so a crash or kill mid-write never leaves a truncated file. Combined with per-path locks for the full read-modify-write cycle, concurrent callers can't lose each other's updates. The `install` subcommand uses the same pattern and keeps a backup of the previous config.
 - **Rate limiting + CORS allowlist** — optional `--rate-limit` caps per-IP request volume; `--allow-origin` restricts browser-facing CORS. `/health` and `/version` stay reachable under load for monitoring.
 - **Request timeout** — HTTP POST requests are capped at 2 minutes of wall-clock time. Long-lived SSE GET streams are exempt so idle clients aren't reaped.
@@ -679,7 +680,7 @@ npm run lint:fix   # auto-fix
 - **Quick wins.** `get_recent_notes`, `get_vault_stats`, `resolve_alias`.
 - **MCP prompts.** `daily-review`, `weekly-rollup`, `find-stale-notes`, `extract-action-items`, `build-moc`.
 - **Progress notifications** on `rename_tag`, `find_unused_attachments`, `index_vault`.
-- **Elicitation** on `delete_note(permanent: true)` for clients that support it.
+- **Elicitation** on `delete_note(permanent: true)`, `move_note` reference rewrites, and `rename_tag` bulk writes for clients that support it.
 - **eslint** wired up with typescript-eslint flat config; `npm run lint` and `lint:fix`.
 
 **v1.7.0** — `delete_note` reference handling:

--- a/src/__tests__/handlers/harness.ts
+++ b/src/__tests__/handlers/harness.ts
@@ -19,6 +19,12 @@ import path from "path";
 import os from "os";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  ElicitRequestSchema,
+  type ClientCapabilities,
+  type ElicitRequest,
+  type ElicitResult,
+} from "@modelcontextprotocol/sdk/types.js";
 import { buildMcpServer } from "../../index.js";
 
 export interface TestEnv {
@@ -33,6 +39,10 @@ export interface CreateTestEnvOptions {
   skipFixtures?: boolean;
   /** Additional fixture files to create (relative path → content). */
   extraFiles?: Record<string, string>;
+  /** Optional client capabilities for handler tests that need MCP features. */
+  clientCapabilities?: ClientCapabilities;
+  /** Optional handler for server elicitation requests. */
+  onElicit?: (request: ElicitRequest) => ElicitResult | Promise<ElicitResult>;
 }
 
 export async function createTestEnv(options: CreateTestEnvOptions = {}): Promise<TestEnv> {
@@ -52,7 +62,15 @@ export async function createTestEnv(options: CreateTestEnvOptions = {}): Promise
   }
 
   const server = buildMcpServer(vaultDir);
-  const client = new Client({ name: "handler-test", version: "0.0.0" });
+  const client = new Client(
+    { name: "handler-test", version: "0.0.0" },
+    options.clientCapabilities ? { capabilities: options.clientCapabilities } : undefined,
+  );
+  if (options.onElicit) {
+    client.setRequestHandler(ElicitRequestSchema, async (request) =>
+      options.onElicit!(request),
+    );
+  }
   const [clientT, serverT] = InMemoryTransport.createLinkedPair();
 
   await Promise.all([server.connect(serverT), client.connect(clientT)]);

--- a/src/__tests__/handlers/tags.test.ts
+++ b/src/__tests__/handlers/tags.test.ts
@@ -206,6 +206,56 @@ describe("tag handlers — rename_tag", () => {
     expect(textContent(search)).toContain("note-a.md");
   });
 
+  it("aborts rename_tag when elicitation confirms the wrong tag", async () => {
+    await env.cleanup();
+    env = await createTestEnv({
+      clientCapabilities: { elicitation: {} },
+      onElicit: () => ({
+        action: "accept",
+        content: { confirmTag: "wrong" },
+      }),
+    });
+
+    const result = await env.client.callTool({
+      name: "rename_tag",
+      arguments: { oldName: "draft", newName: "wip" },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toContain("Confirmation tag did not match #wip");
+    const search = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "draft" },
+    });
+    expect(textContent(search)).toContain("note-a.md");
+  });
+
+  it("renames after elicitation confirms the new tag", async () => {
+    await env.cleanup();
+    env = await createTestEnv({
+      clientCapabilities: { elicitation: {} },
+      onElicit: (request) => {
+        expect(request.params.message).toContain("across the vault");
+        return {
+          action: "accept",
+          content: { confirmTag: "wip" },
+        };
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "rename_tag",
+      arguments: { oldName: "draft", newName: "wip" },
+    });
+
+    expect(isError(result)).toBe(false);
+    const search = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "wip" },
+    });
+    expect(textContent(search)).toContain("note-a.md");
+  });
+
   it("rejects new tag names the parser cannot round-trip", async () => {
     const result = await env.client.callTool({
       name: "rename_tag",

--- a/src/__tests__/handlers/write.test.ts
+++ b/src/__tests__/handlers/write.test.ts
@@ -314,6 +314,47 @@ describe("write handlers — move_note", () => {
     await expect(fs.access(path.join(env.vaultDir, "note-c.md"))).rejects.toThrow();
   });
 
+  it("cancels a link-rewriting move when elicitation is cancelled", async () => {
+    await env.cleanup();
+    env = await createTestEnv({
+      clientCapabilities: { elicitation: {} },
+      onElicit: () => ({ action: "cancel" }),
+    });
+
+    const result = await env.client.callTool({
+      name: "move_note",
+      arguments: { oldPath: "note-c.md", newPath: "archive/note-c.md" },
+    });
+
+    expect(isError(result)).toBe(false);
+    expect(textContent(result)).toContain('Move of "note-c.md" cancelled.');
+    await expect(fs.access(path.join(env.vaultDir, "note-c.md"))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(env.vaultDir, "archive/note-c.md"))).rejects.toThrow();
+  });
+
+  it("moves after elicitation confirms the destination path", async () => {
+    await env.cleanup();
+    env = await createTestEnv({
+      clientCapabilities: { elicitation: {} },
+      onElicit: (request) => {
+        expect(request.params.message).toContain("update references across the vault");
+        return {
+          action: "accept",
+          content: { confirmPath: "archive/note-c.md" },
+        };
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "move_note",
+      arguments: { oldPath: "note-c.md", newPath: "archive/note-c.md" },
+    });
+
+    expect(isError(result)).toBe(false);
+    await expect(fs.access(path.join(env.vaultDir, "archive/note-c.md"))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(env.vaultDir, "note-c.md"))).rejects.toThrow();
+  });
+
   it("refuses to overwrite an existing destination", async () => {
     const result = await env.client.callTool({
       name: "move_note",

--- a/src/lib/confirmation.ts
+++ b/src/lib/confirmation.ts
@@ -1,0 +1,57 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { log } from "./logger.js";
+
+export type TextConfirmationResult =
+  | { status: "confirmed" }
+  | { status: "skipped" }
+  | { status: "cancelled" }
+  | { status: "mismatch"; value: unknown };
+
+interface TextConfirmationOptions {
+  tool: string;
+  message: string;
+  fieldName: string;
+  fieldDescription: string;
+  expectedValue: string;
+}
+
+export async function elicitTextConfirmation(
+  server: McpServer,
+  options: TextConfirmationOptions,
+): Promise<TextConfirmationResult> {
+  const caps = server.server.getClientCapabilities();
+  if (caps?.elicitation === undefined) return { status: "skipped" };
+
+  try {
+    const elicit = await server.server.elicitInput({
+      message: options.message,
+      requestedSchema: {
+        type: "object",
+        properties: {
+          [options.fieldName]: {
+            type: "string",
+            description: options.fieldDescription,
+          },
+        },
+        required: [options.fieldName],
+      },
+    });
+
+    if (elicit.action !== "accept") return { status: "cancelled" };
+
+    const confirmed = elicit.content?.[options.fieldName];
+    if (confirmed === undefined || confirmed === null || confirmed === "") {
+      return { status: "cancelled" };
+    }
+    if (
+      typeof confirmed !== "string" ||
+      confirmed.trim() !== options.expectedValue
+    ) {
+      return { status: "mismatch", value: confirmed };
+    }
+    return { status: "confirmed" };
+  } catch (err) {
+    log.warn(`${options.tool}: elicitation skipped`, { err: err as Error });
+    return { status: "skipped" };
+  }
+}

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -8,6 +8,7 @@ import { makeProgressReporter } from "../lib/progress.js";
 import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { formatFailedPath } from "../lib/tool-output.js";
 import { mapConcurrent } from "../lib/concurrency.js";
+import { elicitTextConfirmation } from "../lib/confirmation.js";
 import { log } from "../lib/logger.js";
 
 import type { TagInfo } from "../types.js";
@@ -300,6 +301,32 @@ export function registerTagTools(server: McpServer, vaultPath: string): void {
     async ({ oldName, newName, hierarchical, dryRun }, extra) => {
       try {
         if (oldName === newName) return errorResult("oldName and newName must differ");
+        if (!dryRun) {
+          const confirmation = await elicitTextConfirmation(server, {
+            tool: "rename_tag",
+            message:
+              `Rename #${displayTagValue(oldName)} to #${displayTagValue(newName)} across the vault? ` +
+              "This can rewrite many notes. Type the new tag name to confirm.",
+            fieldName: "confirmTag",
+            fieldDescription: "Re-type the new tag name to confirm vault-wide tag rewriting.",
+            expectedValue: newName,
+          });
+          if (confirmation.status === "cancelled") {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Rename of #${displayTagValue(oldName)} to #${displayTagValue(newName)} cancelled.`,
+                },
+              ],
+            };
+          }
+          if (confirmation.status === "mismatch") {
+            return errorResult(
+              `Confirmation tag did not match #${displayTagValue(newName)}; rename aborted.`,
+            );
+          }
+        }
         const notes = await listNotes(vaultPath);
         const opts = { oldName, newName, hierarchical };
         const reportProgress = makeProgressReporter(extra);

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -14,6 +14,7 @@ import { getDailyNoteConfig } from "../config.js";
 import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { formatFailedPath } from "../lib/tool-output.js";
 import { formatMomentDate, parseLocalDateOnly } from "../lib/dates.js";
+import { elicitTextConfirmation } from "../lib/confirmation.js";
 import { log } from "../lib/logger.js";
 
 function textResult(text: string) {
@@ -371,6 +372,25 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
       try {
         const resolvedOld = ensureMdExtension(oldPath);
         const resolvedNew = ensureMdExtension(newPath);
+        if (updateLinks !== false) {
+          const confirmation = await elicitTextConfirmation(server, {
+            tool: "move_note",
+            message:
+              `Move "${displayWriteValue(resolvedOld)}" to "${displayWriteValue(resolvedNew)}" and update references across the vault? ` +
+              "This can rewrite many notes. Type the destination path to confirm.",
+            fieldName: "confirmPath",
+            fieldDescription: "Re-type the destination path to confirm vault-wide reference rewriting.",
+            expectedValue: resolvedNew,
+          });
+          if (confirmation.status === "cancelled") {
+            return textResult(`Move of "${displayWriteValue(resolvedOld)}" cancelled.`);
+          }
+          if (confirmation.status === "mismatch") {
+            return errorResult(
+              `Confirmation path did not match "${displayWriteValue(resolvedNew)}"; move aborted.`,
+            );
+          }
+        }
         const result = await moveNote(vaultPath, resolvedOld, resolvedNew, { updateLinks });
         const lines: string[] = [
           `Moved note from '${displayWriteValue(resolvedOld)}' to '${displayWriteValue(resolvedNew)}'.`,


### PR DESCRIPTION
Bulk rewrite tools now ask elicitation-capable clients for a typed checkpoint before rewriting across the vault. move_note asks for the destination path before reference rewrites, and ename_tag asks for the new tag before non-dry-run writes; clients without elicitation and dry runs keep current behavior.

Risk: low. The only new interaction is for clients that advertise elicitation support, and cancel/mismatch exits before writes. Score: 6 = severity 3 x reach 4 / effort 2. MCP elicitation docs treat an empty elicitation capability as form support: https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation

Tested: 
pm run verify

Greptile: skipped; trial review quota is exhausted.