### PR TITLE
fix reject windows alternate data stream paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Windows vault paths containing alternate data stream syntax are now rejected at the shared resolver, preventing tools such as `get_attachment` from addressing hidden streams through path suffixes.
 - Surgical note edit tools now require read access to the target before inspecting section, block, or replacement matches, preventing write-only notes from leaking structure or match counts.
 - `move_note` now requires read access to the source note as well as write access to the source and destination, preventing write-only folders from being used to disclose notes by moving them into readable paths.
 - `move_note` reference rewrites and `rename_tag` bulk writes now ask elicitation-capable clients for a typed confirmation before rewriting across the vault, while keeping existing behavior for clients without elicitation and for dry runs.

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ The server also declares the MCP [`logging` capability](https://modelcontextprot
 
 ## Security
 
-- **Vault boundary** — every tool and resource routes through a single path resolver that rejects `..` traversal, null-byte injection, and symlinks pointing outside the vault (ancestor-realpath check).
+- **Vault boundary** — every tool and resource routes through a single path resolver that rejects `..` traversal, null-byte injection, and symlinks pointing outside the vault (ancestor-realpath check). On Windows it also rejects reserved device names and alternate data stream syntax.
 - **Excluded directories** — `.obsidian`, `.git`, and `.trash` are pruned at traversal time and at resolution time, so nested occurrences never leak back to clients.
 - **HTTP transport** — binds to `127.0.0.1` by default with DNS rebinding protection (host-header allowlist). Optional `--token=<secret>` requires `Authorization: Bearer <secret>` on every `/mcp` request; compared in constant time.
 - **Error sanitization** — filesystem error messages are stripped of absolute host paths before being returned to MCP clients. Uncaught HTTP errors respond with a generic `Internal server error` body; full detail stays in the server log.

--- a/src/__tests__/handlers/attachments.test.ts
+++ b/src/__tests__/handlers/attachments.test.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
 
 let env: TestEnv;
+const itWin32 = process.platform === "win32" ? it : it.skip;
 
 beforeEach(async () => {
   env = await createTestEnv({
@@ -206,6 +207,15 @@ describe("attachments handlers — get_attachment", () => {
     const text = textContent(result);
     expect(text).toContain('"tools/bad\\tthing.exe"');
     expect(text).not.toContain("tools/bad\tthing.exe");
+  });
+
+  itWin32("rejects Windows alternate data stream attachment paths", async () => {
+    const result = await env.client.callTool({
+      name: "get_attachment",
+      arguments: { path: "assets/used-image.png:hidden.txt" },
+    });
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/alternate data stream/i);
   });
 
   it("enforces the maxBytes cap", async () => {

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -66,6 +66,15 @@ describe("resolveVaultPath", () => {
     );
   });
 
+  itWin32("should block alternate data stream syntax", () => {
+    expect(() => resolveVaultPath(vaultDir, "note.md:hidden.png")).toThrow(
+      /alternate data stream/i,
+    );
+    expect(() => resolveVaultPath(vaultDir, "folder/note.md:hidden.txt")).toThrow(
+      /alternate data stream/i,
+    );
+  });
+
   it("should block sibling directory prefix attack", () => {
     // If vault is /tmp/vault, a path resolving to /tmp/vault-evil should fail
     const siblingDir = vaultDir + "-evil";

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -46,6 +46,17 @@ function lockKey(fullPath: string): string {
   return CASE_INSENSITIVE_FS ? fullPath.toLowerCase() : fullPath;
 }
 
+function rejectWindowsAlternateDataStreams(relativePath: string): void {
+  if (!IS_WIN32) return;
+  const badSegment = relativePath
+    .replace(/\\/g, "/")
+    .split("/")
+    .find((seg) => seg.includes(":"));
+  if (badSegment) {
+    throw new Error(`Invalid path: "${badSegment}" uses Windows alternate data stream syntax`);
+  }
+}
+
 // Synthetic lock key used to serialize vault-wide bulk-write operations
 // (move_note + delete_note with `removeReferences: true`, plus rename_tag
 // which scans every note and applies `updateNote` calls). Distinct from
@@ -244,6 +255,7 @@ export function resolveVaultPath(
       `Invalid path: must be vault-relative, not absolute (${relativePath})`,
     );
   }
+  rejectWindowsAlternateDataStreams(relativePath);
   assertAllowed(relativePath, access);
   const resolved = path.resolve(vaultPath, relativePath);
   const resolvedVault = path.resolve(vaultPath);
@@ -390,6 +402,7 @@ export async function resolveVaultInternalPathSafe(
       `Invalid path: must be vault-relative, not absolute (${relativePath})`,
     );
   }
+  rejectWindowsAlternateDataStreams(relativePath);
   const resolved = path.resolve(vaultPath, relativePath);
   const resolvedVault = path.resolve(vaultPath);
   if (!resolved.startsWith(resolvedVault + path.sep) && resolved !== resolvedVault) {


### PR DESCRIPTION
Windows path resolution now rejects alternate data stream syntax before permission checks and filesystem use, so attachment and note tools cannot address hidden streams through `name:stream` suffixes. Risk is low: the check is Windows-only, and colon-bearing path segments are not valid ordinary Windows filenames.

Score: 4 severity x 2 reach / 1 effort = 8.

Tested: npm run test -- src/__tests__/vault.test.ts src/__tests__/handlers/attachments.test.ts; npm run test -- src/__tests__/vault.test.ts src/__tests__/handlers/attachments.test.ts src/__tests__/security.test.ts src/__tests__/regression-vault-fn.test.ts; npm run verify.