### PR TITLE
fix: fail fast on oversized http bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- HTTP transport now rejects oversized JSON request bodies as soon as `Content-Length` or streamed bytes cross the cap, instead of waiting for the request to finish.
 - `get_attachment` now refuses hidden dotfile attachments, matching the files skipped by attachment inventory scans.
 - `move_note` now creates the destination with no-replace semantics, preventing an external writer from racing the move into overwriting a newly created note.
 - Semantic embedding provider errors now redact secret-bearing URLs before returning them to MCP clients.

--- a/src/__tests__/regression-http-fixes.test.ts
+++ b/src/__tests__/regression-http-fixes.test.ts
@@ -12,6 +12,8 @@ import { startHttpServer, type HttpServerHandle } from "../http-server.js";
 //        is configured (GET stays public for monitoring probes).
 //   M5 — Repeated `startHttpServer` calls used to leak SIGINT/SIGTERM
 //        listeners and trip MaxListenersExceededWarning at 11 boots.
+//   DSS-R04-C035 — Oversized HTTP bodies return 413 as soon as the declared or
+//        streamed size crosses the cap, not only after the request finishes.
 
 function buildNoopServer(): McpServer {
   return new McpServer({ name: "test", version: "0.0.0" });
@@ -117,6 +119,65 @@ function rawRequest(
   });
 }
 
+function rawOpenBodyRequest(
+  port: number,
+  options: {
+    method: string;
+    path: string;
+    host?: string;
+    headers?: Record<string, string>;
+    initialBody?: string | Buffer;
+    timeoutMs?: number;
+  },
+): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let cleanup = (): void => {};
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+    const headers: Record<string, string> = {
+      Host: options.host ?? `127.0.0.1:${port}`,
+      ...(options.headers ?? {}),
+    };
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: options.path,
+        method: options.method,
+        headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          finish(() => resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString("utf-8"),
+          }));
+        });
+      },
+    );
+    const timeout = setTimeout(() => {
+      finish(() => reject(new Error("raw open-body request timed out")));
+    }, options.timeoutMs ?? 1_000);
+    cleanup = () => {
+      clearTimeout(timeout);
+      req.destroy();
+    };
+    req.on("error", (err) => {
+      if (!settled) finish(() => reject(err));
+    });
+    req.flushHeaders();
+    if (options.initialBody !== undefined) req.write(options.initialBody);
+  });
+}
+
 describe("regression: C1 — DNS rebinding protection actually rejects bad Host", () => {
   it("rejects a POST to /mcp whose Host header is not in the allowedHosts list", async () => {
     const token = "rebind-test-token";
@@ -182,6 +243,43 @@ describe("regression: C1 — DNS rebinding protection actually rejects bad Host"
     // The host is allowed, so the request reaches the MCP handshake.
     // We don't assert a specific code beyond "not the Host-rejected 403".
     expect(res.status).not.toBe(403);
+  });
+});
+
+describe("regression: DSS-R04-C035 — HTTP body caps fail fast", () => {
+  it("rejects oversized Content-Length before the body arrives", async () => {
+    const handle = await startOnEphemeral();
+    handles.push(handle);
+
+    const res = await rawOpenBodyRequest(handle.port, {
+      method: "POST",
+      path: "/mcp",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": String(4 * 1024 * 1024 + 1),
+      },
+    });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toContain("Request body too large");
+  });
+
+  it("rejects chunked bodies as soon as the stream crosses the cap", async () => {
+    const handle = await startOnEphemeral();
+    handles.push(handle);
+
+    const res = await rawOpenBodyRequest(handle.port, {
+      method: "POST",
+      path: "/mcp",
+      headers: {
+        "Content-Type": "application/json",
+        "Transfer-Encoding": "chunked",
+      },
+      initialBody: Buffer.alloc(4 * 1024 * 1024 + 1, 0x78),
+    });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toContain("Request body too large");
   });
 });
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -54,26 +54,40 @@ class BodyTooLargeError extends Error {
   }
 }
 
+function declaredBodyTooLarge(req: IncomingMessage): boolean {
+  const contentLength = req.headers["content-length"];
+  if (typeof contentLength !== "string" || !/^\d+$/.test(contentLength)) return false;
+  return BigInt(contentLength) > BigInt(MAX_BODY_BYTES);
+}
+
 function readBody(req: IncomingMessage): Promise<unknown> {
   return new Promise((resolve, reject) => {
     let size = 0;
-    let exceeded = false;
+    let settled = false;
     const chunks: Buffer[] = [];
+
+    const fail = (err: Error): void => {
+      if (settled) return;
+      settled = true;
+      chunks.length = 0;
+      reject(err);
+    };
+
     req.on("data", (chunk: Buffer) => {
-      if (exceeded) return;
+      if (settled) return;
       size += chunk.length;
       if (size > MAX_BODY_BYTES) {
-        // Stop buffering but keep reading + discarding so the request stream
-        // drains cleanly. Destroying the socket here races with the 413
-        // response write and produces noisy `write after end` errors.
-        exceeded = true;
-        chunks.length = 0;
+        // Stop buffering and let the caller return 413 immediately; keep the
+        // request stream flowing so the socket can drain without a hard reset.
+        fail(new BodyTooLargeError());
+        req.resume();
       } else {
         chunks.push(chunk);
       }
     });
     req.on("end", () => {
-      if (exceeded) return reject(new BodyTooLargeError());
+      if (settled) return;
+      settled = true;
       const raw = Buffer.concat(chunks).toString("utf-8");
       if (!raw) return resolve(undefined);
       try {
@@ -82,7 +96,7 @@ function readBody(req: IncomingMessage): Promise<unknown> {
         reject(err instanceof Error ? err : new Error("Invalid JSON body"));
       }
     });
-    req.on("error", reject);
+    req.on("error", (err) => fail(err));
   });
 }
 
@@ -430,6 +444,11 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
         const contentType = req.headers["content-type"] ?? "";
         if (!contentType.toLowerCase().includes("application/json")) {
           sendJson(res, 415, { error: "Unsupported Media Type: expected application/json" });
+          return;
+        }
+        if (declaredBodyTooLarge(req)) {
+          req.resume();
+          sendJson(res, 413, { error: "Request body too large" });
           return;
         }
         let body: unknown;


### PR DESCRIPTION
HTTP request body caps now fail fast: oversized Content-Length values return 413 before bytes are read, and chunked streams reject as soon as they cross the cap instead of waiting for the request to finish.

Risk: low; this only narrows oversized POST handling on the HTTP transport.
Score: 3 severity x 3 reach / 1 effort = 9.
Tested: npm test -- src/__tests__/regression-http-fixes.test.ts src/__tests__/http-server.test.ts; npm run typecheck; npm run lint; npm run verify.

Greptile review is skipped because the trial review limit is exhausted.