### PR TITLE
fix oversized cache snapshot loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Folder-scoped permissions now re-check the canonical in-vault target after following symlinks, preventing allowed symlink aliases from reading or writing outside their configured folders.
+- Persistent index and embedding cache loaders now ignore oversized snapshot files before reading or parsing them, preventing corrupted vault-local cache files from forcing unbounded memory use.
 - Windows vault paths containing alternate data stream syntax are now rejected at the shared resolver, preventing tools such as `get_attachment` from addressing hidden streams through path suffixes.
 - Surgical note edit tools now require read access to the target before inspecting section, block, or replacement matches, preventing write-only notes from leaking structure or match counts.
 - `move_note` now requires read access to the source note as well as write access to the source and destination, preventing write-only folders from being used to disclose notes by moving them into readable paths.

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Two caches live under `<vault>/.obsidian/cache/`:
 | `mcp-pro-index-cache.json` | mtime-keyed snapshot of recently read notes. The next process start hydrates from this and stat-passes against the live filesystem; only changed notes are re-read. |
 | `mcp-pro-embeddings.json` | Persisted embeddings for semantic search (only present once `index_vault` has run). Vault-relocation safe via an embedded `vaultRoot` check; switching providers / models invalidates entries automatically. |
 
-Both are vault-local, are excluded from vault scans (`.obsidian/` is pruned), and can be deleted at any time. Persistence can be turned off entirely with `OBSIDIAN_CACHE_DISABLED=1`.
+Both are vault-local, are excluded from vault scans (`.obsidian/` is pruned), and can be deleted at any time. Oversized snapshots are ignored before loading so a corrupted or synced cache file cannot force an unbounded JSON parse. Persistence can be turned off entirely with `OBSIDIAN_CACHE_DISABLED=1`.
 
 ### Semantic Search Provider
 

--- a/src/__tests__/embedding-store.test.ts
+++ b/src/__tests__/embedding-store.test.ts
@@ -16,6 +16,7 @@ import {
   clearStore,
   snapshotForTests,
   invalidateIfIncompatible,
+  setMaxEmbeddingBytesForTests,
 } from "../lib/embedding-store.js";
 
 let vaultDir: string;
@@ -25,6 +26,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  setMaxEmbeddingBytesForTests(null);
   await clearStore(vaultDir, { removeSnapshot: true });
   await fs.rm(vaultDir, { recursive: true, force: true });
 });
@@ -259,6 +261,38 @@ describe("snapshot persistence", () => {
     expect(hits).toHaveLength(1);
     expect(hits[0].notePath).toBe("a.md");
     expect(hits[0].headingPath).toEqual(["A"]);
+  });
+
+  it("ignores snapshots larger than the embedding persistence cap before rehydrating", async () => {
+    setMaxEmbeddingBytesForTests(256);
+    const file = path.join(vaultDir, ".obsidian", "cache", "mcp-pro-embeddings.json");
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        vaultRoot: path.resolve(vaultDir),
+        providerId: "test",
+        model: "m",
+        dimension: 3,
+        noteHashes: { "a.md": "h" },
+        embeddings: [
+          {
+            notePath: "a.md",
+            chunkIndex: 1,
+            headingPath: [],
+            text: "stale".repeat(100),
+            hash: "h",
+            vector: [1, 2, 3],
+          },
+        ],
+      }),
+      "utf-8",
+    );
+
+    await loadStore(vaultDir);
+
+    expect(snapshotForTests(vaultDir).totalChunks).toBe(0);
   });
 
   it("invalidateIfIncompatible clears entries when provider/model differ", async () => {

--- a/src/__tests__/index-cache.test.ts
+++ b/src/__tests__/index-cache.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
-import { readAllCached, clearCache, cacheSize, flushNow } from "../lib/index-cache.js";
+import {
+  readAllCached,
+  clearCache,
+  cacheSize,
+  flushNow,
+  setMaxPersistedBytesForTests,
+} from "../lib/index-cache.js";
 
 let vaultDir: string;
 const itPosix = process.platform === "win32" ? it.skip : it;
@@ -12,6 +18,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  setMaxPersistedBytesForTests(null);
   await clearCache(vaultDir);
   await fs.rm(vaultDir, { recursive: true, force: true });
 });
@@ -134,6 +141,37 @@ describe("persistent cache", () => {
     expect(result.cacheHits).toBe(2);
     expect(result.cacheMisses).toBe(0);
     expect(result.contents.get("a.md")).toBe("alpha");
+  });
+
+  it("ignores snapshots larger than the persisted cache cap before rehydrating", async () => {
+    setMaxPersistedBytesForTests(256);
+    await write("a.md", "fresh");
+    const fullPath = path.join(vaultDir, "a.md");
+    const stat = await fs.stat(fullPath);
+    const snap = path.join(vaultDir, ".obsidian", "cache", "mcp-pro-index-cache.json");
+    await fs.mkdir(path.dirname(snap), { recursive: true });
+    await fs.writeFile(
+      snap,
+      JSON.stringify({
+        version: 1,
+        vaultRoot: path.resolve(vaultDir),
+        entries: {
+          "a.md": {
+            fullPath,
+            content: "stale".repeat(100),
+            mtimeMs: stat.mtimeMs,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    await clearCache(vaultDir);
+    const result = await readAllCached(vaultDir, ["a.md"]);
+
+    expect(result.cacheHits).toBe(0);
+    expect(result.cacheMisses).toBe(1);
+    expect(result.contents.get("a.md")).toBe("fresh");
   });
 
   it("invalidates rehydrated entries when mtime changed since the snapshot", async () => {

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -164,7 +164,18 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
     }
     let raw: string;
     try {
-      raw = await fs.readFile(await storePath(vaultPath), "utf-8");
+      const file = await storePath(vaultPath);
+      const stat = await fs.stat(file);
+      if (stat.size > maxEmbeddingBytes) {
+        log.warn("embedding-store: snapshot exceeds MAX_EMBEDDING_BYTES; ignoring", {
+          bytes: stat.size,
+          max: maxEmbeddingBytes,
+        });
+        state.loaded = true;
+        state.loadingPromise = null;
+        return state;
+      }
+      raw = await fs.readFile(file, "utf-8");
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
         log.warn("embedding-store: failed to read snapshot", { err: err as Error });

--- a/src/lib/index-cache.ts
+++ b/src/lib/index-cache.ts
@@ -38,7 +38,12 @@ const CACHE_FILE_VERSION = 1;
 const CACHE_REL_PATH = ".obsidian/cache/mcp-pro-index-cache.json";
 const CACHE_FILE_MODE = 0o600;
 const FLUSH_DEBOUNCE_MS = 5_000;
-const MAX_PERSISTED_BYTES = 64 * 1024 * 1024; // 64 MB safety cap
+const MAX_PERSISTED_BYTES_DEFAULT = 64 * 1024 * 1024; // 64 MB safety cap
+let maxPersistedBytes = MAX_PERSISTED_BYTES_DEFAULT;
+
+export function setMaxPersistedBytesForTests(bytes: number | null): void {
+  maxPersistedBytes = bytes === null ? MAX_PERSISTED_BYTES_DEFAULT : bytes;
+}
 
 interface CacheEntry {
   /** Absolute path used as the cache key. */
@@ -120,6 +125,16 @@ async function loadFromDisk(vaultPath: string, state: VaultCacheState): Promise<
   }
   let raw: string;
   try {
+    const stat = await fs.stat(file);
+    if (stat.size > maxPersistedBytes) {
+      state.loaded = true;
+      log.warn("index-cache: snapshot exceeds MAX_PERSISTED_BYTES; ignoring", {
+        file,
+        bytes: stat.size,
+        max: maxPersistedBytes,
+      });
+      return;
+    }
     raw = await fs.readFile(file, "utf-8");
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
@@ -250,7 +265,7 @@ async function doFlush(vaultPath: string, state: VaultCacheState): Promise<void>
   );
   for (const [rel, entry] of sorted) {
     total += entry.content.length;
-    if (total > MAX_PERSISTED_BYTES) break;
+    if (total > maxPersistedBytes) break;
     snapshot.entries[rel] = {
       fullPath: entry.fullPath,
       content: entry.content,


### PR DESCRIPTION
Index and embedding cache loaders now stat their vault-local snapshot before reading, and ignore files above the same persistence cap used by writes. This closes a corrupted or synced cache-file path that could force large string allocation and JSON.parse before the cache was validated.

Score: 3 severity x 3 reach / 1 effort = 9.

Tested: npm run test -- src/__tests__/index-cache.test.ts src/__tests__/embedding-store.test.ts; npm run test -- src/__tests__/index-cache.test.ts src/__tests__/regression-cache-flush.test.ts src/__tests__/embedding-store.test.ts src/__tests__/regression-embedding-fixes.test.ts src/__tests__/regression-embedding-fn.test.ts; npm run typecheck; npm run verify.