### PR TITLE
fix: cap base files before reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `read_base` and `query_base` now reject oversized `.base` files before reading them, preventing the parser cap from allocating large files or broadening queries through an empty parsed Base.
 - Recoverable `delete_note` now validates each `.trash` parent directory before creating deeper folders, preventing symlinked trash ancestors from creating directories outside the vault.
 - Note read/edit helpers, `get_note`, and `obsidian://note/...` resources now reject non-`.md` vault files, keeping attachments, Canvas files, and Bases on their dedicated tool paths.
 - Folder-scoped permissions now re-check the canonical in-vault target after following symlinks, preventing allowed symlink aliases from reading or writing outside their configured folders.

--- a/src/__tests__/handlers/bases.test.ts
+++ b/src/__tests__/handlers/bases.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
+import { MAX_BASE_FILE_BYTES } from "../../lib/bases.js";
 
 let env: TestEnv | undefined;
 
@@ -9,6 +10,23 @@ afterEach(async () => {
 });
 
 describe("base handlers — read_base", () => {
+  it("rejects oversized Base files before parsing", async () => {
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "huge.base": "x".repeat(MAX_BASE_FILE_BYTES + 1),
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "read_base",
+      arguments: { path: "huge.base" },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/base file exceeds size cap/i);
+  });
+
   it("escapes control characters in parsed display fields", async () => {
     env = await createTestEnv({
       skipFixtures: true,
@@ -44,6 +62,33 @@ describe("base handlers — read_base", () => {
 });
 
 describe("base handlers — query_base", () => {
+  it("rejects oversized Base files without returning readable rows", async () => {
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "note.md": [
+          "---",
+          "secret: readable",
+          "---",
+          "# Note",
+          "",
+        ].join("\n"),
+        "huge.base": "x".repeat(MAX_BASE_FILE_BYTES + 1),
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "query_base",
+      arguments: { path: "huge.base", includeFrontmatter: true },
+    });
+
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toMatch(/base file exceeds size cap/i);
+    expect(text).not.toContain("- note.md");
+    expect(text).not.toContain("secret");
+  });
+
   it("populates file.size/ctime/mtime for Base filters", async () => {
     env = await createTestEnv({
       skipFixtures: true,

--- a/src/lib/bases.ts
+++ b/src/lib/bases.ts
@@ -65,7 +65,7 @@ export interface ParsedBase {
  * Reject before handing bytes to js-yaml so we can't be coerced into a
  * large allocation.
  */
-const MAX_BASE_FILE_BYTES = 1_048_576;
+export const MAX_BASE_FILE_BYTES = 1_048_576;
 
 /** Cap on collected warnings so a pathological Base with thousands of
  *  unrecognized clauses can't blow up memory. */

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -5,6 +5,7 @@ import { StringDecoder } from "string_decoder";
 import { mapConcurrent } from "./concurrency.js";
 import { assertAllowed, type AccessKind } from "./permissions.js";
 import { renameWithRetry } from "./fs-ops.js";
+import { MAX_BASE_FILE_BYTES } from "./bases.js";
 import type { SearchResult, SearchMatch, CanvasData } from "../types.js";
 
 // Bounded fan-out for vault-wide scans. Higher values saturate the event loop
@@ -1166,6 +1167,12 @@ export async function readBaseFile(
   relativePath: string,
 ): Promise<string> {
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
+  const stats = await fs.stat(fullPath);
+  if (stats.size > MAX_BASE_FILE_BYTES) {
+    throw new Error(
+      `Base file exceeds size cap (${stats.size} > ${MAX_BASE_FILE_BYTES} bytes)`,
+    );
+  }
   return fs.readFile(fullPath, "utf-8");
 }
 


### PR DESCRIPTION
What: `.base` files are now stat-checked before `read_base` or `query_base` reads them. Oversized Bases return an error instead of being read and parsed as an empty Base.

Why: the existing parser cap ran after `fs.readFile`, and an oversized Base treated as empty could match every readable note.

Risk: low. Normal Bases are small, and oversized generated files now fail closed rather than returning broad rows.

Score: 4 x 3 / 1 = 12. Authenticated DoS and broad-query risk with narrow reach and small patch.

Tested: npm test -- src/__tests__/bases.test.ts src/__tests__/regression-bases-2026.test.ts src/__tests__/handlers/bases.test.ts src/__tests__/regression-fn-cluster.test.ts; npm run typecheck; npm run verify.