### PR TITLE
fix: reject windows path aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Display and error sanitization now escape Unicode bidi controls as `\uHHHH`, preventing vault-controlled names or snippets from visually reordering client output.
+- Windows path resolution now rejects filename components ending in a space or period before permissions, excluded-directory checks, or attachment classification run.
 - `add_canvas_node` now accepts only absolute `http://` and `https://` URLs for Canvas link nodes, rejecting malformed, local-file, and application-protocol links before persistence.
 - Base YAML parsing now refuses anchors and aliases before `js-yaml` runs, preventing alias graphs from shaping Base filters, views, or serialized output.
 - Full-note `.md` reads and read-modify-write helpers now refuse files over 5 MiB before materializing them, while `get_note` line fragments still stream targeted ranges from large notes.

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ The server also declares the MCP [`logging` capability](https://modelcontextprot
 
 ## Security
 
-- **Vault boundary** — every tool and resource routes through a single path resolver that rejects `..` traversal, null-byte injection, and symlinks pointing outside the vault (ancestor-realpath check). On Windows it also rejects reserved device names and alternate data stream syntax.
+- **Vault boundary** — every tool and resource routes through a single path resolver that rejects `..` traversal, null-byte injection, and symlinks pointing outside the vault (ancestor-realpath check). On Windows it also rejects reserved device names, alternate data stream syntax, and trailing-dot/space filename aliases.
 - **Note/file boundary** — note read and edit surfaces only target `.md` files; attachments, Canvas files, and Bases stay on their dedicated tools with their own caps and parsers.
 - **Full-note cap** — full `.md` note reads and read-modify-write helpers refuse notes over 5 MiB before materializing them; `get_note` line fragments still stream from large notes for targeted inspection.
 - **Excluded directories** — `.obsidian`, `.git`, and `.trash` are pruned at traversal time and at resolution time, so nested occurrences never leak back to clients.

--- a/src/__tests__/handlers/attachments.test.ts
+++ b/src/__tests__/handlers/attachments.test.ts
@@ -218,6 +218,17 @@ describe("attachments handlers — get_attachment", () => {
     expect(textContent(md)).toMatch(/use get_note/i);
   });
 
+  itWin32("rejects trailing-dot aliases before attachment classification", async () => {
+    const result = await env.client.callTool({
+      name: "get_attachment",
+      arguments: { path: "embed-host.md." },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toMatch(/space or period|windows normalizes/i);
+    expect(text).not.toContain("Embed host");
+  });
+
   it("escapes control characters in rejected text-format paths", async () => {
     const result = await env.client.callTool({
       name: "get_attachment",

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -80,6 +80,18 @@ describe("resolveVaultPath", () => {
     );
   });
 
+  itWin32("should block trailing dot and space aliases", () => {
+    expect(() => resolveVaultPath(vaultDir, "notes/secret.md.")).toThrow(
+      /space or period/i,
+    );
+    expect(() => resolveVaultPath(vaultDir, "notes/secret.md ")).toThrow(
+      /space or period/i,
+    );
+    expect(() => resolveVaultPath(vaultDir, ".obsidian./config.json")).toThrow(
+      /space or period/i,
+    );
+  });
+
   it("should block sibling directory prefix attack", () => {
     // If vault is /tmp/vault, a path resolving to /tmp/vault-evil should fail
     const siblingDir = vaultDir + "-evil";

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -96,6 +96,24 @@ function rejectWindowsAlternateDataStreams(relativePath: string): void {
   }
 }
 
+function rejectWindowsTrailingDotOrSpace(relativePath: string): void {
+  if (!IS_WIN32) return;
+  const badSegment = relativePath
+    .replace(/\\/g, "/")
+    .split("/")
+    .find((seg) =>
+      seg !== "" &&
+      seg !== "." &&
+      seg !== ".." &&
+      (seg.endsWith(".") || seg.endsWith(" ")),
+    );
+  if (badSegment) {
+    throw new Error(
+      `Invalid path: "${badSegment}" ends with a space or period, which Windows normalizes`,
+    );
+  }
+}
+
 // Synthetic lock key used to serialize vault-wide bulk-write operations
 // (move_note + delete_note with `removeReferences: true`, plus rename_tag
 // which scans every note and applies `updateNote` calls). Distinct from
@@ -306,6 +324,7 @@ export function resolveVaultPath(
     );
   }
   rejectWindowsAlternateDataStreams(relativePath);
+  rejectWindowsTrailingDotOrSpace(relativePath);
   assertAllowed(relativePath, access);
   const resolved = path.resolve(vaultPath, relativePath);
   const resolvedVault = path.resolve(vaultPath);


### PR DESCRIPTION
Windows path resolution now rejects path components ending in a space or period before permissions, excluded-directory checks, attachment classification, or filesystem reads run. Windows normalizes those suffixes, so inputs such as `embed-host.md.` can otherwise address `embed-host.md` after raw suffix checks have already passed.

Risk: low; this only rejects Windows-only path aliases that do not name stable vault filenames through the server.
Score: 3 severity x 3 reach / 1 effort = 9.
Tested: npm test -- src/__tests__/vault.test.ts src/__tests__/handlers/attachments.test.ts src/__tests__/regression-tools-attachments.test.ts src/__tests__/regression-vault-fixes.test.ts; npm run typecheck; npm run lint; npm run verify.
Sources: https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/file-folder-name-whitespace-characters and https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file.

Greptile review is skipped because the trial review limit is exhausted.