### PR TITLE
fix: reject frontmatter anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- YAML frontmatter parsing now ignores anchors and aliases, and frontmatter updates refuse to rewrite notes containing them.
 - Exclusive note creation now removes its zero-byte reservation if the staged atomic write fails.
 - `get_attachment` now refuses symlinked attachment paths, matching attachment inventory scans and reducing path-swap exposure during direct reads.
 - HTTP transport now rejects oversized JSON request bodies as soon as `Content-Length` or streamed bytes cross the cap, instead of waiting for the request to finish.

--- a/src/__tests__/markdown.test.ts
+++ b/src/__tests__/markdown.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   parseFrontmatter,
+  parseStrictYamlFrontmatter,
   updateFrontmatter,
   extractWikilinks,
   extractWikilinkSpans,
@@ -99,6 +100,39 @@ The body.`;
     expect(result.data).toEqual({});
     expect(result.content).toBe(content);
   });
+
+  it("leaves YAML anchors and aliases unparsed for vault-wide reads", () => {
+    const content = [
+      "---",
+      "base: &base",
+      "  tags: [private]",
+      "copy: *base",
+      "---",
+      "Body.",
+    ].join("\n");
+    const result = parseFrontmatter(content);
+    expect(result.data).toEqual({});
+    expect(result.content).toBe(content);
+    const strict = parseStrictYamlFrontmatter(content);
+    expect(strict.error?.message).toMatch(/anchors and aliases/i);
+  });
+
+  it("allows plain scalar ampersands and stars in frontmatter", () => {
+    const content = [
+      "---",
+      "title: R&D notes",
+      "pattern: \"*.md\"",
+      "plain: look * here and R & D",
+      "emphasis: note *emphasis*",
+      "---",
+      "Body.",
+    ].join("\n");
+    const result = parseFrontmatter(content);
+    expect(result.data.title).toBe("R&D notes");
+    expect(result.data.pattern).toBe("*.md");
+    expect(result.data.plain).toBe("look * here and R & D");
+    expect(result.data.emphasis).toBe("note *emphasis*");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -154,6 +188,20 @@ ${body}`;
     expect(() =>
       updateFrontmatter(oversizedFrontmatter(), { status: "safe" }),
     ).toThrow(/Frontmatter block exceeds size cap/);
+  });
+
+  it("refuses to update frontmatter containing YAML anchors or aliases", () => {
+    const content = [
+      "---",
+      "base: &base",
+      "  tags: [private]",
+      "copy: *base",
+      "---",
+      "Body.",
+    ].join("\n");
+    expect(() => updateFrontmatter(content, { status: "safe" })).toThrow(
+      /anchors and aliases/i,
+    );
   });
 });
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -8,7 +8,7 @@ const YAML_MATTER_OPTIONS = { language: "yaml" };
 type FrontmatterScan =
   | { kind: "none" }
   | { kind: "oversized"; bytes?: number }
-  | { kind: "found"; bytes: number };
+  | { kind: "found"; bytes: number; yaml: string };
 
 export interface ParsedFrontmatter {
   data: Record<string, unknown>;
@@ -42,14 +42,15 @@ function scanYamlFrontmatter(content: string): FrontmatterScan {
     const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
 
     if (line === "---") {
+      const yaml = content.slice(yamlStart, lineStart);
       const bytes = Buffer.byteLength(
-        content.slice(yamlStart, lineStart),
+        yaml,
         "utf8",
       );
       if (bytes > MAX_FRONTMATTER_BYTES) {
         return { kind: "oversized", bytes };
       }
-      return { kind: "found", bytes };
+      return { kind: "found", bytes, yaml };
     }
 
     if (lineEnd === -1) return { kind: "none" };
@@ -57,6 +58,76 @@ function scanYamlFrontmatter(content: string): FrontmatterScan {
   }
 
   return { kind: "none" };
+}
+
+function hasYamlAnchorOrAliasToken(yaml: string): boolean {
+  let inSingle = false;
+  let inDouble = false;
+
+  for (const rawLine of yaml.split(/\n/)) {
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    let nodeStart = 0;
+
+    for (let i = 0; i < line.length; i += 1) {
+      const ch = line.charAt(i);
+      const prev = i === 0 ? "" : line.charAt(i - 1);
+      const next = line.charAt(i + 1);
+
+      if (inSingle) {
+        if (ch === "'" && line[i + 1] === "'") {
+          i += 1;
+        } else if (ch === "'") {
+          inSingle = false;
+        }
+        continue;
+      }
+
+      if (inDouble) {
+        if (ch === "\\") {
+          i += 1;
+        } else if (ch === "\"") {
+          inDouble = false;
+        }
+        continue;
+      }
+
+      if (ch === "#") {
+        if (i === 0 || /\s/.test(prev)) break;
+        continue;
+      }
+      if (ch === "'") {
+        inSingle = true;
+        continue;
+      }
+      if (ch === "\"") {
+        inDouble = true;
+        continue;
+      }
+      if (ch === "[" || ch === "{" || ch === ",") {
+        nodeStart = i + 1;
+        continue;
+      }
+      if (ch === ":" && (next === "" || /[\s\]},]/.test(next))) {
+        nodeStart = i + 1;
+        continue;
+      }
+      if (ch !== "&" && ch !== "*") continue;
+
+      if (!/[A-Za-z0-9_-]/.test(next)) continue;
+
+      const prefix = line.slice(nodeStart, i).trim();
+      if (
+        prefix === "" ||
+        prefix === "-" ||
+        prefix === "?" ||
+        /^!\S+$/.test(prefix) ||
+        /^[-?]\s+!\S+$/.test(prefix)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 function asFrontmatterObject(value: unknown): Record<string, unknown> {
@@ -83,6 +154,16 @@ export function parseStrictYamlFrontmatter(content: string): ParsedFrontmatter {
       content,
       hasFrontmatter: true,
       oversized: true,
+      bytes: scan.bytes,
+    };
+  }
+
+  if (hasYamlAnchorOrAliasToken(scan.yaml)) {
+    return {
+      data: {},
+      content,
+      hasFrontmatter: true,
+      error: new Error("YAML frontmatter anchors and aliases are not supported."),
       bytes: scan.bytes,
     };
   }


### PR DESCRIPTION
YAML frontmatter reads now ignore metadata blocks containing anchors or aliases, and frontmatter updates refuse to rewrite those blocks. This keeps vault-wide metadata scans bounded to plain Obsidian-style frontmatter while preserving ordinary scalar values such as `R&D` and `*.md`.

Risk: medium-low; notes that rely on YAML anchors or aliases no longer expose those values through frontmatter tools, but note bodies still read unchanged.
Score: 3 severity x 3 reach / 1 effort = 9.
Tested: npm test -- src/__tests__/markdown.test.ts src/__tests__/regression-markdown-sections.test.ts src/__tests__/regression-tag-rewriter.test.ts src/__tests__/handlers/read.test.ts src/__tests__/handlers/write.test.ts src/__tests__/handlers/tags.test.ts; npm run typecheck; npm run lint; npm run verify.

Greptile review is skipped because the trial review limit is exhausted.