### PR TITLE
fix require read access for move sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `move_note` now requires read access to the source note as well as write access to the source and destination, preventing write-only folders from being used to disclose notes by moving them into readable paths.
 - `move_note` reference rewrites and `rename_tag` bulk writes now ask elicitation-capable clients for a typed confirmation before rewriting across the vault, while keeping existing behavior for clients without elicitation and for dry runs.
 - Frontmatter parsing now accepts only Obsidian-style YAML delimiter lines, leaves oversized YAML blocks unparsed during vault-wide reads, and refuses metadata updates on oversized blocks.
 - Canvas link nodes now reject dangerous URL schemes after URL normalization, catching control-character-obfuscated `javascript:`, `data:`, and `vbscript:` inputs.

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Restrict the tools' read/write surface to specific folders without exposing the 
 | `OBSIDIAN_READ_PATHS` | Comma- or colon-separated list of folders that read tools may access. Unset means unrestricted. Use `.` to mean the vault root. |
 | `OBSIDIAN_WRITE_PATHS` | Same shape, but for mutations (create / append / update / delete / move / surgical edits). |
 
-Read and write are independent, so an audit account can be read-only on most of the vault but write-only to a `Drafts/` folder. The startup log line and `--help` advertise the active scope. The allowlist is enforced at a single path-resolution choke point so every tool inherits it.
+Read and write are independent, so an audit account can be read-only on most of the vault but write-only to a `Drafts/` folder. Moving a note requires read access to the source and write access to the destination, because the move carries the source content into its new folder. The startup log line and `--help` advertise the active scope. The allowlist is enforced at a single path-resolution choke point so every tool inherits it.
 
 ### Persistent Caches
 

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -18,6 +18,7 @@ import {
   getNoteStats,
   getVaultRootRealPath,
 } from "../lib/vault.js";
+import { setPermissions } from "../lib/permissions.js";
 
 let vaultDir: string;
 const itWin32 = process.platform === "win32" ? it : it.skip;
@@ -29,6 +30,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   vi.restoreAllMocks();
+  setPermissions({ readPaths: null, writePaths: null });
   await fs.rm(vaultDir, { recursive: true, force: true });
 });
 
@@ -375,6 +377,20 @@ describe("moveNote", () => {
     await expect(moveNote(vaultDir, "a.md", "b.md")).rejects.toThrow(
       "Destination already exists: b.md",
     );
+  });
+
+  it("requires read access to the source note before moving it", async () => {
+    await fs.mkdir(path.join(vaultDir, "private"), { recursive: true });
+    await fs.mkdir(path.join(vaultDir, "public"), { recursive: true });
+    await fs.writeFile(path.join(vaultDir, "private", "secret.md"), "secret", "utf-8");
+    setPermissions({ readPaths: ["public"], writePaths: ["private", "public"] });
+
+    await expect(
+      moveNote(vaultDir, "private/secret.md", "public/secret.md", { updateLinks: false }),
+    ).rejects.toThrow(/OBSIDIAN_READ_PATHS/);
+
+    await expect(fs.access(path.join(vaultDir, "private", "secret.md"))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(vaultDir, "public", "secret.md"))).rejects.toThrow();
   });
 
   itWin32("retries transient Windows rename failures while moving notes", async () => {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -809,6 +809,9 @@ export async function moveNote(
   options: MoveNoteOptions = {},
 ): Promise<MoveNoteResult> {
   const updateLinks = options.updateLinks !== false;
+  // Moving preserves the source bytes at a new path, so the source has to pass
+  // both write permission for the rename and read permission for disclosure.
+  await resolveVaultPathSafe(vaultPath, oldPath, "read");
   const fullOldPath = await resolveVaultPathSafe(vaultPath, oldPath, "write");
   const fullNewPath = await resolveVaultPathSafe(vaultPath, newPath, "write");
   const doRename = async (): Promise<void> => {


### PR DESCRIPTION
move_note now checks source read access before renaming, so split read/write deployments cannot move write-only notes into readable paths. Risk is low: unrestricted configs and ordinary readable-source moves keep working.\n\nScore: 4 severity x 4 reach / 1 effort = 16.\n\nTested: npm run test -- src/__tests__/vault.test.ts src/__tests__/link-rewriter.test.ts src/__tests__/handlers/write.test.ts; npm run verify.