### PR TITLE
fix: prevent move_note destination races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `move_note` now creates the destination with no-replace semantics, preventing an external writer from racing the move into overwriting a newly created note.
 - Semantic embedding provider errors now redact secret-bearing URLs before returning them to MCP clients.
 - Section edit tools now bound replacement, insertion, block, and find/replace payloads before writing notes, preventing oversized MCP requests from being persisted through surgical edits.
 - Canvas helpers now reject oversized `.canvas` files before reading, parsing, or updating them, and `read_canvas` keeps large summaries bounded while still reporting total node and edge counts.

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -428,6 +428,29 @@ describe("moveNote", () => {
     );
   });
 
+  it("does not overwrite a destination created after the move starts", async () => {
+    await writeNote(vaultDir, "source.md", "source content");
+    const racedDest = path.join(vaultDir, "raced.md");
+    const realMkdir = fs.mkdir.bind(fs);
+    const mkdirSpy = vi.spyOn(fs, "mkdir").mockImplementation(async (...args) => {
+      const result = await realMkdir(...args);
+      if (String(args[0]) === vaultDir) {
+        await fs.writeFile(racedDest, "racer content", "utf-8");
+      }
+      return result;
+    });
+
+    await expect(
+      moveNote(vaultDir, "source.md", "raced.md", { updateLinks: false }),
+    ).rejects.toThrow("Destination already exists: raced.md");
+
+    mkdirSpy.mockRestore();
+    await expect(fs.readFile(path.join(vaultDir, "source.md"), "utf-8")).resolves.toBe(
+      "source content",
+    );
+    await expect(fs.readFile(racedDest, "utf-8")).resolves.toBe("racer content");
+  });
+
   it("requires read access to the source note before moving it", async () => {
     await fs.mkdir(path.join(vaultDir, "private"), { recursive: true });
     await fs.mkdir(path.join(vaultDir, "public"), { recursive: true });
@@ -442,17 +465,31 @@ describe("moveNote", () => {
     await expect(fs.access(path.join(vaultDir, "public", "secret.md"))).rejects.toThrow();
   });
 
-  itWin32("retries transient Windows rename failures while moving notes", async () => {
-    await writeNote(vaultDir, "old.md", "moving");
+  itWin32("retries transient Windows rename failures for case-only renames", async () => {
+    await writeNote(vaultDir, "Old.md", "moving");
     const realRename = fs.rename.bind(fs);
     const renameSpy = vi.spyOn(fs, "rename");
     renameSpy
       .mockRejectedValueOnce(Object.assign(new Error("simulated EBUSY"), { code: "EBUSY" }))
       .mockImplementation(realRename);
 
-    await moveNote(vaultDir, "old.md", "new.md");
+    await moveNote(vaultDir, "Old.md", "old.md");
 
     expect(renameSpy).toHaveBeenCalledTimes(2);
+    await expect(fs.access(path.join(vaultDir, "old.md"))).resolves.toBeUndefined();
+  });
+
+  itWin32("retries transient Windows unlink failures after no-replace moves", async () => {
+    await writeNote(vaultDir, "old.md", "moving");
+    const realUnlink = fs.unlink.bind(fs);
+    const unlinkSpy = vi.spyOn(fs, "unlink");
+    unlinkSpy
+      .mockRejectedValueOnce(Object.assign(new Error("simulated EBUSY"), { code: "EBUSY" }))
+      .mockImplementation(realUnlink);
+
+    await moveNote(vaultDir, "old.md", "new.md", { updateLinks: false });
+
+    expect(unlinkSpy).toHaveBeenCalledTimes(2);
     await expect(fs.access(path.join(vaultDir, "old.md"))).rejects.toThrow();
     await expect(fs.access(path.join(vaultDir, "new.md"))).resolves.toBeUndefined();
   });

--- a/src/lib/fs-ops.ts
+++ b/src/lib/fs-ops.ts
@@ -5,23 +5,31 @@ import fs from "fs/promises";
 // release those handles within a few milliseconds, so retry the transient
 // class before surfacing a failure. POSIX EACCES is normally structural, not a
 // timing issue, so non-Windows platforms stay fail-fast.
-const RENAME_RETRY_CODES: ReadonlySet<string> = process.platform === "win32"
+const FILE_RETRY_CODES: ReadonlySet<string> = process.platform === "win32"
   ? new Set(["EPERM", "EBUSY", "EACCES"])
   : new Set();
 
-const RENAME_RETRY_DELAYS_MS = [5, 10, 20, 40, 80, 160];
+const FILE_RETRY_DELAYS_MS = [5, 10, 20, 40, 80, 160];
 
-export async function renameWithRetry(from: string, to: string): Promise<void> {
+async function retryTransientFileError(fn: () => Promise<void>): Promise<void> {
   for (let attempt = 0; ; attempt++) {
     try {
-      await fs.rename(from, to);
+      await fn();
       return;
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code ?? "";
-      if (!RENAME_RETRY_CODES.has(code) || attempt >= RENAME_RETRY_DELAYS_MS.length) {
+      if (!FILE_RETRY_CODES.has(code) || attempt >= FILE_RETRY_DELAYS_MS.length) {
         throw err;
       }
-      await new Promise((r) => setTimeout(r, RENAME_RETRY_DELAYS_MS[attempt]));
+      await new Promise((r) => setTimeout(r, FILE_RETRY_DELAYS_MS[attempt]));
     }
   }
+}
+
+export async function renameWithRetry(from: string, to: string): Promise<void> {
+  await retryTransientFileError(() => fs.rename(from, to));
+}
+
+export async function unlinkWithRetry(file: string): Promise<void> {
+  await retryTransientFileError(() => fs.unlink(file));
 }

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1,10 +1,11 @@
 import fs from "fs/promises";
+import { constants as fsConstants } from "fs";
 import path from "path";
 import { randomBytes } from "crypto";
 import { StringDecoder } from "string_decoder";
 import { mapConcurrent } from "./concurrency.js";
 import { assertAllowed, type AccessKind } from "./permissions.js";
-import { renameWithRetry } from "./fs-ops.js";
+import { renameWithRetry, unlinkWithRetry } from "./fs-ops.js";
 import { MAX_BASE_FILE_BYTES } from "./bases.js";
 import type { SearchResult, SearchMatch, CanvasData } from "../types.js";
 
@@ -21,6 +22,7 @@ const SEARCH_SNIPPET_OMISSION = "...";
 export const MAX_CANVAS_FILE_BYTES = 1_048_576;
 const MAX_CANVAS_NODES = 10_000;
 const MAX_CANVAS_EDGES = 20_000;
+const COPY_FALLBACK_CODES = new Set(["EXDEV", "EPERM", "ENOSYS", "ENOTSUP", "EOPNOTSUPP"]);
 
 const EXCLUDED_DIRS = [".obsidian", ".trash", ".git"];
 const EXCLUDED_SET = new Set(EXCLUDED_DIRS);
@@ -850,6 +852,53 @@ export async function deleteNote(
   return performDelete();
 }
 
+async function linkOrCopyFileNoReplace(fullOldPath: string, fullNewPath: string): Promise<void> {
+  try {
+    await fs.link(fullOldPath, fullNewPath);
+    return;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code ?? "";
+    if (!COPY_FALLBACK_CODES.has(code)) throw err;
+  }
+  await fs.copyFile(fullOldPath, fullNewPath, fsConstants.COPYFILE_EXCL);
+}
+
+async function createDestinationNoReplace(fullOldPath: string, fullNewPath: string): Promise<void> {
+  const sourceStat = await fs.lstat(fullOldPath);
+  if (sourceStat.isSymbolicLink()) {
+    const linkTarget = await fs.readlink(fullOldPath);
+    if (IS_WIN32) {
+      await fs.symlink(linkTarget, fullNewPath, "file");
+    } else {
+      await fs.symlink(linkTarget, fullNewPath);
+    }
+    return;
+  }
+  await linkOrCopyFileNoReplace(fullOldPath, fullNewPath);
+}
+
+async function movePathNoReplace(
+  fullOldPath: string,
+  fullNewPath: string,
+  displayNewPath: string,
+): Promise<void> {
+  let createdDestination = false;
+  try {
+    await createDestinationNoReplace(fullOldPath, fullNewPath);
+    createdDestination = true;
+    await unlinkWithRetry(fullOldPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code ?? "";
+    if (createdDestination) {
+      try { await fs.unlink(fullNewPath); } catch { /* ignore cleanup failure */ }
+    }
+    if (code === "EEXIST") {
+      throw new Error(`Destination already exists: ${displayNewPath}`, { cause: err });
+    }
+    throw err;
+  }
+}
+
 export interface MoveNoteOptions {
   /** When true (default), rewrite wikilinks and markdown links in every other
    *  note + canvas to point at the new path. Set false to skip the scan
@@ -863,7 +912,7 @@ export interface MoveNoteResult {
    *  when no other note/canvas referenced the moved file (or `updateLinks`
    *  was false). */
   updatedReferrers: string[];
-  /** Per-file failures during the rewrite pass. The rename has already
+  /** Per-file failures during the rewrite pass. The move has already
    *  committed by the time these are surfaced. Empty when everything landed
    *  cleanly. */
   failedReferrers: Array<{ path: string; error: string }>;
@@ -884,38 +933,17 @@ export async function moveNote(
   const fullOldPath = await resolveVaultPathSafe(vaultPath, oldPath, "write");
   const fullNewPath = await resolveVaultPathSafe(vaultPath, newPath, "write");
   const doRename = async (): Promise<void> => {
-    // TOCTOU note: there is a small race window between `fs.access` and
-    // `fs.rename` where another process (Obsidian, a sync client, a second
-    // MCP server, an unrelated shell) could create a file at `fullNewPath`
-    // after our existence check returns ENOENT but before our rename runs.
-    // We deliberately do NOT close this race here, for two reasons:
-    //   1. POSIX `rename(2)` is documented to silently overwrite an existing
-    //      destination, which is the standard expected behavior. Closing
-    //      the window would require platform-specific syscalls (`renameat2`
-    //      with RENAME_NOREPLACE on Linux, or O_EXCL + link/unlink dance
-    //      elsewhere) that Node does not expose portably.
-    //   2. The vault-level lock taken by `performMove` already serializes
-    //      moveNote against itself and against deleteNote+removeReferences
-    //      and rename_tag, which covers every in-process writer. The
-    //      remaining race is exclusively against EXTERNAL writers on the
-    //      same vault, and those can also race against the rename itself
-    //      regardless of any pre-check we add.
-    // The pre-check stays as a friendly fast-path error for the common case
-    // (user typo'd into an existing file); on a race it merely upgrades to
-    // standard rename-overwrite semantics rather than a corruption bug.
-    try {
-      await fs.access(fullNewPath);
-      // A case-only rename (Note.md to note.md on a case-insensitive FS)
-      // resolves to the same inode, so `access` succeeds even though the
-      // caller intends to rename. Detect that case and allow the rename.
-      if (lockKey(fullOldPath) !== lockKey(fullNewPath)) {
-        throw new Error(`Destination already exists: ${newPath}`);
-      }
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    // A case-only rename (Note.md to note.md on a case-insensitive FS)
+    // resolves to the same inode, so a fail-on-exists move would reject the
+    // caller's intended rename. Keep that path on the native rename retry
+    // helper; every other move must create the destination with no-replace
+    // semantics before unlinking the old name.
+    if (lockKey(fullOldPath) === lockKey(fullNewPath)) {
+      await renameWithRetry(fullOldPath, fullNewPath);
+      return;
     }
     await fs.mkdir(path.dirname(fullNewPath), { recursive: true });
-    await renameWithRetry(fullOldPath, fullNewPath);
+    await movePathNoReplace(fullOldPath, fullNewPath, newPath);
   };
 
   const performMove = async (): Promise<MoveNoteResult> => {


### PR DESCRIPTION
Moves now create the destination with no-replace semantics before removing the old note path, so a destination created by an external vault writer during the move is left intact and the move fails. Case-only renames keep the native rename retry path, and the same Windows transient retry policy now covers the unlink step used by normal moves.\n\nRisk: medium; move_note changes from single native rename to create-destination-then-unlink for normal file moves, but the failure mode is duplicate source/destination content rather than overwriting a newly created note.\nScore: medium severity x medium reach / medium effort.\nDocs: Node documents that rename overwrites an existing destination, while COPYFILE_EXCL fails if the destination exists: https://nodejs.org/api/fs.html#fspromisesrenameoldpath-newpath and https://nodejs.org/api/fs.html#fspromisescopyfilesrc-dest-mode.\nTested: npm test -- src/__tests__/vault.test.ts src/__tests__/link-rewriter.test.ts src/__tests__/handlers/write.test.ts; npm run typecheck; npm run lint; npm run verify.\n\nGreptile review is skipped because the trial review limit is exhausted.