### PR TITLE
fix: redact embedding provider url secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Semantic embedding provider errors now redact secret-bearing URLs before returning them to MCP clients.
 - Section edit tools now bound replacement, insertion, block, and find/replace payloads before writing notes, preventing oversized MCP requests from being persisted through surgical edits.
 - Canvas helpers now reject oversized `.canvas` files before reading, parsing, or updating them, and `read_canvas` keeps large summaries bounded while still reporting total node and edge counts.
 - `read_base` and `query_base` now reject oversized `.base` files before reading them, preventing the parser cap from allocating large files or broadening queries through an empty parsed Base.

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { sanitizeError, escapeControlChars, stripPaths } from "../lib/errors.js";
+import {
+  sanitizeError,
+  escapeControlChars,
+  stripPaths,
+  redactUrlSecrets,
+} from "../lib/errors.js";
 
 describe("escapeControlChars", () => {
   it("passes printable ASCII through unchanged", () => {
@@ -48,6 +53,17 @@ describe("sanitizeError", () => {
     expect(sanitizeError(new Error("oops\r\nbad"))).toBe("oops\\r\\nbad");
   });
 
+  it("redacts secret-bearing URLs in client-facing messages", () => {
+    const msg = sanitizeError(
+      "provider rejected https://alice:pa55@example.internal/v1?api_key=secret#debug",
+    );
+    expect(msg).toBe("provider rejected https://<redacted-url>");
+    expect(msg).not.toContain("alice");
+    expect(msg).not.toContain("pa55");
+    expect(msg).not.toContain("api_key");
+    expect(msg).not.toContain("example.internal");
+  });
+
   it("returns a fixed string for non-Error input", () => {
     expect(sanitizeError(undefined)).toBe("Unknown error");
     expect(sanitizeError(null)).toBe("Unknown error");
@@ -64,5 +80,24 @@ describe("stripPaths", () => {
 
   it("strips quoted paths", () => {
     expect(stripPaths("ENOENT, open '/tmp/foo/bar.md'")).toBe("ENOENT, open <path>");
+  });
+});
+
+describe("redactUrlSecrets", () => {
+  it("leaves plain diagnostic URLs unchanged", () => {
+    expect(redactUrlSecrets("see https://api.example.com/v1")).toBe(
+      "see https://api.example.com/v1",
+    );
+  });
+
+  it("redacts URL credentials, query strings, and fragments", () => {
+    const out = redactUrlSecrets(
+      "bad ftp://user:pass@example.test/path?token=abc#frag.",
+    );
+    expect(out).toBe("bad ftp://<redacted-url>.");
+    expect(out).not.toContain("user");
+    expect(out).not.toContain("pass");
+    expect(out).not.toContain("token=abc");
+    expect(out).not.toContain("example.test");
   });
 });

--- a/src/__tests__/handlers/semantic.test.ts
+++ b/src/__tests__/handlers/semantic.test.ts
@@ -323,4 +323,29 @@ describe("semantic handlers — provider missing", () => {
     expect(isError(r2)).toBe(true);
     expect(textContent(r2)).toMatch(/OBSIDIAN_EMBEDDING_PROVIDER/);
   });
+
+  it("does not echo secret-bearing embedding URLs in provider configuration errors", async () => {
+    resetProviderForTests();
+    process.env.OBSIDIAN_EMBEDDING_PROVIDER = "ollama";
+    process.env.OBSIDIAN_EMBEDDING_URL =
+      "ftp://user:pa55@example.internal:11434/v1?token=secret#debug";
+    process.env.OBSIDIAN_EMBEDDING_MODEL = "test-model";
+    try {
+      const result = await env.client.callTool({ name: "index_vault", arguments: {} });
+      const text = textContent(result);
+      expect(isError(result)).toBe(true);
+      expect(text).toContain("OBSIDIAN_EMBEDDING_URL scheme/host not allowed");
+      expect(text).not.toContain("user");
+      expect(text).not.toContain("pa55");
+      expect(text).not.toContain("token=secret");
+      expect(text).not.toContain("example.internal");
+      expect(text).not.toContain("#debug");
+    } finally {
+      delete process.env.OBSIDIAN_EMBEDDING_PROVIDER;
+      delete process.env.OBSIDIAN_EMBEDDING_URL;
+      delete process.env.OBSIDIAN_EMBEDDING_MODEL;
+      resetProviderForTests();
+      setProviderForTests(new MockProvider());
+    }
+  });
 });

--- a/src/__tests__/regression-embedding-fixes.test.ts
+++ b/src/__tests__/regression-embedding-fixes.test.ts
@@ -407,3 +407,54 @@ describe("OllamaProvider probe (M16)", () => {
     expect(batchedAttempts).toBe(1);
   });
 });
+
+describe("embedding provider error redaction", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    resetProviderForTests();
+    process.env.OBSIDIAN_EMBEDDING_PROVIDER = "openai";
+    process.env.OBSIDIAN_EMBEDDING_URL = "https://api.example.com/v1";
+    process.env.OBSIDIAN_EMBEDDING_MODEL = "text-embedding-3-small";
+    process.env.OBSIDIAN_EMBEDDING_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    setProviderForTests(null);
+    resetProviderForTests();
+    delete process.env.OBSIDIAN_EMBEDDING_PROVIDER;
+    delete process.env.OBSIDIAN_EMBEDDING_URL;
+    delete process.env.OBSIDIAN_EMBEDDING_MODEL;
+    delete process.env.OBSIDIAN_EMBEDDING_API_KEY;
+  });
+
+  it("redacts secret-bearing URLs echoed by provider error bodies", async () => {
+    const provider = getActiveProvider();
+    expect(provider).not.toBeNull();
+
+    globalThis.fetch = vi.fn(async () =>
+      new Response(
+        "failed https://user:pa55@example.internal/v1?api_key=secret#debug",
+        { status: 500 },
+      ),
+    );
+
+    await expect(provider!.embed(["hello"])).rejects.toThrow(
+      /failed https:\/\/<redacted-url>/,
+    );
+
+    let message = "";
+    try {
+      await provider!.embed(["hello"]);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+
+    expect(message).not.toContain("user");
+    expect(message).not.toContain("pa55");
+    expect(message).not.toContain("api_key=secret");
+    expect(message).not.toContain("example.internal");
+    expect(message).not.toContain("#debug");
+  });
+});

--- a/src/lib/embedding-providers.ts
+++ b/src/lib/embedding-providers.ts
@@ -20,6 +20,8 @@
  * crashing the server.
  */
 
+import { redactUrlSecrets } from "./errors.js";
+
 export interface EmbeddingProvider {
   /** Stable identifier used in the persisted index — switching providers
    *  invalidates cached vectors because dimensions / spaces don't match. */
@@ -49,7 +51,7 @@ function validateEmbeddingUrl(raw: string): string {
     parsed = new URL(raw);
   } catch {
     throw new Error(
-      `OBSIDIAN_EMBEDDING_URL is not a valid URL: "${raw}". ` +
+      "OBSIDIAN_EMBEDDING_URL is not a valid URL. " +
         "Provide a full URL like https://api.example.com or http://localhost:11434",
     );
   }
@@ -64,7 +66,7 @@ function validateEmbeddingUrl(raw: string): string {
 
   if (!isHttps && !isLoopback) {
     throw new Error(
-      `OBSIDIAN_EMBEDDING_URL scheme/host not allowed: "${raw}". ` +
+      "OBSIDIAN_EMBEDDING_URL scheme/host not allowed. " +
         "Only https:// URLs and http:// to localhost/127.0.0.1 are permitted.",
     );
   }
@@ -103,7 +105,7 @@ function validateModelName(name: string, context: string): string {
 }
 
 function truncateBody(body: string): string {
-  const trimmed = body.trim();
+  const trimmed = redactUrlSecrets(body.trim());
   if (trimmed.length <= ERROR_BODY_MAX) return trimmed;
   return trimmed.slice(0, ERROR_BODY_MAX) + "… (truncated)";
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -3,8 +3,9 @@
 // Node's `fs` errors carry absolute host filesystem paths in their `.message`
 // (e.g. `ENOENT: no such file or directory, open '/home/user/vault/note.md'`).
 // Forwarding these to MCP clients leaks vault locations and potentially other
-// host layout information. `sanitizeError` strips the path and returns a
-// short, code-based message suitable for client-facing error payloads.
+// host layout information. Other error paths may also contain secret-bearing
+// URLs. `sanitizeError` strips those sensitive details and returns a short,
+// code-based message suitable for client-facing error payloads.
 
 const FS_ERROR_MESSAGES: Record<string, string> = {
   ENOENT: "File or directory not found",
@@ -26,14 +27,14 @@ interface ErrnoLike {
 
 /**
  * Convert an unknown thrown value into a message safe to return to an MCP
- * client. Strips absolute paths, stack traces, collapses known errno
+ * client. Strips absolute paths and secret-bearing URLs, collapses known errno
  * codes to generic human-readable text, and escapes control characters so
  * an attacker-controlled value (e.g. a filename with `\n` in it embedded
  * in an error message) can't break out of its line and inject text into
  * the LLM context.
  */
 export function sanitizeError(err: unknown): string {
-  if (typeof err === "string") return escapeControlChars(stripPaths(err));
+  if (typeof err === "string") return escapeControlChars(stripPaths(redactUrlSecrets(err)));
   if (!err || typeof err !== "object") return "Unknown error";
 
   const e = err as ErrnoLike;
@@ -41,7 +42,7 @@ export function sanitizeError(err: unknown): string {
   if (code && FS_ERROR_MESSAGES[code]) return FS_ERROR_MESSAGES[code];
 
   const msg = typeof e.message === "string" ? e.message : fallbackErrorMessage(err);
-  return escapeControlChars(stripPaths(msg));
+  return escapeControlChars(stripPaths(redactUrlSecrets(msg)));
 }
 
 function fallbackErrorMessage(err: unknown): string {
@@ -81,6 +82,31 @@ export function escapeControlChars(s: string): string {
     if (c === "\r") return "\\r";
     if (c === "\t") return "\\t";
     return `\\x${c.charCodeAt(0).toString(16).padStart(2, "0")}`;
+  });
+}
+
+const URL_LIKE_RE = /\b[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s<>"'`]+/g;
+const TRAILING_URL_PUNCT_RE = /[)\].,;!?]+$/;
+
+/**
+ * Remove credentials and parameter-bearing URL details from client-facing
+ * error text. Plain URLs are left alone so ordinary diagnostics stay useful;
+ * URLs with userinfo, query strings, or fragments are collapsed because those
+ * parts commonly carry API keys, bearer tokens, or internal setup details.
+ */
+export function redactUrlSecrets(s: string): string {
+  return s.replace(URL_LIKE_RE, (candidate) => {
+    const trailing = candidate.match(TRAILING_URL_PUNCT_RE)?.[0] ?? "";
+    const rawUrl = trailing ? candidate.slice(0, -trailing.length) : candidate;
+    try {
+      const parsed = new URL(rawUrl);
+      if (!parsed.username && !parsed.password && !parsed.search && !parsed.hash) {
+        return candidate;
+      }
+      return `${parsed.protocol}//<redacted-url>${trailing}`;
+    } catch {
+      return `<redacted-url>${trailing}`;
+    }
   });
 }
 


### PR DESCRIPTION
Redacts credentials, query strings, fragments, and internal host details from embedding-provider URL errors before they reach MCP clients. This closes DSS-R05-C037 without changing provider selection or semantic tool schemas.\n\nRisk: low; the change only narrows error text and provider response snippets.\nScore: medium severity x medium reach / low effort.\nTested: npm test -- src/__tests__/errors.test.ts src/__tests__/handlers/semantic.test.ts src/__tests__/regression-embedding-fixes.test.ts; npm run verify.\n\nGreptile review is skipped because the trial review limit is exhausted.