### PR TITLE
fix require read access for surgical edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Surgical note edit tools now require read access to the target before inspecting section, block, or replacement matches, preventing write-only notes from leaking structure or match counts.
 - `move_note` now requires read access to the source note as well as write access to the source and destination, preventing write-only folders from being used to disclose notes by moving them into readable paths.
 - `move_note` reference rewrites and `rename_tag` bulk writes now ask elicitation-capable clients for a typed confirmation before rewriting across the vault, while keeping existing behavior for clients without elicitation and for dry runs.
 - Frontmatter parsing now accepts only Obsidian-style YAML delimiter lines, leaves oversized YAML blocks unparsed during vault-wide reads, and refuses metadata updates on oversized blocks.

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Restrict the tools' read/write surface to specific folders without exposing the 
 | `OBSIDIAN_READ_PATHS` | Comma- or colon-separated list of folders that read tools may access. Unset means unrestricted. Use `.` to mean the vault root. |
 | `OBSIDIAN_WRITE_PATHS` | Same shape, but for mutations (create / append / update / delete / move / surgical edits). |
 
-Read and write are independent, so an audit account can be read-only on most of the vault but write-only to a `Drafts/` folder. Moving a note requires read access to the source and write access to the destination, because the move carries the source content into its new folder. The startup log line and `--help` advertise the active scope. The allowlist is enforced at a single path-resolution choke point so every tool inherits it.
+Read and write are independent, so an audit account can be read-only on most of the vault but write-only to a `Drafts/` folder. Moving a note requires read access to the source and write access to the destination, because the move carries the source content into its new folder. Surgical edits (`replace_in_note`, `update_section`, `insert_at_section`, and `edit_block`) require read access to the target plus write access because they inspect existing content before writing. The startup log line and `--help` advertise the active scope. The allowlist is enforced at a single path-resolution choke point so every tool inherits it.
 
 ### Persistent Caches
 

--- a/src/__tests__/regression-tools-sections.test.ts
+++ b/src/__tests__/regression-tools-sections.test.ts
@@ -7,6 +7,7 @@ import {
   isError,
   type TestEnv,
 } from "./handlers/harness.js";
+import { setPermissions } from "../lib/permissions.js";
 
 /**
  * Regression tests for src/tools/sections.ts.
@@ -23,12 +24,23 @@ import {
 let env: TestEnv;
 
 beforeEach(async () => {
+  setPermissions({ readPaths: null, writePaths: null });
   env = await createTestEnv();
 });
 
 afterEach(async () => {
+  setPermissions({ readPaths: null, writePaths: null });
   await env.cleanup();
 });
+
+async function writePrivateNote(content: string): Promise<string> {
+  const dir = path.join(env.vaultDir, "private");
+  await fs.mkdir(dir, { recursive: true });
+  const fullPath = path.join(dir, "secret.md");
+  await fs.writeFile(fullPath, content, "utf-8");
+  setPermissions({ readPaths: ["public"], writePaths: ["private"] });
+  return fullPath;
+}
 
 describe("regression: replace_in_note ReDoS guards (C3)", () => {
   it("returns an error in under 500ms for a 1MB note with `(a+)+$`", async () => {
@@ -232,6 +244,90 @@ describe("regression: insert_at_section UTF-8 byte count (H11)", () => {
     // Should mention 4 bytes, not 2 (the code-unit count).
     expect(msg).toContain("4 bytes");
     expect(msg).not.toContain("2 bytes");
+  });
+});
+
+describe("regression: surgical edits require read access to inspect note content", () => {
+  it("blocks replace_in_note before it can report match counts for write-only notes", async () => {
+    const original = "# Secret\n\nneedle\n";
+    const fullPath = await writePrivateNote(original);
+
+    const result = await env.client.callTool({
+      name: "replace_in_note",
+      arguments: {
+        path: "private/secret.md",
+        find: "needle",
+        replace: "redacted",
+        expectedCount: 99,
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    const msg = textContent(result);
+    expect(msg).toMatch(/OBSIDIAN_READ_PATHS/);
+    expect(msg).not.toMatch(/Match-count check failed|found 1|Replaced|No matches/i);
+    await expect(fs.readFile(fullPath, "utf-8")).resolves.toBe(original);
+  });
+
+  it("blocks update_section before it can reveal or modify a write-only section", async () => {
+    const original = "# Secret\n\nold body\n";
+    const fullPath = await writePrivateNote(original);
+
+    const result = await env.client.callTool({
+      name: "update_section",
+      arguments: {
+        path: "private/secret.md",
+        section: "Secret",
+        newBody: "new body",
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    const msg = textContent(result);
+    expect(msg).toMatch(/OBSIDIAN_READ_PATHS/);
+    expect(msg).not.toMatch(/Section not found|Updated section/i);
+    await expect(fs.readFile(fullPath, "utf-8")).resolves.toBe(original);
+  });
+
+  it("blocks insert_at_section before it can reveal or modify a write-only section", async () => {
+    const original = "# Secret\n\nold body\n";
+    const fullPath = await writePrivateNote(original);
+
+    const result = await env.client.callTool({
+      name: "insert_at_section",
+      arguments: {
+        path: "private/secret.md",
+        section: "Secret",
+        content: "inserted",
+        position: "append",
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    const msg = textContent(result);
+    expect(msg).toMatch(/OBSIDIAN_READ_PATHS/);
+    expect(msg).not.toMatch(/Section not found|Inserted/i);
+    await expect(fs.readFile(fullPath, "utf-8")).resolves.toBe(original);
+  });
+
+  it("blocks edit_block before it can reveal or modify a write-only block", async () => {
+    const original = "# Secret\n\nHidden paragraph. ^private-block\n";
+    const fullPath = await writePrivateNote(original);
+
+    const result = await env.client.callTool({
+      name: "edit_block",
+      arguments: {
+        path: "private/secret.md",
+        block: "private-block",
+        newContent: "changed",
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    const msg = textContent(result);
+    expect(msg).toMatch(/OBSIDIAN_READ_PATHS/);
+    expect(msg).not.toMatch(/Block not found|Updated block/i);
+    await expect(fs.readFile(fullPath, "utf-8")).resolves.toBe(original);
   });
 });
 

--- a/src/tools/sections.ts
+++ b/src/tools/sections.ts
@@ -35,6 +35,10 @@ function errorResult(text: string) {
 /** Escape control characters before embedding values in section-tool display text. */
 const displaySectionValue = escapeControlChars;
 
+async function assertReadableEditTarget(vaultPath: string, notePath: string): Promise<void> {
+  await resolveVaultPathSafe(vaultPath, notePath, "read");
+}
+
 function isAsciiDigit(ch: string): boolean {
   return ch >= "0" && ch <= "9";
 }
@@ -275,6 +279,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
 
         let resolvedHeading = "";
         let bodyBytes = 0;
+        await assertReadableEditTarget(vaultPath, notePath);
         await updateNote(vaultPath, notePath, (existing) => {
           const found = findSection(existing, headingPath);
           if (!found) {
@@ -327,6 +332,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
         if (headingPath.length === 0) return errorResult("section must not be empty");
 
         let resolvedHeading = "";
+        await assertReadableEditTarget(vaultPath, notePath);
         await updateNote(vaultPath, notePath, (existing) => {
           const found = findSection(existing, headingPath);
           if (!found) {
@@ -464,6 +470,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
         }
 
         let count = 0;
+        await assertReadableEditTarget(vaultPath, notePath);
         await updateNote(vaultPath, notePath, (existing) => {
           // Cap the input size we apply the regex to — refusing the work is
           // far better than holding the per-file write lock while the engine
@@ -531,6 +538,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
     },
     async ({ path: notePath, block, newContent }) => {
       try {
+        await assertReadableEditTarget(vaultPath, notePath);
         await updateNote(vaultPath, notePath, (existing) => {
           const found = findBlockById(existing, block);
           if (!found) throw new Error(`Block not found: "^${block}"`);


### PR DESCRIPTION
Surgical note edit tools now check read access before inspecting existing content, so write-only folders cannot leak match counts, headings, or block IDs through edit responses. Risk is low: unrestricted configs and readable targets keep existing behavior.

Score: 3 severity x 4 reach / 1 effort = 12.

Tested: npm run test -- src/__tests__/regression-tools-sections.test.ts; npm run test -- src/__tests__/regression-tools-sections.test.ts src/__tests__/handlers/write.test.ts; npm run verify.