### PR TITLE
fix: bound section edit payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Section edit tools now bound replacement, insertion, block, and find/replace payloads before writing notes, preventing oversized MCP requests from being persisted through surgical edits.
 - Canvas helpers now reject oversized `.canvas` files before reading, parsing, or updating them, and `read_canvas` keeps large summaries bounded while still reporting total node and edge counts.
 - `read_base` and `query_base` now reject oversized `.base` files before reading them, preventing the parser cap from allocating large files or broadening queries through an empty parsed Base.
 - Recoverable `delete_note` now validates each `.trash` parent directory before creating deeper folders, preventing symlinked trash ancestors from creating directories outside the vault.

--- a/src/__tests__/regression-tools-sections.test.ts
+++ b/src/__tests__/regression-tools-sections.test.ts
@@ -22,6 +22,8 @@ import { setPermissions } from "../lib/permissions.js";
  */
 
 let env: TestEnv;
+const TOO_LARGE_SECTION_PAYLOAD = "x".repeat(1_000_001);
+const TOO_LARGE_FIND = "x".repeat(4097);
 
 beforeEach(async () => {
   setPermissions({ readPaths: null, writePaths: null });
@@ -145,7 +147,7 @@ describe("regression: replace_in_note ReDoS guards (C3)", () => {
       },
     });
     expect(isError(result)).toBe(true);
-    expect(textContent(result)).toMatch(/too long|targeted/i);
+    expect(textContent(result)).toMatch(/too_big|too big|4096/i);
   });
 
   it("rejects an unknown flag character (single-letter allowlist only)", async () => {
@@ -283,6 +285,106 @@ describe("regression: insert_at_section UTF-8 byte count (H11)", () => {
     // Should mention 4 bytes, not 2 (the code-unit count).
     expect(msg).toContain("4 bytes");
     expect(msg).not.toContain("2 bytes");
+  });
+});
+
+describe("regression: section edit payload bounds", () => {
+  it("rejects oversized update_section replacement bodies before writing", async () => {
+    const original = "# Tasks\n\n- existing\n";
+    const fullPath = path.join(env.vaultDir, "bounded-update.md");
+    await fs.writeFile(fullPath, original, "utf-8");
+
+    const result = await env.client.callTool({
+      name: "update_section",
+      arguments: {
+        path: "bounded-update.md",
+        section: "Tasks",
+        newBody: TOO_LARGE_SECTION_PAYLOAD,
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/validation|too_big|too long|max/i);
+    await expect(fs.readFile(fullPath, "utf-8")).resolves.toBe(original);
+  });
+
+  it("rejects oversized insert_at_section content before writing", async () => {
+    const original = "# Tasks\n\n- existing\n";
+    const fullPath = path.join(env.vaultDir, "bounded-insert.md");
+    await fs.writeFile(fullPath, original, "utf-8");
+
+    const result = await env.client.callTool({
+      name: "insert_at_section",
+      arguments: {
+        path: "bounded-insert.md",
+        section: "Tasks",
+        content: TOO_LARGE_SECTION_PAYLOAD,
+        position: "append",
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/validation|too_big|too long|max/i);
+    await expect(fs.readFile(fullPath, "utf-8")).resolves.toBe(original);
+  });
+
+  it("rejects oversized literal find strings before replace_in_note writes", async () => {
+    const original = "# Text\n\nneedle\n";
+    const fullPath = path.join(env.vaultDir, "bounded-find.md");
+    await fs.writeFile(fullPath, original, "utf-8");
+
+    const result = await env.client.callTool({
+      name: "replace_in_note",
+      arguments: {
+        path: "bounded-find.md",
+        find: TOO_LARGE_FIND,
+        replace: "x",
+        regex: false,
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/validation|too_big|too long|max/i);
+    await expect(fs.readFile(fullPath, "utf-8")).resolves.toBe(original);
+  });
+
+  it("rejects oversized replacement text before replace_in_note writes", async () => {
+    const original = "# Text\n\nneedle\n";
+    const fullPath = path.join(env.vaultDir, "bounded-replace.md");
+    await fs.writeFile(fullPath, original, "utf-8");
+
+    const result = await env.client.callTool({
+      name: "replace_in_note",
+      arguments: {
+        path: "bounded-replace.md",
+        find: "needle",
+        replace: TOO_LARGE_SECTION_PAYLOAD,
+        regex: false,
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/validation|too_big|too long|max/i);
+    await expect(fs.readFile(fullPath, "utf-8")).resolves.toBe(original);
+  });
+
+  it("rejects oversized edit_block replacement content before writing", async () => {
+    const original = "# Text\n\nparagraph ^block\n";
+    const fullPath = path.join(env.vaultDir, "bounded-block.md");
+    await fs.writeFile(fullPath, original, "utf-8");
+
+    const result = await env.client.callTool({
+      name: "edit_block",
+      arguments: {
+        path: "bounded-block.md",
+        block: "block",
+        newContent: TOO_LARGE_SECTION_PAYLOAD,
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/validation|too_big|too long|max/i);
+    await expect(fs.readFile(fullPath, "utf-8")).resolves.toBe(original);
   });
 });
 

--- a/src/tools/sections.ts
+++ b/src/tools/sections.ts
@@ -14,6 +14,9 @@ import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import { log } from "../lib/logger.js";
 
 const SECTION_LIST_CACHE_LIMIT = 16;
+const SECTION_EDIT_PAYLOAD_MAX_CHARS = 1_000_000;
+const FIND_MAX_LEN = 4096;
+const NOTE_INPUT_MAX_LEN = 1_000_000;
 
 interface SectionListCacheEntry {
   fullPath: string;
@@ -399,6 +402,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
           .describe("Heading path identifying the section to replace (e.g., 'Tasks' or 'Daily/Today')."),
         newBody: z
           .string()
+          .max(SECTION_EDIT_PAYLOAD_MAX_CHARS)
           .describe("Replacement body content. The heading line itself is kept intact."),
       },
     },
@@ -449,7 +453,10 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
       inputSchema: {
         path: z.string().min(1).describe("Vault-relative path to the note."),
         section: z.string().min(1).describe("Heading path identifying the section."),
-        content: z.string().describe("Content to insert. A trailing newline is normalized."),
+        content: z
+          .string()
+          .max(SECTION_EDIT_PAYLOAD_MAX_CHARS)
+          .describe("Content to insert. A trailing newline is normalized."),
         position: z
           .enum(["before", "after-heading", "append"])
           .default("append")
@@ -538,8 +545,15 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
       },
       inputSchema: {
         path: z.string().min(1).describe("Vault-relative path to the note."),
-        find: z.string().min(1).describe("Literal string (default) or regex pattern to match."),
-        replace: z.string().describe("Replacement text. With `regex: true`, supports $1, $2 backreferences."),
+        find: z
+          .string()
+          .min(1)
+          .max(FIND_MAX_LEN)
+          .describe("Literal string (default) or regex pattern to match."),
+        replace: z
+          .string()
+          .max(SECTION_EDIT_PAYLOAD_MAX_CHARS)
+          .describe("Replacement text. With `regex: true`, supports $1, $2 backreferences."),
         regex: z.boolean().default(false).describe("Treat `find` as a JavaScript regex (multi-line, case-sensitive by default)."),
         flags: z.string().optional().describe("Regex flags (e.g., 'gi'). Defaults to 'g' so all matches are replaced."),
         expectedCount: z.number().int().min(0).optional().describe("If set, abort unless exactly this many matches are found."),
@@ -549,8 +563,6 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
       // Defense in depth: arbitrary regex from LLM input is inherently risky.
       // The validation below caps obvious foot-guns, rejects known
       // backtracking-prone shapes, and keeps `regex: true` a deliberate choice.
-      const FIND_MAX_LEN = 4096;
-      const INPUT_MAX_LEN = 1_000_000;
       const ALLOWED_FLAGS = new Set(["g", "i", "m", "s", "u", "y"]);
 
       try {
@@ -605,9 +617,9 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
           // Cap the input size we apply the regex to — refusing the work is
           // far better than holding the per-file write lock while the engine
           // backtracks against a pathological pattern.
-          if (existing.length > INPUT_MAX_LEN) {
+          if (existing.length > NOTE_INPUT_MAX_LEN) {
             throw new Error(
-              `note is too large for replace_in_note (${existing.length} > ${INPUT_MAX_LEN} chars). Use a more targeted tool.`,
+              `note is too large for replace_in_note (${existing.length} > ${NOTE_INPUT_MAX_LEN} chars). Use a more targeted tool.`,
             );
           }
           if (unsafeRegexPattern) {
@@ -663,7 +675,10 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
           .transform((s) => s.replace(/^\^+/, ""))
           .refine((s) => s.length > 0, { message: "block id must not be empty after stripping leading '^'" })
           .describe("Block id with or without the leading `^` (e.g. `myid` or `^myid`)."),
-        newContent: z.string().describe("Replacement content. The `^id` anchor is appended automatically."),
+        newContent: z
+          .string()
+          .max(SECTION_EDIT_PAYLOAD_MAX_CHARS)
+          .describe("Replacement content. The `^id` anchor is appended automatically."),
       },
     },
     async ({ path: notePath, block, newContent }) => {


### PR DESCRIPTION
Bound the surgical edit payload fields for `update_section`, `insert_at_section`, `replace_in_note`, and `edit_block`, and added regressions that prove oversized requests are rejected before note bytes change. This closes the unbounded section-edit payload path without changing ordinary below-limit edits.

Risk: oversized surgical edit calls now fail schema validation; normal section, block, and replace edits stay on the same code paths.

Score: 3 severity x 3 reach / 1 effort = 9.

Tested: `npm test -- src/__tests__/regression-tools-sections.test.ts`; `npm test -- src/__tests__/regression-tools-sections.test.ts src/__tests__/handlers/write.test.ts`; `npm run typecheck`; `npm run lint`; `npm run verify`.

Greptile is skipped because the trial review quota is exhausted.