### PR TITLE
fix: fail closed on unsupported base filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persistent index and embedding cache loaders now ignore oversized snapshot files before reading or parsing them, preventing corrupted vault-local cache files from forcing unbounded memory use.
 - HTTP transport now returns `400` for malformed request URL or Host data before auth and routing, preventing those requests from escaping the normal response path.
 - `get_attachment` now returns HTML, XML, and CSS attachments with `text/plain` resource metadata, preventing active vault-controlled text from being advertised as renderable content.
+- `query_base` now treats unsupported filters, missing requested views, and unevaluable link filters as no-match with warnings, preventing Base queries from broadening result sets beyond the visible filter intent.
 - Windows vault paths containing alternate data stream syntax are now rejected at the shared resolver, preventing tools such as `get_attachment` from addressing hidden streams through path suffixes.
 - Surgical note edit tools now require read access to the target before inspecting section, block, or replacement matches, preventing write-only notes from leaking structure or match counts.
 - `move_note` now requires read access to the source note as well as write access to the source and destination, preventing write-only folders from being used to disclose notes by moving them into readable paths.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Give AI assistants deep, structured access to your Obsidian knowledge base. Read
 ### Bases (Obsidian 1.10+)
 - `list_bases` enumerates `.base` files
 - `read_base` returns the parsed YAML (filters, properties, views)
-- `query_base` runs the filter DSL against the vault and returns matching notes; supports `taggedWith()`, `file.hasTag()`, `file.inFolder()`, comparison operators, and `and`/`or`/`not` combinators
+- `query_base` runs the filter DSL against the vault and returns matching notes; supports `taggedWith()`, `file.hasTag()`, `file.inFolder()`, comparison operators, and `and`/`or`/`not` combinators. Unsupported filters warn and fail closed instead of broadening results.
 
 ### Attachments
 - `list_attachments` enumerates every non-md/canvas/base file with a per-extension count summary
@@ -438,7 +438,7 @@ Tag extraction is similarly case-tolerant: `tags`, `Tags`, `TAGS`, `tag`, and `T
 |------|-------------|----------------|
 | `list_bases` | Enumerate `.base` files in the vault | (none) |
 | `read_base` | Parse a Base file (filters, properties, views) | `path` |
-| `query_base` | Run a Base's filter DSL against the vault | `path`, `view`, `limit`, `includeFrontmatter` |
+| `query_base` | Run a Base's filter DSL against the vault; unsupported filters warn and fail closed | `path`, `view`, `limit`, `includeFrontmatter` |
 
 ### Attachments
 

--- a/src/__tests__/bases.test.ts
+++ b/src/__tests__/bases.test.ts
@@ -66,10 +66,27 @@ describe("evaluateFilter / queryBase", () => {
     expect(result.rows.map((r) => r.path).sort()).toEqual(["a.md", "c.md"]);
   });
 
-  it("warns on unknown filter functions and treats as match-all", () => {
+  it("warns on unknown filter functions and treats as no-match", () => {
     const ctx = { warnings: [] };
-    expect(evaluateFilter(rows[0], "mysteryFn(\"x\")", ctx)).toBe(true);
+    expect(evaluateFilter(rows[0], "mysteryFn(\"x\")", ctx)).toBe(false);
     expect(ctx.warnings.length).toBe(1);
+  });
+
+  it("warns on unknown filter shapes and treats as no-match", () => {
+    const ctx = { warnings: [] };
+    expect(evaluateFilter(rows[0], { custom: ["status"] } as never, ctx)).toBe(false);
+    expect(ctx.warnings.some((w) => w.includes("Unknown filter shape"))).toBe(true);
+  });
+
+  it("fails closed when filter recursion exceeds the cap", () => {
+    let filter: unknown = 'status == "active"';
+    for (let i = 0; i < 70; i += 1) {
+      filter = { and: [filter] };
+    }
+
+    const result = queryBase(rows, { filters: filter as never });
+    expect(result.rows).toHaveLength(0);
+    expect(result.warnings.some((w) => w.includes("recursion exceeded"))).toBe(true);
   });
 
   it("supports numeric > comparison", () => {

--- a/src/__tests__/handlers/bases.test.ts
+++ b/src/__tests__/handlers/bases.test.ts
@@ -69,13 +69,51 @@ describe("base handlers — query_base", () => {
     expect(textContent(result)).toContain("- note.md");
   });
 
-  it("escapes control characters in view labels, warnings, and frontmatter keys", async () => {
+  it("escapes control characters in view labels and frontmatter keys", async () => {
     env = await createTestEnv({
       skipFixtures: true,
       extraFiles: {
         "note.md": [
           "---",
           "\"bad\\tkey\": \"dirty\\nvalue\"",
+          "---",
+          "# Note",
+          "",
+        ].join("\n"),
+        "query.base": [
+          "views:",
+          "  - type: table",
+          "    name: \"dirty\\nview\"",
+          "",
+        ].join("\n"),
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "query_base",
+      arguments: {
+        path: "query.base",
+        view: "dirty\nview",
+        includeFrontmatter: true,
+      },
+    });
+
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain("Base: query.base (view: dirty\\nview)");
+    expect(text).toContain('    bad\\tkey: "dirty\\nvalue"');
+    expect(text).not.toContain("dirty\nview");
+    expect(text).not.toContain("bad\tkey");
+    expect(text).not.toContain("dirty\nvalue");
+  });
+
+  it("fails closed for missing views instead of returning base-level rows", async () => {
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "note.md": [
+          "---",
+          "secret: readable",
           "---",
           "# Note",
           "",
@@ -100,11 +138,45 @@ describe("base handlers — query_base", () => {
 
     expect(isError(result)).toBe(false);
     const text = textContent(result);
-    expect(text).toContain("Base: query.base (view: missing\\nview)");
-    expect(text).toContain('View not found: "missing\\nview";');
-    expect(text).toContain('    bad\\tkey: "dirty\\nvalue"');
+    expect(text).toContain("Matched 0 note(s)");
+    expect(text).toContain('View not found: "missing\\nview"; treating query as no-match.');
+    expect(text).not.toContain("- note.md");
+    expect(text).not.toContain("secret");
     expect(text).not.toContain("missing\nview");
-    expect(text).not.toContain("bad\tkey");
-    expect(text).not.toContain("dirty\nvalue");
+  });
+
+  it("fails closed for unsupported filters instead of returning readable rows", async () => {
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "public.md": [
+          "---",
+          "secret: readable",
+          "---",
+          "# Public",
+          "",
+        ].join("\n"),
+        "query.base": [
+          "filters:",
+          "  - mysteryFn(\"status\")",
+          "",
+        ].join("\n"),
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "query_base",
+      arguments: {
+        path: "query.base",
+        includeFrontmatter: true,
+      },
+    });
+
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain("Matched 0 note(s)");
+    expect(text).toContain("Unknown filter function: mysteryFn");
+    expect(text).not.toContain("- public.md");
+    expect(text).not.toContain("secret");
   });
 });

--- a/src/__tests__/regression-bases-2026.test.ts
+++ b/src/__tests__/regression-bases-2026.test.ts
@@ -109,11 +109,10 @@ describe("O2: extended file.* properties", () => {
     expect(mtimeResult.rows).toHaveLength(1);
   });
 
-  it("filters on unpopulated optional fields stay permissive (warn + true)", () => {
+  it("filters on unpopulated optional fields fail closed with a warning", () => {
     const row = buildRow("a.md", noteWithFrontmatter({}));
     const result = queryBase([row], { filters: ['file.linksTo("Other")'] });
-    // Permissive fallback when row.links is undefined: row passes, warning surfaces.
-    expect(result.rows).toHaveLength(1);
+    expect(result.rows).toHaveLength(0);
     expect(result.warnings.some((w) => w.toLowerCase().includes("links"))).toBe(true);
   });
 });

--- a/src/lib/bases.ts
+++ b/src/lib/bases.ts
@@ -21,8 +21,9 @@ import { parseFrontmatter, extractTags } from "./markdown.js";
  *       - priority > 3
  *       - taggedWith(file, "tag")   # legacy function form (still accepted)
  *
- * Unsupported expressions surface as parse warnings and evaluate to `true`
- * (permissive fallback) so a partial Base still returns plausible rows.
+ * Unsupported expressions surface as parse warnings and evaluate to `false`
+ * so unsupported filters cannot broaden a query beyond the Base's visible
+ * intent.
  */
 
 export interface BaseDocument {
@@ -169,8 +170,7 @@ function flattenFilter(filter: BaseFilter | BaseFilter[] | undefined): BaseFilte
 
 /**
  * Evaluate a Base filter against a single row. Unrecognized clauses log a
- * warning and short-circuit to `true` so the row is included rather than
- * silently dropped.
+ * warning and short-circuit to `false` so unsupported filters fail closed.
  */
 export function evaluateFilter(
   row: BaseRow,
@@ -179,8 +179,8 @@ export function evaluateFilter(
   depth = 0,
 ): boolean {
   if (depth > MAX_FILTER_DEPTH) {
-    pushWarning(ctx.warnings, `Filter recursion exceeded ${MAX_FILTER_DEPTH} levels; clauses past this depth were skipped.`);
-    return true;
+    pushWarning(ctx.warnings, `Filter recursion exceeded ${MAX_FILTER_DEPTH} levels; treating clause as no-match.`);
+    return false;
   }
   if (filter === undefined) return true;
   if (typeof filter === "string") return evaluateExpression(row, filter, ctx);
@@ -198,7 +198,7 @@ export function evaluateFilter(
     return !evaluateFilter(row, inner, ctx, depth + 1);
   }
   pushWarning(ctx.warnings, `Unknown filter shape: ${JSON.stringify(filter)}`);
-  return true;
+  return false;
 }
 
 // ---------- Expression parsing ----------
@@ -413,9 +413,8 @@ function evaluateMethod(
         const target = firstStringArg(args, `file.${method}`, ctx);
         if (target === null) return false;
         if (!row.links) {
-          // Permissive: builder didn't supply links; warn and match-all.
-          pushWarning(ctx.warnings, `file.${method}: row has no links populated; treating as match.`);
-          return true;
+          pushWarning(ctx.warnings, `file.${method}: row has no links populated; treating as no-match.`);
+          return false;
         }
         return matchesLink(row.links, target);
       }
@@ -474,7 +473,7 @@ function evaluateValueMethod(
       return true;
     default:
       pushWarning(ctx.warnings, `Unknown method: ${chainForWarnings}.${method}`);
-      return true;
+      return false;
   }
 }
 
@@ -544,7 +543,7 @@ function evaluateFunction(
     }
     default:
       pushWarning(ctx.warnings, `Unknown filter function: ${name}`);
-      return true;
+      return false;
   }
 }
 
@@ -623,7 +622,8 @@ export function queryBase(
   if (viewName && Array.isArray(base.views)) {
     const view = base.views.find((v) => v.name === viewName || v.type === viewName);
     if (!view) {
-      pushWarning(ctx.warnings, `View not found: "${viewName}"; using base-level filters only.`);
+      pushWarning(ctx.warnings, `View not found: "${viewName}"; treating query as no-match.`);
+      return { rows: [], warnings: ctx.warnings };
     } else {
       viewFilter = flattenFilter(view.filters);
       order = Array.isArray(view.order) ? view.order : undefined;

--- a/src/tools/bases.ts
+++ b/src/tools/bases.ts
@@ -106,7 +106,7 @@ export function registerBaseTools(server: McpServer, vaultPath: string): void {
     {
       title: "Query Base",
       description:
-        "Run a Base file's filters against the vault and return matching note paths. Optionally pick a named view to apply that view's filters and ordering on top of the base-level filters. Supported filter syntax (subset of Obsidian's full DSL): chained methods `file.hasTag(\"tag\")`, `file.hasProperty(\"key\")`, `file.inFolder(\"path\")`, `file.linksTo(\"target\")`, `file.name.contains(\"x\")`/`.startsWith`/`.endsWith`/`.equals`, plus `.isEmpty`/`.isNotEmpty` on any value; legacy function form `taggedWith(file, \"tag\")`; comparisons `key == \"val\"`, `key != x`, `key contains x`, `>=`, `<=`, `>`, `<`; combinators `and:`, `or:`, `not:`. Recognized file properties: file.name, file.basename, file.folder, file.ext, file.path, file.size, file.ctime, file.mtime, file.tags, file.properties, file.links, file.embeds, file.backlinks. Unsupported clauses are reported as warnings and treated as match-all.",
+        "Run a Base file's filters against the vault and return matching note paths. Optionally pick a named view to apply that view's filters and ordering on top of the base-level filters. Supported filter syntax (subset of Obsidian's full DSL): chained methods `file.hasTag(\"tag\")`, `file.hasProperty(\"key\")`, `file.inFolder(\"path\")`, `file.linksTo(\"target\")`, `file.name.contains(\"x\")`/`.startsWith`/`.endsWith`/`.equals`, plus `.isEmpty`/`.isNotEmpty` on any value; legacy function form `taggedWith(file, \"tag\")`; comparisons `key == \"val\"`, `key != x`, `key contains x`, `>=`, `<=`, `>`, `<`; combinators `and:`, `or:`, `not:`. Recognized file properties: file.name, file.basename, file.folder, file.ext, file.path, file.size, file.ctime, file.mtime, file.tags, file.properties, file.links, file.embeds, file.backlinks. Unsupported clauses are reported as warnings and treated as no-match.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,
@@ -161,8 +161,8 @@ export function registerBaseTools(server: McpServer, vaultPath: string): void {
             const row = buildRow(notePath, content, stats.get(notePath));
             // BUG-4: Populate row.links from the note's outgoing wikilinks so
             // file.linksTo() / file.hasLink() filters evaluate correctly.
-            // Without this, row.links is undefined and the evaluator falls
-            // back to a permissive match-all.
+            // Without this, row.links is undefined and link filters fail
+            // closed with a warning.
             const linkInfos = extractWikilinks(content);
             row.links = linkInfos
               .filter((l) => !l.isEmbed)


### PR DESCRIPTION
query_base now fails closed when a Base filter cannot be evaluated, a requested view is missing, or link metadata is unavailable. Obsidian's Bases docs describe filters as conditions that narrow the dataset and view filters as being combined with global filters: https://obsidian.md/help/bases/syntax.

Risk: medium; unsupported Base filters that used to return broad results now return no rows with warnings.

Score: 3 severity x 3 reach / 1 effort = 9.

Tested: npm test -- src/__tests__/bases.test.ts src/__tests__/regression-bases-2026.test.ts src/__tests__/handlers/bases.test.ts; npm run typecheck; npm run verify.