### PR TITLE
fix: cap full-note reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Full-note `.md` reads and read-modify-write helpers now refuse files over 5 MiB before materializing them, while `get_note` line fragments still stream targeted ranges from large notes.
 - YAML frontmatter parsing now ignores anchors and aliases, and frontmatter updates refuse to rewrite notes containing them.
 - Exclusive note creation now removes its zero-byte reservation if the staged atomic write fails.
 - `get_attachment` now refuses symlinked attachment paths, matching attachment inventory scans and reducing path-swap exposure during direct reads.

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ The server also declares the MCP [`logging` capability](https://modelcontextprot
 
 - **Vault boundary** — every tool and resource routes through a single path resolver that rejects `..` traversal, null-byte injection, and symlinks pointing outside the vault (ancestor-realpath check). On Windows it also rejects reserved device names and alternate data stream syntax.
 - **Note/file boundary** — note read and edit surfaces only target `.md` files; attachments, Canvas files, and Bases stay on their dedicated tools with their own caps and parsers.
+- **Full-note cap** — full `.md` note reads and read-modify-write helpers refuse notes over 5 MiB before materializing them; `get_note` line fragments still stream from large notes for targeted inspection.
 - **Excluded directories** — `.obsidian`, `.git`, and `.trash` are pruned at traversal time and at resolution time, so nested occurrences never leak back to clients.
 - **HTTP transport** — binds to `127.0.0.1` by default with DNS rebinding protection (host-header allowlist). Optional `--token=<secret>` requires `Authorization: Bearer <secret>` on every `/mcp` request; compared in constant time. Malformed request URL or Host data is rejected before routing.
 - **Attachment safety** — executable extensions are blocked, SVGs are returned as `text/plain`, and active text formats such as HTML/XML/CSS are served with `text/plain` resource metadata.

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
+import { setMaxNoteFileBytesForTests } from "../../lib/vault.js";
 
 let env: TestEnv;
 
@@ -10,6 +11,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  setMaxNoteFileBytesForTests(null);
   await env.cleanup();
 });
 
@@ -23,6 +25,26 @@ describe("read handlers — search_notes", () => {
     expect(isError(result)).toBe(false);
     expect(text).toContain("note-b.md");
     expect(text).toContain("note-c.md");
+  });
+
+  it("skips oversized notes before vault-wide content search", async () => {
+    setMaxNoteFileBytesForTests(200);
+    await fs.writeFile(
+      path.join(env.vaultDir, "oversized.md"),
+      "secret needle ".repeat(20),
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "search_notes",
+      arguments: { query: "secret" },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain('No results found for "secret"');
+    expect(text).not.toContain("oversized.md");
+    expect(text).not.toContain("secret needle");
   });
 
   it("respects case sensitivity when asked", async () => {
@@ -224,6 +246,42 @@ describe("read handlers — get_note", () => {
     // No absolute paths, no OS error codes leaked.
     expect(text).not.toMatch(/[A-Z]:\\/);
     expect(text).not.toMatch(/^\/[a-z]/);
+  });
+
+  it("rejects oversized full-note reads without returning body text", async () => {
+    setMaxNoteFileBytesForTests(10);
+    await fs.writeFile(
+      path.join(env.vaultDir, "oversized.md"),
+      "private note body",
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "oversized.md" },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(true);
+    expect(text).toMatch(/note file exceeds size cap/i);
+    expect(text).not.toContain("private note body");
+  });
+
+  it("still returns line fragments from notes over the full-read cap", async () => {
+    setMaxNoteFileBytesForTests(10);
+    await fs.writeFile(
+      path.join(env.vaultDir, "long.md"),
+      ["first", "second", "third"].join("\n"),
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "long.md", lines: "2" },
+    });
+
+    expect(isError(result)).toBe(false);
+    expect(textContent(result)).toBe("second");
   });
 
   it("rejects non-markdown vault files", async () => {

--- a/src/__tests__/handlers/write.test.ts
+++ b/src/__tests__/handlers/write.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
+import { setMaxNoteFileBytesForTests } from "../../lib/vault.js";
 
 let env: TestEnv;
 
@@ -10,6 +11,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  setMaxNoteFileBytesForTests(null);
   await env.cleanup();
 });
 
@@ -133,6 +135,24 @@ describe("write handlers — append_to_note / prepend_to_note", () => {
       arguments: { path: "no-such-file.md", content: "x" },
     });
     expect(isError(result)).toBe(true);
+  });
+
+  it("refuses to append to oversized existing notes without changing bytes", async () => {
+    setMaxNoteFileBytesForTests(10);
+    const original = "private body";
+    await fs.writeFile(path.join(env.vaultDir, "oversized.md"), original, "utf-8");
+
+    const result = await env.client.callTool({
+      name: "append_to_note",
+      arguments: { path: "oversized.md", content: "tail" },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(true);
+    expect(text).toMatch(/note file exceeds size cap/i);
+    expect(text).not.toContain(original);
+    await expect(fs.readFile(path.join(env.vaultDir, "oversized.md"), "utf-8"))
+      .resolves.toBe(original);
   });
 
   it("prepend preserves frontmatter and inserts after it", async () => {

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -18,6 +18,7 @@ import {
   listCanvasFiles,
   readCanvasFile,
   MAX_CANVAS_FILE_BYTES,
+  setMaxNoteFileBytesForTests,
   getNoteStats,
   getVaultRootRealPath,
 } from "../lib/vault.js";
@@ -33,6 +34,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   vi.restoreAllMocks();
+  setMaxNoteFileBytesForTests(null);
   setPermissions({ readPaths: null, writePaths: null });
   await fs.rm(vaultDir, { recursive: true, force: true });
 });
@@ -196,6 +198,28 @@ describe("readNote", () => {
       "Not a markdown note: secret.txt",
     );
   });
+
+  it("rejects oversized full-note reads before materializing content", async () => {
+    setMaxNoteFileBytesForTests(10);
+    await fs.writeFile(path.join(vaultDir, "oversized.md"), "x".repeat(11), "utf-8");
+
+    await expect(readNote(vaultDir, "oversized.md")).rejects.toThrow(
+      /Note file exceeds size cap \(11 > 10 bytes\): oversized\.md/,
+    );
+  });
+
+  it("still streams line fragments from notes over the full-read cap", async () => {
+    setMaxNoteFileBytesForTests(10);
+    await fs.writeFile(
+      path.join(vaultDir, "long.md"),
+      ["first", "second", "third"].join("\n"),
+      "utf-8",
+    );
+
+    await expect(readNoteLineRange(vaultDir, "long.md", 2, 2)).resolves.toEqual({
+      text: "second",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -237,6 +261,15 @@ describe("writeNote", () => {
     expect(content).toBe("new");
   });
 
+  it("rejects writes that would exceed the note file cap", async () => {
+    setMaxNoteFileBytesForTests(10);
+
+    await expect(writeNote(vaultDir, "too-big.md", "x".repeat(11))).rejects.toThrow(
+      /Note file exceeds size cap/,
+    );
+    await expect(fs.access(path.join(vaultDir, "too-big.md"))).rejects.toThrow();
+  });
+
   it("should reject non-markdown write targets", async () => {
     await fs.writeFile(path.join(vaultDir, "asset.txt"), "original", "utf-8");
 
@@ -261,6 +294,24 @@ describe("writeNote", () => {
 
     await expect(fs.readFile(path.join(vaultDir, "asset.txt"), "utf-8"))
       .resolves.toBe("original");
+  });
+
+  it("refuses to read-modify-write oversized existing notes", async () => {
+    setMaxNoteFileBytesForTests(10);
+    const oversized = "x".repeat(11);
+    await fs.writeFile(path.join(vaultDir, "oversized.md"), oversized, "utf-8");
+
+    await expect(updateNote(vaultDir, "oversized.md", () => "small")).rejects.toThrow(
+      /Note file exceeds size cap/,
+    );
+    await expect(appendToNote(vaultDir, "oversized.md", "tail")).rejects.toThrow(
+      /Note file exceeds size cap/,
+    );
+    await expect(prependToNote(vaultDir, "oversized.md", "head")).rejects.toThrow(
+      /Note file exceeds size cap/,
+    );
+    await expect(fs.readFile(path.join(vaultDir, "oversized.md"), "utf-8"))
+      .resolves.toBe(oversized);
   });
 });
 

--- a/src/lib/index-cache.ts
+++ b/src/lib/index-cache.ts
@@ -1,7 +1,12 @@
 import crypto from "crypto";
 import fs from "fs/promises";
 import path from "path";
-import { getVaultRootRealPath, resolveVaultInternalPathSafe, resolveVaultPathSafe } from "./vault.js";
+import {
+  assertNoteFileSize,
+  getVaultRootRealPath,
+  resolveVaultInternalPathSafe,
+  resolveVaultPathSafe,
+} from "./vault.js";
 import { mapConcurrent } from "./concurrency.js";
 import { log } from "./logger.js";
 import { renameWithRetry } from "./fs-ops.js";
@@ -344,6 +349,7 @@ export async function readAllCached(
     let mtimeMs: number;
     try {
       const stat = await fs.stat(fullPath);
+      assertNoteFileSize(relPath, stat.size);
       mtimeMs = stat.mtimeMs;
       mtimes.set(relPath, stat.mtime.getTime());
       statsByPath.set(relPath, {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -19,6 +19,9 @@ const SEARCH_MATCH_COUNT_WEIGHT = 0.25;
 const SEARCH_REPEATED_SAME_LINE_PENALTY = 0.5;
 const SEARCH_SNIPPET_MAX_CHARS = 240;
 const SEARCH_SNIPPET_OMISSION = "...";
+const MAX_NOTE_FILE_BYTES_DEFAULT = 5 * 1024 * 1024;
+let maxNoteFileBytes = MAX_NOTE_FILE_BYTES_DEFAULT;
+export const MAX_NOTE_FILE_BYTES = MAX_NOTE_FILE_BYTES_DEFAULT;
 export const MAX_CANVAS_FILE_BYTES = 1_048_576;
 const MAX_CANVAS_NODES = 10_000;
 const MAX_CANVAS_EDGES = 20_000;
@@ -31,6 +34,30 @@ function assertMarkdownNotePath(relativePath: string): void {
   if (!relativePath.toLowerCase().endsWith(".md")) {
     throw new Error(`Not a markdown note: ${relativePath}`);
   }
+}
+
+export function setMaxNoteFileBytesForTests(bytes: number | null): void {
+  maxNoteFileBytes = bytes === null ? MAX_NOTE_FILE_BYTES_DEFAULT : bytes;
+}
+
+export function assertNoteFileSize(relativePath: string, size: number): void {
+  if (size > maxNoteFileBytes) {
+    throw new Error(
+      `Note file exceeds size cap (${size} > ${maxNoteFileBytes} bytes): ${relativePath}`,
+    );
+  }
+}
+
+async function assertResolvedNoteFileSize(
+  fullPath: string,
+  relativePath: string,
+): Promise<void> {
+  const stats = await fs.stat(fullPath);
+  assertNoteFileSize(relativePath, stats.size);
+}
+
+function assertNoteContentSize(relativePath: string, content: string): void {
+  assertNoteFileSize(relativePath, Buffer.byteLength(content, "utf-8"));
 }
 
 // Legacy DOS device names reserved by the Windows filesystem at any depth.
@@ -473,6 +500,7 @@ export async function readNote(
   assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
   try {
+    await assertResolvedNoteFileSize(fullPath, relativePath);
     return await fs.readFile(fullPath, "utf-8");
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
@@ -565,6 +593,7 @@ export async function writeNote(
 ): Promise<void> {
   assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
+  assertNoteContentSize(relativePath, content);
   await withFileLock(fullPath, async () => {
     await fs.mkdir(path.dirname(fullPath), { recursive: true });
     if (options?.exclusive) {
@@ -637,9 +666,11 @@ export async function updateNote(
   assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
+    await assertResolvedNoteFileSize(fullPath, relativePath);
     const existing = await fs.readFile(fullPath, "utf-8");
     const next = await transform(existing);
     if (next === existing) return;
+    assertNoteContentSize(relativePath, next);
     await atomicWriteFile(fullPath, next);
   });
 }
@@ -652,9 +683,12 @@ export async function appendToNote(
   assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
+    await assertResolvedNoteFileSize(fullPath, relativePath);
     const existing = await fs.readFile(fullPath, "utf-8");
     const separator = existing.endsWith("\n") ? "" : "\n";
-    await atomicWriteFile(fullPath, existing + separator + content);
+    const next = existing + separator + content;
+    assertNoteContentSize(relativePath, next);
+    await atomicWriteFile(fullPath, next);
   });
 }
 
@@ -697,6 +731,7 @@ export async function prependToNote(
   assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
+    await assertResolvedNoteFileSize(fullPath, relativePath);
     const existing = await fs.readFile(fullPath, "utf-8");
 
     // Detect frontmatter by scanning only the first N lines instead of
@@ -714,6 +749,7 @@ export async function prependToNote(
       result = content + "\n" + existing;
     }
 
+    assertNoteContentSize(relativePath, result);
     await atomicWriteFile(fullPath, result);
   });
 }


### PR DESCRIPTION
Full-note `.md` reads and read-modify-write helpers now check a 5 MiB file cap before materializing content, and the vault-wide content cache applies the same guard after `stat`. Line-range `get_note` fragments still stream so large notes can be inspected in targeted slices.

Risk: medium; notes over 5 MiB are no longer returned or rewritten through full-note paths, but targeted line fragments still work and dedicated attachment/Canvas/Base tools keep their own caps.
Score: 4 severity x 3 reach / 2 effort = 6.
Tested: npm test -- src/__tests__/vault.test.ts src/__tests__/index-cache.test.ts src/__tests__/handlers/read.test.ts src/__tests__/handlers/write.test.ts src/__tests__/regression-tools-read.test.ts src/__tests__/regression-tools-write.test.ts; npm run typecheck; npm run lint; npm run verify.

Greptile review is skipped because the trial review limit is exhausted.