### PR TITLE
fix check symlink targets against folder permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Folder-scoped permissions now re-check the canonical in-vault target after following symlinks, preventing allowed symlink aliases from reading or writing outside their configured folders.
 - Windows vault paths containing alternate data stream syntax are now rejected at the shared resolver, preventing tools such as `get_attachment` from addressing hidden streams through path suffixes.
 - Surgical note edit tools now require read access to the target before inspecting section, block, or replacement matches, preventing write-only notes from leaking structure or match counts.
 - `move_note` now requires read access to the source note as well as write access to the source and destination, preventing write-only folders from being used to disclose notes by moving them into readable paths.

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Restrict the tools' read/write surface to specific folders without exposing the 
 | `OBSIDIAN_READ_PATHS` | Comma- or colon-separated list of folders that read tools may access. Unset means unrestricted. Use `.` to mean the vault root. |
 | `OBSIDIAN_WRITE_PATHS` | Same shape, but for mutations (create / append / update / delete / move / surgical edits). |
 
-Read and write are independent, so an audit account can be read-only on most of the vault but write-only to a `Drafts/` folder. Moving a note requires read access to the source and write access to the destination, because the move carries the source content into its new folder. Surgical edits (`replace_in_note`, `update_section`, `insert_at_section`, and `edit_block`) require read access to the target plus write access because they inspect existing content before writing. The startup log line and `--help` advertise the active scope. The allowlist is enforced at a single path-resolution choke point so every tool inherits it.
+Read and write are independent, so an audit account can be read-only on most of the vault but write-only to a `Drafts/` folder. Moving a note requires read access to the source and write access to the destination, because the move carries the source content into its new folder. Surgical edits (`replace_in_note`, `update_section`, `insert_at_section`, and `edit_block`) require read access to the target plus write access because they inspect existing content before writing. In-vault symlinks are checked against their real target before the allowlist decision is finalized. The startup log line and `--help` advertise the active scope. The allowlist is enforced at a single path-resolution choke point so every tool inherits it.
 
 ### Persistent Caches
 

--- a/src/__tests__/security.test.ts
+++ b/src/__tests__/security.test.ts
@@ -4,11 +4,13 @@ import path from "path";
 import os from "os";
 import {
   resolveVaultPathSafe,
+  readNote,
   writeNote,
   moveNote,
   deleteNote,
 } from "../lib/vault.js";
 import { sanitizeError } from "../lib/errors.js";
+import { setPermissions } from "../lib/permissions.js";
 
 const SYMLINKS_SUPPORTED = process.platform !== "win32" || process.env.CI_SYMLINKS === "1";
 const CASE_INSENSITIVE_FS = process.platform === "win32" || process.platform === "darwin";
@@ -22,9 +24,14 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  setPermissions({ readPaths: null, writePaths: null });
   await fs.rm(vaultDir, { recursive: true, force: true });
   await fs.rm(outsideDir, { recursive: true, force: true });
 });
+
+async function symlinkDirectory(target: string, link: string): Promise<void> {
+  await fs.symlink(target, link, process.platform === "win32" ? "junction" : "dir");
+}
 
 // ---------------------------------------------------------------------------
 // Symlink escape (regression guard for C1/H1 from the audit)
@@ -61,6 +68,32 @@ describe.skipIf(!SYMLINKS_SUPPORTED)("resolveVaultPathSafe — symlink boundary"
     await expect(deleteNote(vaultDir, "note.md")).rejects.toThrow(
       /symlink/i,
     );
+  });
+});
+
+describe.skipIf(!SYMLINKS_SUPPORTED)("resolveVaultPathSafe — canonical permission boundary", () => {
+  it("rejects reads through an allowed symlink into a read-denied folder", async () => {
+    await fs.mkdir(path.join(vaultDir, "public"), { recursive: true });
+    await fs.mkdir(path.join(vaultDir, "private"), { recursive: true });
+    await fs.writeFile(path.join(vaultDir, "private", "secret.md"), "secret", "utf-8");
+    await symlinkDirectory(path.join(vaultDir, "private"), path.join(vaultDir, "public", "alias"));
+    setPermissions({ readPaths: ["public"], writePaths: null });
+
+    await expect(readNote(vaultDir, "public/alias/secret.md")).rejects.toThrow(
+      /OBSIDIAN_READ_PATHS/,
+    );
+  });
+
+  it("rejects writes through an allowed symlink into a write-denied folder", async () => {
+    await fs.mkdir(path.join(vaultDir, "public"), { recursive: true });
+    await fs.mkdir(path.join(vaultDir, "private"), { recursive: true });
+    await symlinkDirectory(path.join(vaultDir, "private"), path.join(vaultDir, "public", "alias"));
+    setPermissions({ readPaths: null, writePaths: ["public"] });
+
+    await expect(
+      writeNote(vaultDir, "public/alias/created.md", "hidden"),
+    ).rejects.toThrow(/OBSIDIAN_WRITE_PATHS/);
+    await expect(fs.access(path.join(vaultDir, "private", "created.md"))).rejects.toThrow();
   });
 });
 

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -313,7 +313,7 @@ async function assertRealPathWithinVault(
   resolved: string,
   vaultPath: string,
   realVaultRoot?: string,
-): Promise<void> {
+): Promise<{ realVault: string; realPath: string }> {
   const realVault = realVaultRoot ?? await getRealVaultRoot(vaultPath);
   const missing: string[] = [];
   let current = resolved;
@@ -326,7 +326,7 @@ async function assertRealPathWithinVault(
       if (rebuilt !== realVault && !rebuilt.startsWith(realVault + path.sep)) {
         throw new Error("Path traversal via symlink detected");
       }
-      return;
+      return { realVault, realPath: rebuilt };
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       // ENOENT / ENOTDIR: ancestor doesn't exist yet — climb up to find the
@@ -347,6 +347,11 @@ async function assertRealPathWithinVault(
       current = parent;
     }
   }
+}
+
+function vaultRelativeFromRealPath(realVault: string, realPath: string): string {
+  const rel = path.relative(realVault, realPath).replace(/\\/g, "/");
+  return rel === "" ? "." : rel;
 }
 
 function isReadAllowed(relativePath: string): boolean {
@@ -379,7 +384,8 @@ export async function resolveVaultPathSafe(
   options?: { realVaultRoot?: string },
 ): Promise<string> {
   const resolved = resolveVaultPath(vaultPath, relativePath, access);
-  await assertRealPathWithinVault(resolved, vaultPath, options?.realVaultRoot);
+  const canonical = await assertRealPathWithinVault(resolved, vaultPath, options?.realVaultRoot);
+  assertAllowed(vaultRelativeFromRealPath(canonical.realVault, canonical.realPath), access);
   return resolved;
 }
 


### PR DESCRIPTION
﻿Folder allowlists now get a second check after symlinks resolve to their real in-vault target, closing read and write bypasses where an allowed folder symlink points at a denied folder. Risk is moderate-low: the raw-path check remains, and the new check only denies symlinked paths whose canonical target is outside the configured scope.

Score: 4 severity x 3 reach / 1 effort = 12.

Tested: CI_SYMLINKS=1 npm run test -- src/__tests__/security.test.ts -t canonical; CI_SYMLINKS=1 npm run test -- src/__tests__/security.test.ts; CI_SYMLINKS=1 npm run test -- src/__tests__/security.test.ts src/__tests__/vault.test.ts src/__tests__/handlers/read.test.ts src/__tests__/handlers/write.test.ts; npm run verify.
