### PR TITLE
fix: reject non-note paths in note helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Note read/edit helpers, `get_note`, and `obsidian://note/...` resources now reject non-`.md` vault files, keeping attachments, Canvas files, and Bases on their dedicated tool paths.
 - Folder-scoped permissions now re-check the canonical in-vault target after following symlinks, preventing allowed symlink aliases from reading or writing outside their configured folders.
 - Persistent index and embedding cache loaders now ignore oversized snapshot files before reading or parsing them, preventing corrupted vault-local cache files from forcing unbounded memory use.
 - HTTP transport now returns `400` for malformed request URL or Host data before auth and routing, preventing those requests from escaping the normal response path.

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ The server also declares the MCP [`logging` capability](https://modelcontextprot
 ## Security
 
 - **Vault boundary** — every tool and resource routes through a single path resolver that rejects `..` traversal, null-byte injection, and symlinks pointing outside the vault (ancestor-realpath check). On Windows it also rejects reserved device names and alternate data stream syntax.
+- **Note/file boundary** — note read and edit surfaces only target `.md` files; attachments, Canvas files, and Bases stay on their dedicated tools with their own caps and parsers.
 - **Excluded directories** — `.obsidian`, `.git`, and `.trash` are pruned at traversal time and at resolution time, so nested occurrences never leak back to clients.
 - **HTTP transport** — binds to `127.0.0.1` by default with DNS rebinding protection (host-header allowlist). Optional `--token=<secret>` requires `Authorization: Bearer <secret>` on every `/mcp` request; compared in constant time. Malformed request URL or Host data is rejected before routing.
 - **Attachment safety** — executable extensions are blocked, SVGs are returned as `text/plain`, and active text formats such as HTML/XML/CSS are served with `text/plain` resource metadata.

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -226,6 +226,34 @@ describe("read handlers — get_note", () => {
     expect(text).not.toMatch(/^\/[a-z]/);
   });
 
+  it("rejects non-markdown vault files", async () => {
+    await fs.writeFile(path.join(env.vaultDir, "asset.txt"), "hidden asset body", "utf-8");
+
+    const result = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "asset.txt" },
+    });
+
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toMatch(/not a markdown note/i);
+    expect(text).not.toContain("hidden asset body");
+  });
+
+  it("rejects non-markdown line fragments", async () => {
+    await fs.writeFile(path.join(env.vaultDir, "asset-lines.txt"), "hidden line body", "utf-8");
+
+    const result = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "asset-lines.txt", lines: "1" },
+    });
+
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toMatch(/not a markdown note/i);
+    expect(text).not.toContain("hidden line body");
+  });
+
   it("rejects a path traversal attempt with isError, not a crash", async () => {
     const result = await env.client.callTool({
       name: "get_note",

--- a/src/__tests__/handlers/resources.test.ts
+++ b/src/__tests__/handlers/resources.test.ts
@@ -51,6 +51,20 @@ describe("MCP resources", () => {
     expect(firstText(result.contents)).toContain("Nested note that references [[note-a]].");
   });
 
+  it("rejects non-markdown files through the note URI template", async () => {
+    await fs.writeFile(path.join(env.vaultDir, "asset.txt"), "hidden resource body", "utf-8");
+
+    let message = "";
+    try {
+      await env.client.readResource({ uri: "obsidian://note/asset.txt" });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(message).toMatch(/not a markdown note/i);
+    expect(message).not.toContain("hidden resource body");
+  });
+
   it("reads the tag index resource as JSON", async () => {
     const result = await env.client.readResource({ uri: "obsidian://tags" });
     const content = result.contents[0];

--- a/src/__tests__/regression-tools-sections.test.ts
+++ b/src/__tests__/regression-tools-sections.test.ts
@@ -370,6 +370,39 @@ describe("regression: surgical edits require read access to inspect note content
   });
 });
 
+describe("regression: surgical edits only target markdown notes", () => {
+  it("rejects non-markdown files before reading or rewriting them", async () => {
+    const assetPath = path.join(env.vaultDir, "asset.txt");
+    const original = "# Secret\n\nneedle\n";
+    await fs.writeFile(assetPath, original, "utf-8");
+
+    const replace = await env.client.callTool({
+      name: "replace_in_note",
+      arguments: {
+        path: "asset.txt",
+        find: "needle",
+        replace: "redacted",
+      },
+    });
+
+    expect(isError(replace)).toBe(true);
+    expect(textContent(replace)).toMatch(/not a markdown note/i);
+
+    const update = await env.client.callTool({
+      name: "update_section",
+      arguments: {
+        path: "asset.txt",
+        section: "Secret",
+        newBody: "changed",
+      },
+    });
+
+    expect(isError(update)).toBe(true);
+    expect(textContent(update)).toMatch(/not a markdown note/i);
+    await expect(fs.readFile(assetPath, "utf-8")).resolves.toBe(original);
+  });
+});
+
 describe("regression: section tool output escaping", () => {
   it("escapes control characters in listed heading text", async () => {
     await fs.writeFile(

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -6,7 +6,9 @@ import {
   resolveVaultPath,
   listNotes,
   readNote,
+  readNoteLineRange,
   writeNote,
+  updateNote,
   appendToNote,
   prependToNote,
   deleteNote,
@@ -182,6 +184,17 @@ describe("readNote", () => {
       "Note not found: nonexistent.md",
     );
   });
+
+  it("should reject non-markdown vault files", async () => {
+    await fs.writeFile(path.join(vaultDir, "secret.txt"), "not note content", "utf-8");
+
+    await expect(readNote(vaultDir, "secret.txt")).rejects.toThrow(
+      "Not a markdown note: secret.txt",
+    );
+    await expect(readNoteLineRange(vaultDir, "secret.txt", 1, 1)).rejects.toThrow(
+      "Not a markdown note: secret.txt",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -221,6 +234,32 @@ describe("writeNote", () => {
       "utf-8",
     );
     expect(content).toBe("new");
+  });
+
+  it("should reject non-markdown write targets", async () => {
+    await fs.writeFile(path.join(vaultDir, "asset.txt"), "original", "utf-8");
+
+    await expect(writeNote(vaultDir, "asset.txt", "new")).rejects.toThrow(
+      "Not a markdown note: asset.txt",
+    );
+    await expect(updateNote(vaultDir, "asset.txt", () => "new")).rejects.toThrow(
+      "Not a markdown note: asset.txt",
+    );
+    await expect(appendToNote(vaultDir, "asset.txt", "new")).rejects.toThrow(
+      "Not a markdown note: asset.txt",
+    );
+    await expect(prependToNote(vaultDir, "asset.txt", "new")).rejects.toThrow(
+      "Not a markdown note: asset.txt",
+    );
+    await expect(deleteNote(vaultDir, "asset.txt")).rejects.toThrow(
+      "Not a markdown note: asset.txt",
+    );
+    await expect(moveNote(vaultDir, "asset.txt", "asset-renamed.txt")).rejects.toThrow(
+      "Not a markdown note: asset.txt",
+    );
+
+    await expect(fs.readFile(path.join(vaultDir, "asset.txt"), "utf-8"))
+      .resolves.toBe("original");
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import * as fs from "fs/promises";
 import { readFileSync, realpathSync } from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
@@ -8,7 +7,7 @@ import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mc
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { Variables } from "@modelcontextprotocol/sdk/shared/uriTemplate.js";
 import { getVaultConfig, getDailyNoteConfig } from "./config.js";
-import { resolveVaultPathSafe, listNotes, readNote } from "./lib/vault.js";
+import { listNotes, readNote } from "./lib/vault.js";
 import { describePermissions } from "./lib/permissions.js";
 import { flushAllCachesAsync, readAllCached } from "./lib/index-cache.js";
 import { extractTags } from "./lib/markdown.js";
@@ -228,8 +227,7 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
       }
 
       try {
-        const fullPath = await resolveVaultPathSafe(vaultPath, notePath);
-        const content = await fs.readFile(fullPath, "utf-8");
+        const content = await readNote(vaultPath, notePath);
         return {
           contents: [
             {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -21,6 +21,12 @@ const SEARCH_SNIPPET_OMISSION = "...";
 const EXCLUDED_DIRS = [".obsidian", ".trash", ".git"];
 const EXCLUDED_SET = new Set(EXCLUDED_DIRS);
 
+function assertMarkdownNotePath(relativePath: string): void {
+  if (!relativePath.toLowerCase().endsWith(".md")) {
+    throw new Error(`Not a markdown note: ${relativePath}`);
+  }
+}
+
 // Legacy DOS device names reserved by the Windows filesystem at any depth.
 // Opening one of these as a file quietly binds to the device (e.g. NUL
 // discards writes) rather than creating a real file, which surprises users
@@ -447,6 +453,7 @@ export async function readNote(
   vaultPath: string,
   relativePath: string,
 ): Promise<string> {
+  assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
   try {
     return await fs.readFile(fullPath, "utf-8");
@@ -472,6 +479,7 @@ export async function readNoteLineRange(
   startLine: number,
   endLine: number,
 ): Promise<NoteLineRangeRead> {
+  assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
   let handle: fs.FileHandle | undefined;
   try {
@@ -538,6 +546,7 @@ export async function writeNote(
   content: string,
   options?: { exclusive?: boolean },
 ): Promise<void> {
+  assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
     await fs.mkdir(path.dirname(fullPath), { recursive: true });
@@ -603,6 +612,7 @@ export async function updateNote(
   relativePath: string,
   transform: (existing: string) => string | Promise<string>,
 ): Promise<void> {
+  assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
     const existing = await fs.readFile(fullPath, "utf-8");
@@ -617,6 +627,7 @@ export async function appendToNote(
   relativePath: string,
   content: string,
 ): Promise<void> {
+  assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
     const existing = await fs.readFile(fullPath, "utf-8");
@@ -661,6 +672,7 @@ export async function prependToNote(
   relativePath: string,
   content: string,
 ): Promise<void> {
+  assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
     const existing = await fs.readFile(fullPath, "utf-8");
@@ -734,6 +746,7 @@ export async function deleteNote(
   relativePath: string,
   options: DeleteNoteOptions = {},
 ): Promise<DeleteNoteResult> {
+  assertMarkdownNotePath(relativePath);
   const permanent = options.permanent === true;
   const removeReferences = permanent && options.removeReferences === true;
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
@@ -827,6 +840,8 @@ export async function moveNote(
   newPath: string,
   options: MoveNoteOptions = {},
 ): Promise<MoveNoteResult> {
+  assertMarkdownNotePath(oldPath);
+  assertMarkdownNotePath(newPath);
   const updateLinks = options.updateLinks !== false;
   // Moving preserves the source bytes at a new path, so the source has to pass
   // both write permission for the rename and read permission for disclosure.


### PR DESCRIPTION
What: note reads, note resources, and note edit helpers now reject non-.md vault paths at the shared vault helper layer. The obsidian://note resource now reads through the same note path as get_note.

Why: note tools should not read or rewrite attachment, Canvas, or Base files; those formats have dedicated tools with separate caps and parsers.

Risk: low. Tool schemas already describe note paths as .md, and write tools still append .md before calling the shared helpers.

Score: 8 x 8 / 2 = 32. Safety boundary with broad reach and small implementation cost.

Tested: npm test -- src/__tests__/vault.test.ts src/__tests__/handlers/read.test.ts src/__tests__/handlers/resources.test.ts src/__tests__/regression-tools-sections.test.ts; npm run typecheck; npm run lint; npm run verify.