### PR TITLE
fix: cap canvas file reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Canvas helpers now reject oversized `.canvas` files before reading, parsing, or updating them, and `read_canvas` keeps large summaries bounded while still reporting total node and edge counts.
 - `read_base` and `query_base` now reject oversized `.base` files before reading them, preventing the parser cap from allocating large files or broadening queries through an empty parsed Base.
 - Recoverable `delete_note` now validates each `.trash` parent directory before creating deeper folders, preventing symlinked trash ancestors from creating directories outside the vault.
 - Note read/edit helpers, `get_note`, and `obsidian://note/...` resources now reject non-`.md` vault files, keeping attachments, Canvas files, and Bases on their dedicated tool paths.

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Tag extraction is similarly case-tolerant: `tags`, `Tags`, `TAGS`, `tag`, and `T
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
 | `list_canvases` | List all `.canvas` files in the vault | (none) |
-| `read_canvas` | Read a `.canvas` file's nodes and edges | `path` |
+| `read_canvas` | Read a bounded `.canvas` node/edge summary | `path` |
 | `add_canvas_node` | Add a node to a canvas | `canvasPath`, `type`, `content`, `x`, `y` |
 | `add_canvas_edge` | Add an edge between two canvas nodes | `canvasPath`, `fromNode`, `toNode` |
 

--- a/docs/devto-article.md
+++ b/docs/devto-article.md
@@ -252,7 +252,7 @@ This gives the AI a way to reason about context: "Show me everything within 2 ho
 | | `find_broken_links` | Wikilinks pointing to non-existent notes |
 | | `get_graph_neighbors` | BFS traversal to configurable depth |
 | **Canvas** | `list_canvases` | List all `.canvas` files |
-| | `read_canvas` | Read canvas with full node/edge data |
+| | `read_canvas` | Read a bounded node/edge summary |
 | | `add_canvas_node` | Add text, file, link, or group nodes |
 | | `add_canvas_edge` | Connect canvas nodes with edges |
 

--- a/src/__tests__/handlers/canvas.test.ts
+++ b/src/__tests__/handlers/canvas.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
+import { MAX_CANVAS_FILE_BYTES } from "../../lib/vault.js";
 
 let env: TestEnv;
 
@@ -129,6 +130,62 @@ describe("canvas handlers — read_canvas", () => {
     expect(textContent(result)).toMatch(/malformed JSON/i);
   });
 
+  it("rejects oversized canvas files before parsing JSON", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, "huge.canvas"),
+      "x".repeat(MAX_CANVAS_FILE_BYTES + 1),
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "read_canvas",
+      arguments: { path: "huge.canvas" },
+    });
+
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toMatch(/Canvas file exceeds size cap/i);
+    expect(text).not.toMatch(/malformed JSON/i);
+  });
+
+  it("keeps crowded canvas summaries bounded while reporting totals", async () => {
+    const nodes = Array.from({ length: 205 }, (_, i) => ({
+      id: `n${i}`,
+      type: "text",
+      x: i,
+      y: i,
+      width: 120,
+      height: 80,
+      text: `Node ${i}`,
+    }));
+    const edges = Array.from({ length: 205 }, (_, i) => ({
+      id: `e${i}`,
+      fromNode: `n${i % nodes.length}`,
+      toNode: `n${(i + 1) % nodes.length}`,
+      label: `edge ${i}`,
+    }));
+    await fs.writeFile(
+      path.join(env.vaultDir, "crowded.canvas"),
+      JSON.stringify({ nodes, edges }),
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "read_canvas",
+      arguments: { path: "crowded.canvas" },
+    });
+
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toMatch(/Nodes: 205 \| Edges: 205/);
+    expect(text).toContain("[n199] type=text");
+    expect(text).toContain("edge 199");
+    expect(text).toContain("5 more node(s) omitted by read_canvas output cap");
+    expect(text).toContain("5 more edge(s) omitted by read_canvas output cap");
+    expect(text).not.toContain("[n204] type=text");
+    expect(text).not.toContain("edge 204");
+  });
+
   it("escapes control characters in vault-authored canvas output", async () => {
     await fs.writeFile(
       path.join(env.vaultDir, "dirty.canvas"),
@@ -206,6 +263,25 @@ describe("canvas handlers — add_canvas_node", () => {
     expect(canvas.nodes).toHaveLength(3);
     const added = canvas.nodes.find((n) => n.id === idMatch![1]);
     expect(added?.text).toBe("A new thought");
+  });
+
+  it("rejects oversized existing canvas files before mutation", async () => {
+    const fullPath = path.join(env.vaultDir, "huge.canvas");
+    const before = "x".repeat(MAX_CANVAS_FILE_BYTES + 1);
+    await fs.writeFile(fullPath, before, "utf-8");
+
+    const result = await env.client.callTool({
+      name: "add_canvas_node",
+      arguments: {
+        canvasPath: "huge.canvas",
+        type: "text",
+        content: "should not write",
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/Canvas file exceeds size cap/i);
+    await expect(fs.readFile(fullPath, "utf-8")).resolves.toBe(before);
   });
 
   it("validates file-type references stay inside the vault", async () => {

--- a/src/__tests__/semantics.test.ts
+++ b/src/__tests__/semantics.test.ts
@@ -4,7 +4,7 @@ import path from "path";
 import os from "os";
 import { resolveWikilink, extractTags, extractAliases } from "../lib/markdown.js";
 import { formatMomentDate } from "../lib/dates.js";
-import { writeCanvasFile, updateCanvasFile, readCanvasFile } from "../lib/vault.js";
+import { writeCanvasFile, updateCanvasFile, readCanvasFile, MAX_CANVAS_FILE_BYTES } from "../lib/vault.js";
 import type { CanvasData } from "../types.js";
 
 // ---------------------------------------------------------------------------
@@ -174,5 +174,40 @@ describe("updateCanvasFile — round-trip fidelity", () => {
     // Not an object — writeCanvasFile then read via updateCanvasFile.
     await writeCanvasFile(vaultDir, canvasPath, { nodes: [], edges: [] });
     await expect(readCanvasFile(vaultDir, canvasPath)).resolves.toBeDefined();
+  });
+
+  it("rejects oversized existing canvas files before update parsing", async () => {
+    const canvasPath = "huge.canvas";
+    const before = "x".repeat(MAX_CANVAS_FILE_BYTES + 1);
+    await fs.writeFile(path.join(vaultDir, canvasPath), before, "utf-8");
+
+    await expect(
+      updateCanvasFile(vaultDir, canvasPath, (data) => ({
+        nodes: data.nodes,
+        edges: data.edges,
+      })),
+    ).rejects.toThrow("Canvas file exceeds size cap");
+    await expect(fs.readFile(path.join(vaultDir, canvasPath), "utf-8")).resolves.toBe(before);
+  });
+
+  it("rejects writes that would exceed the canvas file cap", async () => {
+    await expect(
+      writeCanvasFile(vaultDir, "too-big.canvas", {
+        nodes: [
+          {
+            id: "n1",
+            type: "text",
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 50,
+            text: "x".repeat(MAX_CANVAS_FILE_BYTES),
+          },
+        ],
+        edges: [],
+      }),
+    ).rejects.toThrow("Canvas file exceeds size cap");
+
+    await expect(fs.access(path.join(vaultDir, "too-big.canvas"))).rejects.toThrow();
   });
 });

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -17,6 +17,7 @@ import {
   searchNotes,
   listCanvasFiles,
   readCanvasFile,
+  MAX_CANVAS_FILE_BYTES,
   getNoteStats,
   getVaultRootRealPath,
 } from "../lib/vault.js";
@@ -745,6 +746,18 @@ describe("readCanvasFile", () => {
 
     await expect(readCanvasFile(vaultDir, "bad.canvas")).rejects.toThrow(
       "Invalid canvas file (malformed JSON): bad.canvas",
+    );
+  });
+
+  it("should reject oversized canvas files before JSON parsing", async () => {
+    await fs.writeFile(
+      path.join(vaultDir, "huge.canvas"),
+      "x".repeat(MAX_CANVAS_FILE_BYTES + 1),
+      "utf-8",
+    );
+
+    await expect(readCanvasFile(vaultDir, "huge.canvas")).rejects.toThrow(
+      "Canvas file exceeds size cap",
     );
   });
 

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -18,6 +18,9 @@ const SEARCH_MATCH_COUNT_WEIGHT = 0.25;
 const SEARCH_REPEATED_SAME_LINE_PENALTY = 0.5;
 const SEARCH_SNIPPET_MAX_CHARS = 240;
 const SEARCH_SNIPPET_OMISSION = "...";
+export const MAX_CANVAS_FILE_BYTES = 1_048_576;
+const MAX_CANVAS_NODES = 10_000;
+const MAX_CANVAS_EDGES = 20_000;
 
 const EXCLUDED_DIRS = [".obsidian", ".trash", ".git"];
 const EXCLUDED_SET = new Set(EXCLUDED_DIRS);
@@ -1176,11 +1179,52 @@ export async function readBaseFile(
   return fs.readFile(fullPath, "utf-8");
 }
 
+function assertCanvasFileSize(size: number, relativePath: string): void {
+  if (size > MAX_CANVAS_FILE_BYTES) {
+    throw new Error(
+      `Canvas file exceeds size cap (${size} > ${MAX_CANVAS_FILE_BYTES} bytes): ${relativePath}`,
+    );
+  }
+}
+
+function assertCanvasDataCounts(
+  nodes: readonly unknown[],
+  edges: readonly unknown[],
+  relativePath: string,
+): void {
+  if (nodes.length > MAX_CANVAS_NODES) {
+    throw new Error(
+      `Canvas node count exceeds cap (${nodes.length} > ${MAX_CANVAS_NODES}): ${relativePath}`,
+    );
+  }
+  if (edges.length > MAX_CANVAS_EDGES) {
+    throw new Error(
+      `Canvas edge count exceeds cap (${edges.length} > ${MAX_CANVAS_EDGES}): ${relativePath}`,
+    );
+  }
+}
+
+function canvasDataFromObject(data: Record<string, unknown>, relativePath: string): CanvasData {
+  const nodes = Array.isArray(data.nodes) ? (data.nodes as CanvasData["nodes"]) : [];
+  const edges = Array.isArray(data.edges) ? (data.edges as CanvasData["edges"]) : [];
+  assertCanvasDataCounts(nodes, edges, relativePath);
+
+  return { nodes, edges };
+}
+
+function serializeCanvasFile(data: Record<string, unknown>, relativePath: string): string {
+  const serialized = JSON.stringify(data, null, 2);
+  assertCanvasFileSize(Buffer.byteLength(serialized, "utf-8"), relativePath);
+  return serialized;
+}
+
 export async function readCanvasFile(
   vaultPath: string,
   relativePath: string,
 ): Promise<CanvasData> {
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
+  const stats = await fs.stat(fullPath);
+  assertCanvasFileSize(stats.size, relativePath);
   const content = await fs.readFile(fullPath, "utf-8");
   let parsed: unknown;
   try {
@@ -1198,10 +1242,7 @@ export async function readCanvasFile(
   if (!Array.isArray(data.nodes)) {
     return { nodes: [], edges: [] };
   }
-  return {
-    nodes: data.nodes as CanvasData["nodes"],
-    edges: Array.isArray(data.edges) ? data.edges as CanvasData["edges"] : [],
-  };
+  return canvasDataFromObject(data, relativePath);
 }
 
 export async function writeCanvasFile(
@@ -1211,8 +1252,10 @@ export async function writeCanvasFile(
 ): Promise<void> {
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
+    assertCanvasDataCounts(data.nodes, data.edges, relativePath);
+    const serialized = serializeCanvasFile(data as unknown as Record<string, unknown>, relativePath);
     await fs.mkdir(path.dirname(fullPath), { recursive: true });
-    await atomicWriteFile(fullPath, JSON.stringify(data, null, 2));
+    await atomicWriteFile(fullPath, serialized);
   });
 }
 
@@ -1233,6 +1276,8 @@ export async function updateCanvasFile(
 ): Promise<void> {
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
+    const stats = await fs.stat(fullPath);
+    assertCanvasFileSize(stats.size, relativePath);
     const raw = await fs.readFile(fullPath, "utf-8");
     let parsed: unknown;
     try {
@@ -1241,13 +1286,12 @@ export async function updateCanvasFile(
       throw new Error(`Invalid canvas file (malformed JSON): ${relativePath}`);
     }
     const obj = (parsed && typeof parsed === "object" ? parsed : {}) as Record<string, unknown>;
-    const current: CanvasData = {
-      nodes: Array.isArray(obj.nodes) ? (obj.nodes as CanvasData["nodes"]) : [],
-      edges: Array.isArray(obj.edges) ? (obj.edges as CanvasData["edges"]) : [],
-    };
+    const current = canvasDataFromObject(obj, relativePath);
     const next = await transform(current);
+    assertCanvasDataCounts(next.nodes, next.edges, relativePath);
     const out = { ...obj, nodes: next.nodes, edges: next.edges };
+    const serialized = serializeCanvasFile(out, relativePath);
     await fs.mkdir(path.dirname(fullPath), { recursive: true });
-    await atomicWriteFile(fullPath, JSON.stringify(out, null, 2));
+    await atomicWriteFile(fullPath, serialized);
   });
 }

--- a/src/tools/canvas.ts
+++ b/src/tools/canvas.ts
@@ -9,6 +9,8 @@ import { log } from "../lib/logger.js";
 import type { CanvasNode, CanvasData } from "../types.js";
 
 const CANVAS_READ_CACHE_LIMIT = 16;
+const CANVAS_SUMMARY_NODE_LIMIT = 200;
+const CANVAS_SUMMARY_EDGE_LIMIT = 200;
 
 interface CanvasReadCacheEntry {
   fullPath: string;
@@ -79,7 +81,8 @@ function renderCanvasSummary(canvasPath: string, data: CanvasData): string {
 
   if (data.nodes.length > 0) {
     lines.push("--- Nodes ---");
-    for (const node of data.nodes) {
+    const visibleNodes = data.nodes.slice(0, CANVAS_SUMMARY_NODE_LIMIT);
+    for (const node of visibleNodes) {
       const pos = `(${node.x}, ${node.y})`;
       const size = `${node.width}x${node.height}`;
       let preview = "";
@@ -106,12 +109,17 @@ function renderCanvasSummary(canvasPath: string, data: CanvasData): string {
         lines.push(`    color: ${displayCanvasValue(node.color)}`);
       }
     }
+    const omittedNodes = data.nodes.length - visibleNodes.length;
+    if (omittedNodes > 0) {
+      lines.push(`  ... ${omittedNodes} more node(s) omitted by read_canvas output cap.`);
+    }
     lines.push("");
   }
 
   if (data.edges.length > 0) {
     lines.push("--- Edges ---");
-    for (const edge of data.edges) {
+    const visibleEdges = data.edges.slice(0, CANVAS_SUMMARY_EDGE_LIMIT);
+    for (const edge of visibleEdges) {
       const label = edge.label ? ` [${displayCanvasValue(edge.label)}]` : "";
       const sides = [
         edge.fromSide ? `from-side=${displayCanvasValue(edge.fromSide)}` : "",
@@ -121,6 +129,10 @@ function renderCanvasSummary(canvasPath: string, data: CanvasData): string {
       lines.push(
         `  ${displayCanvasValue(edge.fromNode)} -> ${displayCanvasValue(edge.toNode)}${label}${sideInfo}`,
       );
+    }
+    const omittedEdges = data.edges.length - visibleEdges.length;
+    if (omittedEdges > 0) {
+      lines.push(`  ... ${omittedEdges} more edge(s) omitted by read_canvas output cap.`);
     }
   }
 
@@ -195,7 +207,7 @@ export function registerCanvasTools(server: McpServer, vaultPath: string): void 
     {
       title: "Read Canvas",
       description:
-        "Read an Obsidian canvas file (.canvas, JSON format) and return a human-readable summary of its structure: every node with id, type, position, size, and content preview, plus every edge with source/target node ids and optional label. Use to inspect or navigate a canvas before calling add_canvas_node or add_canvas_edge.",
+        "Read an Obsidian canvas file (.canvas, JSON format) and return a bounded human-readable summary of its structure: total node/edge counts, up to 200 nodes with id/type/position/size/content preview, and up to 200 edges with source/target node ids plus optional label. Use to inspect or navigate a canvas before calling add_canvas_node or add_canvas_edge.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,


### PR DESCRIPTION
Cap Canvas reads and updates at 1 MiB, reject oversized serialized writes, and keep `read_canvas` output to the first 200 nodes and 200 edges while still showing totals. This keeps synced or malformed canvas files from forcing large allocations or huge MCP responses.

Risk: large canvases above 1 MiB now fail closed; crowded canvases beyond 200 nodes or edges show totals and an omission line.

Score: 4 severity x 3 reach / 1 effort = 12.

Tested: `npm test -- src/__tests__/handlers/canvas.test.ts src/__tests__/vault.test.ts src/__tests__/semantics.test.ts src/__tests__/regression-tools-canvas.test.ts src/__tests__/tools.test.ts`; `npm run typecheck`; `npm run lint`; `npm run verify`.

Greptile is skipped because the trial review quota is exhausted.