### PR TITLE
fix: clean up failed exclusive creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Exclusive note creation now removes its zero-byte reservation if the staged atomic write fails.
 - `get_attachment` now refuses symlinked attachment paths, matching attachment inventory scans and reducing path-swap exposure during direct reads.
 - HTTP transport now rejects oversized JSON request bodies as soon as `Content-Length` or streamed bytes cross the cap, instead of waiting for the request to finish.
 - `get_attachment` now refuses hidden dotfile attachments, matching the files skipped by attachment inventory scans.

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -827,6 +827,22 @@ describe("writeNote exclusive mode", () => {
     const content = await fs.readFile(path.join(vaultDir, "fresh.md"), "utf-8");
     expect(content).toBe("hello");
   });
+
+  it("removes the reserved file if the staged write fails", async () => {
+    const realWriteFile = fs.writeFile.bind(fs);
+    vi.spyOn(fs, "writeFile").mockImplementation(async (...args: Parameters<typeof fs.writeFile>) => {
+      const [file] = args;
+      if (String(file).endsWith(".tmp")) {
+        throw new Error("simulated staged write failure");
+      }
+      return realWriteFile(...args);
+    });
+
+    await expect(
+      writeNote(vaultDir, "reserved.md", "body", { exclusive: true }),
+    ).rejects.toThrow("simulated staged write failure");
+    await expect(fs.access(path.join(vaultDir, "reserved.md"))).rejects.toThrow();
+  });
 });
 
 describe("atomic writes", () => {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -117,6 +117,17 @@ export async function atomicWriteFile(fullPath: string, content: string): Promis
   }
 }
 
+async function removeEmptyExclusivePlaceholder(fullPath: string): Promise<void> {
+  try {
+    const stat = await fs.lstat(fullPath);
+    if (!stat.isFile() || stat.size !== 0) return;
+    await fs.unlink(fullPath);
+  } catch {
+    // Best effort only: preserving an unexpected file is safer than deleting
+    // something that may have changed after the failed exclusive create.
+  }
+}
+
 export async function withFileLock<T>(fullPath: string, fn: () => Promise<T>): Promise<T> {
   const key = lockKey(fullPath);
   const prev = fileLocks.get(key) ?? Promise.resolve();
@@ -597,7 +608,12 @@ export async function writeNote(
         await handle?.close();
       }
     }
-    await atomicWriteFile(fullPath, content);
+    try {
+      await atomicWriteFile(fullPath, content);
+    } catch (err) {
+      if (options?.exclusive) await removeEmptyExclusivePlaceholder(fullPath);
+      throw err;
+    }
   });
 }
 


### PR DESCRIPTION
Exclusive note creation now removes the zero-byte reservation when the staged atomic write fails. The cleanup only deletes the reserved path if it is still a zero-byte regular file, so unexpected external changes are preserved.

Risk: low; this only changes failed exclusive create cleanup.
Score: 2 severity x 2 reach / 1 effort = 4.
Tested: npm test -- src/__tests__/vault.test.ts src/__tests__/handlers/write.test.ts src/__tests__/regression-vault-fixes.test.ts; npm run typecheck; npm run lint; npm run verify.

Greptile review is skipped because the trial review limit is exhausted.