### PR TITLE
fix: validate trash parents before delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Recoverable `delete_note` now validates each `.trash` parent directory before creating deeper folders, preventing symlinked trash ancestors from creating directories outside the vault.
 - Note read/edit helpers, `get_note`, and `obsidian://note/...` resources now reject non-`.md` vault files, keeping attachments, Canvas files, and Bases on their dedicated tool paths.
 - Folder-scoped permissions now re-check the canonical in-vault target after following symlinks, preventing allowed symlink aliases from reading or writing outside their configured folders.
 - Persistent index and embedding cache loaders now ignore oversized snapshot files before reading or parsing them, preventing corrupted vault-local cache files from forcing unbounded memory use.

--- a/src/__tests__/security.test.ts
+++ b/src/__tests__/security.test.ts
@@ -69,6 +69,33 @@ describe.skipIf(!SYMLINKS_SUPPORTED)("resolveVaultPathSafe — symlink boundary"
       /symlink/i,
     );
   });
+
+  it("does not create nested parents through a symlinked trash root", async () => {
+    await writeNote(vaultDir, "nested/note.md", "hi");
+    const outsideTrash = path.join(outsideDir, "fake-trash");
+    await fs.mkdir(outsideTrash, { recursive: true });
+    await fs.symlink(outsideTrash, path.join(vaultDir, ".trash"));
+
+    await expect(deleteNote(vaultDir, "nested/note.md")).rejects.toThrow(
+      /symlink/i,
+    );
+    await expect(fs.access(path.join(outsideTrash, "nested"))).rejects.toThrow();
+    await expect(readNote(vaultDir, "nested/note.md")).resolves.toBe("hi");
+  });
+
+  it("does not create deeper parents through a symlinked trash ancestor", async () => {
+    await writeNote(vaultDir, "projects/active/plan.md", "details");
+    const outsideTrash = path.join(outsideDir, "fake-trash");
+    await fs.mkdir(outsideTrash, { recursive: true });
+    await fs.mkdir(path.join(vaultDir, ".trash"), { recursive: true });
+    await symlinkDirectory(outsideTrash, path.join(vaultDir, ".trash", "projects"));
+
+    await expect(deleteNote(vaultDir, "projects/active/plan.md")).rejects.toThrow(
+      /symlink/i,
+    );
+    await expect(fs.access(path.join(outsideTrash, "active"))).rejects.toThrow();
+    await expect(readNote(vaultDir, "projects/active/plan.md")).resolves.toBe("details");
+  });
 });
 
 describe.skipIf(!SYMLINKS_SUPPORTED)("resolveVaultPathSafe — canonical permission boundary", () => {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -741,6 +741,37 @@ async function chooseTrashPath(trashFullPath: string): Promise<string> {
   throw new Error(`Could not allocate unique trash path for ${path.basename(trashFullPath)}`);
 }
 
+async function ensureTrashParentDirectory(
+  vaultPath: string,
+  trashRoot: string,
+  parentDir: string,
+): Promise<void> {
+  const root = path.resolve(trashRoot);
+  const parent = path.resolve(parentDir);
+  if (parent !== root && !parent.startsWith(root + path.sep)) {
+    throw new Error("Invalid trash path parent");
+  }
+
+  const realVault = await getRealVaultRoot(vaultPath);
+  const relative = path.relative(root, parent);
+  const segments = relative === "" ? [] : relative.split(path.sep).filter(Boolean);
+  let current = root;
+
+  for (const segment of ["", ...segments]) {
+    if (segment) current = path.join(current, segment);
+    try {
+      await fs.mkdir(current);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    }
+    await assertRealPathWithinVault(current, vaultPath, realVault);
+    const stat = await fs.stat(current);
+    if (!stat.isDirectory()) {
+      throw new Error(`Trash path parent is not a directory: ${path.basename(current)}`);
+    }
+  }
+}
+
 export async function deleteNote(
   vaultPath: string,
   relativePath: string,
@@ -784,9 +815,9 @@ export async function deleteNote(
         ) {
           throw new Error(`Invalid trash path: ${relativePath}`);
         }
-        await fs.mkdir(path.dirname(trashFullPath), { recursive: true });
-        // Realpath check on the canonical destination: rejects a symlinked
-        // `.trash` (or any intermediate dir) that resolves outside the vault.
+        await ensureTrashParentDirectory(vaultPath, trashRoot, path.dirname(trashFullPath));
+        // Realpath check on the canonical destination: rejects a symlink swap
+        // after parent creation but before the rename.
         await assertRealPathWithinVault(trashFullPath, vaultPath);
         const finalTrashPath = await chooseTrashPath(trashFullPath);
         await renameWithRetry(fullPath, finalTrashPath);


### PR DESCRIPTION
What: recoverable delete now creates `.trash` destination parents one segment at a time and checks each canonical path before descending. The delete still mirrors nested note paths under `.trash` for normal vaults.

Why: a symlinked `.trash` root or nested trash ancestor could previously receive recursive mkdir calls before the later containment check rejected the rename.

Risk: low. This only changes the recoverable delete path and preserves successful trash moves for ordinary directories.

Score: 5 x 3 / 1 = 15. Host filesystem side effect, narrower reach, small patch.

Tested: CI_SYMLINKS=1 npm test -- src/__tests__/security.test.ts src/__tests__/regression-vault-fixes.test.ts src/__tests__/vault.test.ts; npm run typecheck; npm run verify.