### PR TITLE
fix: reject symlink attachment reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `get_attachment` now refuses symlinked attachment paths, matching attachment inventory scans and reducing path-swap exposure during direct reads.
 - HTTP transport now rejects oversized JSON request bodies as soon as `Content-Length` or streamed bytes cross the cap, instead of waiting for the request to finish.
 - `get_attachment` now refuses hidden dotfile attachments, matching the files skipped by attachment inventory scans.
 - `move_note` now creates the destination with no-replace semantics, preventing an external writer from racing the move into overwriting a newly created note.

--- a/src/__tests__/attachments-display.test.ts
+++ b/src/__tests__/attachments-display.test.ts
@@ -10,6 +10,7 @@ import { isError, textContent } from "./handlers/harness.js";
 interface AttachmentMocks {
   attachments: string[];
   notes?: string[];
+  vaultPath?: string;
   resolvedPath?: string;
   stats?: Map<string, number>;
 }
@@ -40,7 +41,7 @@ async function createAttachmentClient(mocks: AttachmentMocks): Promise<{
 
   const { registerAttachmentTools } = await import("../tools/attachments.js");
   const server = new McpServer({ name: "attachment-display-test", version: "0.0.0" });
-  registerAttachmentTools(server, "mock-vault");
+  registerAttachmentTools(server, mocks.vaultPath ?? "mock-vault");
 
   const client = new Client({ name: "attachment-display-client", version: "0.0.0" });
   const [clientT, serverT] = InMemoryTransport.createLinkedPair();
@@ -118,6 +119,7 @@ describe("attachment display escaping", () => {
     const relPath = "assets/big\nfile.png";
     const env = await createAttachmentClient({
       attachments: [],
+      vaultPath: dir,
       resolvedPath: fullPath,
     });
     try {
@@ -142,6 +144,7 @@ describe("attachment display escaping", () => {
 
     const env = await createAttachmentClient({
       attachments: [],
+      vaultPath: dir,
       resolvedPath: fullPath,
     });
     try {

--- a/src/__tests__/handlers/attachments.test.ts
+++ b/src/__tests__/handlers/attachments.test.ts
@@ -5,6 +5,8 @@ import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js"
 
 let env: TestEnv;
 const itWin32 = process.platform === "win32" ? it : it.skip;
+const SYMLINKS_SUPPORTED = process.platform !== "win32" || process.env.CI_SYMLINKS === "1";
+const itSymlink = SYMLINKS_SUPPORTED ? it : it.skip;
 
 beforeEach(async () => {
   env = await createTestEnv({
@@ -247,6 +249,52 @@ describe("attachments handlers — get_attachment", () => {
     const text = textContent(result);
     expect(text).toContain('Refusing to fetch hidden attachment "assets/.env"');
     expect(text).not.toContain("TOKEN=hidden");
+  });
+
+  itSymlink("rejects symlinked attachment files skipped by the inventory", async () => {
+    await fs.symlink(
+      path.join(env.vaultDir, "assets", "used-image.png"),
+      path.join(env.vaultDir, "assets", "linked-image.png"),
+      process.platform === "win32" ? "file" : undefined,
+    );
+
+    const listed = await env.client.callTool({
+      name: "list_attachments",
+      arguments: {},
+    });
+    expect(textContent(listed)).not.toMatch(/linked-image\.png/);
+
+    const result = await env.client.callTool({
+      name: "get_attachment",
+      arguments: { path: "assets/linked-image.png" },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain("Refusing to fetch symlink attachment");
+    expect(text).not.toContain(Buffer.from("PNG-fake-bytes").toString("base64"));
+  });
+
+  itSymlink("rejects symlinked attachment directories skipped by the inventory", async () => {
+    await fs.symlink(
+      path.join(env.vaultDir, "assets"),
+      path.join(env.vaultDir, "linked-assets"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    const listed = await env.client.callTool({
+      name: "list_attachments",
+      arguments: {},
+    });
+    expect(textContent(listed)).not.toMatch(/linked-assets/);
+
+    const result = await env.client.callTool({
+      name: "get_attachment",
+      arguments: { path: "linked-assets/used-image.png" },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain("Refusing to fetch symlink attachment");
+    expect(text).not.toContain(Buffer.from("PNG-fake-bytes").toString("base64"));
   });
 
   itWin32("rejects Windows alternate data stream attachment paths", async () => {

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -73,6 +73,28 @@ function hiddenAttachmentBasename(relPath: string): string | null {
   return basename.startsWith(".") ? basename : null;
 }
 
+async function assertNoSymlinkAttachmentPath(
+  vaultPath: string,
+  fullPath: string,
+  relPath: string,
+): Promise<void> {
+  const vaultRoot = path.resolve(vaultPath);
+  const resolvedFullPath = path.resolve(fullPath);
+  const relativeFromVault = path.relative(vaultRoot, resolvedFullPath);
+  if (relativeFromVault.startsWith("..") || path.isAbsolute(relativeFromVault)) {
+    throw new Error("Path traversal via symlink detected");
+  }
+
+  let current = vaultRoot;
+  for (const segment of relativeFromVault.split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    const entry = await fs.lstat(current);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Refusing to fetch symlink attachment: ${displayAttachmentValue(relPath)}`);
+    }
+  }
+}
+
 /** Group attachments by their lower-cased extension for the summary line. */
 function summarizeByExtension(paths: readonly string[]): Map<string, number> {
   const out = new Map<string, number>();
@@ -465,16 +487,28 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
           );
         }
 
-        const fullPath = await resolveVaultPathSafe(vaultPath, relPath);
-        const stat = await fs.stat(fullPath);
         const limit = maxBytes ?? DEFAULT_GET_ATTACHMENT_LIMIT;
-        if (stat.size > limit) {
+        const fullPath = await resolveVaultPathSafe(vaultPath, relPath);
+        await assertNoSymlinkAttachmentPath(vaultPath, fullPath, relPath);
+        const handle = await fs.open(fullPath, "r");
+        let bytes: Buffer;
+        try {
+          const stat = await handle.stat();
+          if (stat.size > limit) {
+            return errorResult(
+              `Attachment "${displayAttachmentValue(relPath)}" is ${stat.size.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`,
+            );
+          }
+          bytes = await handle.readFile();
+        } finally {
+          await handle.close();
+        }
+        if (bytes.byteLength > limit) {
           return errorResult(
-            `Attachment "${displayAttachmentValue(relPath)}" is ${stat.size.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`,
+            `Attachment "${displayAttachmentValue(relPath)}" is ${bytes.byteLength.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`,
           );
         }
-
-        const bytes = await fs.readFile(fullPath);
+        const attachmentSize = bytes.byteLength;
         const mime = detectMimeType(relPath);
         const category = categorizeMimeType(mime);
         const basename = path.basename(relPath);
@@ -490,7 +524,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
               {
                 type: "text" as const,
                 text: `Attached: ${displayedBasename} (SVG returned as text/plain for security - SVGs may contain embedded scripts)\n` +
-                      `Size: ${stat.size.toLocaleString()} bytes`,
+                      `Size: ${attachmentSize.toLocaleString()} bytes`,
               },
               {
                 type: "resource" as const,
@@ -526,7 +560,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         if (category === "image") {
           return {
             content: [
-              { type: "text" as const, text: `Attached: ${displayedBasename} (${mime}, ${stat.size.toLocaleString()} bytes)${magicWarning}` },
+              { type: "text" as const, text: `Attached: ${displayedBasename} (${mime}, ${attachmentSize.toLocaleString()} bytes)${magicWarning}` },
               { type: "image" as const, data, mimeType: mime },
             ],
           };
@@ -534,7 +568,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         if (category === "audio") {
           return {
             content: [
-              { type: "text" as const, text: `Attached: ${displayedBasename} (${mime}, ${stat.size.toLocaleString()} bytes)` },
+              { type: "text" as const, text: `Attached: ${displayedBasename} (${mime}, ${attachmentSize.toLocaleString()} bytes)` },
               { type: "audio" as const, data, mimeType: mime },
             ],
           };
@@ -543,7 +577,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         const mimeLabel = resourceMime === mime ? mime : `${mime} returned as ${resourceMime}`;
         return {
           content: [
-            { type: "text" as const, text: `Attached: ${displayedBasename} (${mimeLabel}, ${stat.size.toLocaleString()} bytes)` },
+            { type: "text" as const, text: `Attached: ${displayedBasename} (${mimeLabel}, ${attachmentSize.toLocaleString()} bytes)` },
             {
               type: "resource" as const,
               resource: {


### PR DESCRIPTION
Direct attachment reads now refuse symlinked file or directory components, matching the attachment inventory boundary. get_attachment also reads from the opened file handle and rechecks the byte cap after reading so path swaps after open cannot change which path is read.

Risk: low; this narrows direct get_attachment reads for symlinked paths only.
Score: 3 severity x 2 reach / 1 effort = 6.
Tested: CI_SYMLINKS=1 npm test -- src/__tests__/handlers/attachments.test.ts src/__tests__/regression-tools-attachments.test.ts src/__tests__/attachments-display.test.ts; npm run typecheck; npm run lint; CI_SYMLINKS=1 npm run verify.

Greptile review is skipped because the trial review limit is exhausted.