### PR TITLE
fix: block hidden attachment reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `get_attachment` now refuses hidden dotfile attachments, matching the files skipped by attachment inventory scans.
 - `move_note` now creates the destination with no-replace semantics, preventing an external writer from racing the move into overwriting a newly created note.
 - Semantic embedding provider errors now redact secret-bearing URLs before returning them to MCP clients.
 - Section edit tools now bound replacement, insertion, block, and find/replace payloads before writing notes, preventing oversized MCP requests from being persisted through surgical edits.

--- a/src/__tests__/handlers/attachments.test.ts
+++ b/src/__tests__/handlers/attachments.test.ts
@@ -16,6 +16,7 @@ beforeEach(async () => {
       "assets/page.html": "<script>alert(1)</script>",
       "assets/feed.xml": "<?xml version=\"1.0\"?><feed />",
       "assets/theme.css": "body { background: red; }",
+      "assets/.env": "TOKEN=hidden",
       "embed-host.md": "# Embed host\n\n![[used-image.png]]\n\nAlso linked: [doc](assets/notes.pdf)\n",
     },
   });
@@ -39,6 +40,8 @@ describe("attachments handlers — list_attachments", () => {
     expect(text).toMatch(/notes\.pdf/);
     // Markdown notes never appear in attachment listings.
     expect(text).not.toMatch(/embed-host\.md/);
+    // Hidden dotfiles are skipped by the inventory and direct reads.
+    expect(text).not.toMatch(/\.env/);
   });
 
   it("filters by extension", async () => {
@@ -233,6 +236,17 @@ describe("attachments handlers — get_attachment", () => {
     const text = textContent(result);
     expect(text).toContain('"tools/bad\\tthing.exe"');
     expect(text).not.toContain("tools/bad\tthing.exe");
+  });
+
+  it("rejects hidden dotfile attachments skipped by the inventory", async () => {
+    const result = await env.client.callTool({
+      name: "get_attachment",
+      arguments: { path: "assets/.env" },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain('Refusing to fetch hidden attachment "assets/.env"');
+    expect(text).not.toContain("TOKEN=hidden");
   });
 
   itWin32("rejects Windows alternate data stream attachment paths", async () => {

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -68,6 +68,11 @@ function safeResourceMimeType(mime: string): string {
   return ACTIVE_TEXT_MIME_TYPES.has(mime.toLowerCase()) ? "text/plain" : mime;
 }
 
+function hiddenAttachmentBasename(relPath: string): string | null {
+  const basename = path.posix.basename(relPath.replace(/\\/g, "/"));
+  return basename.startsWith(".") ? basename : null;
+}
+
 /** Group attachments by their lower-cased extension for the summary line. */
 function summarizeByExtension(paths: readonly string[]): Map<string, number> {
   const out = new Map<string, number>();
@@ -436,6 +441,13 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
     },
     async ({ path: relPath, maxBytes }) => {
       try {
+        const hiddenName = hiddenAttachmentBasename(relPath);
+        if (hiddenName) {
+          return errorResult(
+            `Refusing to fetch hidden attachment "${displayAttachmentValue(relPath)}" via get_attachment.`,
+          );
+        }
+
         // Reject text-format files so the wrong tool isn't used on them.
         const lowerPath = relPath.toLowerCase();
         if (lowerPath.endsWith(".md") || lowerPath.endsWith(".canvas") || lowerPath.endsWith(".base")) {


### PR DESCRIPTION
Direct attachment reads now reject hidden dotfile basenames before resolving and reading bytes, matching the files skipped by attachment inventory scans. This closes DSS-R04-C034 without changing the normal attachment list/find_unused/get_attachment schemas.

Risk: low; the change narrows direct get_attachment reads for dotfile basenames only.
Score: 2 severity x 2 reach / 1 effort = 4.
Tested: npm test -- src/__tests__/handlers/attachments.test.ts src/__tests__/regression-tools-attachments.test.ts src/__tests__/attachments-display.test.ts; npm run typecheck; npm run lint; npm run verify.

Greptile review is skipped because the trial review limit is exhausted.