### PR TITLE
fix: require auth for wildcard cors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Display and error sanitization now escape Unicode bidi controls as `\uHHHH`, preventing vault-controlled names or snippets from visually reordering client output.
+- HTTP transport now refuses wildcard CORS (`--allow-origin=*`) unless bearer auth is configured, preventing unauthenticated loopback servers from exposing MCP responses to arbitrary browser origins.
 - Windows path resolution now rejects filename components ending in a space or period before permissions, excluded-directory checks, or attachment classification run.
 - `add_canvas_node` now accepts only absolute `http://` and `https://` URLs for Canvas link nodes, rejecting malformed, local-file, and application-protocol links before persistence.
 - Base YAML parsing now refuses anchors and aliases before `js-yaml` runs, preventing alias graphs from shaping Base filters, views, or serialized output.

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ npx -y obsidian-mcp-pro --transport=http --token=your-secret
 ```
 
 The HTTP server binds to `127.0.0.1` by default with DNS rebinding protection enabled.
-If `--host` is set to a non-loopback address, startup requires `--token=<secret>` or
-`MCP_HTTP_TOKEN`.
+If `--host` is set to a non-loopback address or `--allow-origin=*` is configured,
+startup requires `--token=<secret>` or `MCP_HTTP_TOKEN`.
 
 > [!WARNING]
 > **Never bind `--host=0.0.0.0` directly to the public internet.** Doing so exposes your entire Obsidian vault to anyone who can reach the port. The server refuses non-loopback binds without a bearer token, but if you need remote access:
@@ -205,7 +205,7 @@ Additional hardening flags:
 
 | Flag | Purpose |
 |------|---------|
-| `--allow-origin=<csv>` | Restrict CORS to an allowlist (e.g. `https://claude.ai,https://chat.openai.com`). Default is localhost-only. |
+| `--allow-origin=<csv>` | Restrict CORS to an allowlist (e.g. `https://claude.ai,https://chat.openai.com`). Default is localhost-only; `*` requires bearer auth. |
 | `--rate-limit=<n>` | Cap requests per minute per client IP. `/health` and `/version` are exempt. Default is unlimited. |
 
 Operational endpoints (no auth required):
@@ -345,7 +345,7 @@ The server also declares the MCP [`logging` capability](https://modelcontextprot
 - **Note/file boundary** — note read and edit surfaces only target `.md` files; attachments, Canvas files, and Bases stay on their dedicated tools with their own caps and parsers.
 - **Full-note cap** — full `.md` note reads and read-modify-write helpers refuse notes over 5 MiB before materializing them; `get_note` line fragments still stream from large notes for targeted inspection.
 - **Excluded directories** — `.obsidian`, `.git`, and `.trash` are pruned at traversal time and at resolution time, so nested occurrences never leak back to clients.
-- **HTTP transport** — binds to `127.0.0.1` by default with DNS rebinding protection (host-header allowlist). Optional `--token=<secret>` requires `Authorization: Bearer <secret>` on every `/mcp` request; compared in constant time. Malformed request URL or Host data is rejected before routing.
+- **HTTP transport** — binds to `127.0.0.1` by default with DNS rebinding protection (host-header allowlist). Optional `--token=<secret>` requires `Authorization: Bearer <secret>` on every `/mcp` request; compared in constant time. Non-loopback binds and wildcard CORS require bearer auth. Malformed request URL or Host data is rejected before routing.
 - **Attachment safety** — executable extensions are blocked, SVGs are returned as `text/plain`, and active text formats such as HTML/XML/CSS are served with `text/plain` resource metadata.
 - **Canvas link safety** — Canvas link nodes added through the server accept only absolute `http://` and `https://` URLs, preventing local file and application-protocol links from being persisted by tool calls.
 - **Regex edit safety** — `replace_in_note` caps regex pattern/input size and rejects backtracking-prone repeated groups before matching.
@@ -353,7 +353,7 @@ The server also declares the MCP [`logging` capability](https://modelcontextprot
 - **YAML parser boundaries** — Obsidian properties are parsed only from `---` YAML delimiter lines; non-YAML gray-matter language blocks stay as body text, oversized frontmatter is skipped on reads and refused for metadata updates, and note/Base YAML containing anchors or aliases is not parsed.
 - **Bulk-write confirmations** — clients that support MCP elicitation are asked to re-type the destination path or new tag before `move_note` rewrites references or `rename_tag` writes across the vault. Dry runs and clients without elicitation keep their existing behavior.
 - **Atomic writes** — every note write (`create_note`, `append`, `prepend`, `update_frontmatter`, canvas mutations) stages content to a sibling temp file then renames onto the target, so a crash or kill mid-write never leaves a truncated file. Combined with per-path locks for the full read-modify-write cycle, concurrent callers can't lose each other's updates. The `install` subcommand uses the same pattern and keeps a backup of the previous config.
-- **Rate limiting + CORS allowlist** — optional `--rate-limit` caps per-IP request volume; `--allow-origin` restricts browser-facing CORS. `/health` and `/version` stay reachable under load for monitoring.
+- **Rate limiting + CORS allowlist** — optional `--rate-limit` caps per-IP request volume; `--allow-origin` restricts browser-facing CORS and refuses `*` unless bearer auth is enabled. `/health` and `/version` stay reachable under load for monitoring.
 - **Request timeout** — HTTP POST requests are capped at 2 minutes of wall-clock time. Long-lived SSE GET streams are exempt so idle clients aren't reaped.
 - **Process supervision** — `uncaughtException` exits cleanly so systemd/Docker/npx supervisors can restart; `unhandledRejection` logs but doesn't kill the process.
 

--- a/src/__tests__/regression-http-fixes.test.ts
+++ b/src/__tests__/regression-http-fixes.test.ts
@@ -489,6 +489,30 @@ describe("regression: HTTP bearer token must not be empty", () => {
     await expect(startOnEphemeral({ bearerToken: "   " })).rejects.toThrow(/token.*empty/i);
   });
 
+  it("rejects wildcard CORS without bearer auth", async () => {
+    await expect(startOnEphemeral({ allowedOrigins: ["*"] })).rejects.toThrow(
+      /bearer token.*CORS.*all origins/i,
+    );
+  });
+
+  it("allows wildcard CORS when bearer auth is configured", async () => {
+    const handle = await startOnEphemeral({
+      allowedOrigins: ["*"],
+      bearerToken: "secret",
+    });
+    handles.push(handle);
+
+    const res = await rawRequest(handle.port, {
+      method: "OPTIONS",
+      path: "/mcp",
+      host: `127.0.0.1:${handle.port}`,
+      headers: { Origin: "https://attacker.example" },
+    });
+
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-allow-origin"]).toBe("*");
+  });
+
   it("rejects non-loopback binds without bearer auth", async () => {
     let leaked: HttpServerHandle | undefined;
     let err: unknown;

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -19,7 +19,8 @@ export interface HttpServerOptions {
   /** Allowed CORS origins. Defaults to localhost-only patterns
    *  (`["http://localhost:*", "http://127.0.0.1:*", "http://[::1]:*"]`).
    *  Use an explicit list (e.g. `["https://claude.ai"]`) for browser-facing
-   *  deployments. Pass `["*"]` to allow all origins (a warning is logged).
+   *  deployments. Pass `["*"]` to allow all origins only when Bearer auth is
+   *  configured.
    *  Requests from other origins still succeed (CORS is a browser-only
    *  restriction) but the browser will reject the response. */
   allowedOrigins?: string[];
@@ -264,6 +265,14 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
   if (opts.bearerToken !== undefined && !bearerToken) {
     throw new Error("HTTP bearer token cannot be empty");
   }
+  const allowedOrigins = opts.allowedOrigins && opts.allowedOrigins.length > 0
+    ? opts.allowedOrigins
+    : ["http://localhost:*", "http://127.0.0.1:*", "http://[::1]:*"];
+  if (!bearerToken && allowedOrigins.includes("*")) {
+    throw new Error(
+      "HTTP bearer token is required when CORS allows all origins. Set MCP_HTTP_TOKEN or pass --token, or restrict --allow-origin.",
+    );
+  }
   if (!bearerToken && !isLoopbackBindHost(opts.host)) {
     throw new Error(
       "HTTP bearer token is required when binding to a non-loopback host. Set MCP_HTTP_TOKEN or pass --token, or bind to 127.0.0.1.",
@@ -278,9 +287,6 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
   // `initialize` builds a fresh server below; GC reclaims it once the
   // transport closes (Protocol._onclose clears the transport reference).
   // See https://github.com/rps321321/obsidian-mcp-pro/issues/8.
-  const allowedOrigins = opts.allowedOrigins && opts.allowedOrigins.length > 0
-    ? opts.allowedOrigins
-    : ["http://localhost:*", "http://127.0.0.1:*", "http://[::1]:*"];
   if (allowedOrigins.includes("*")) {
     log.warn("CORS configured with wildcard origin '*'. Consider restricting to specific origins for production deployments.");
   }


### PR DESCRIPTION
HTTP startup now refuses `--allow-origin=*` unless bearer auth is configured. The previous loopback setup could start without a token and return `Access-Control-Allow-Origin: *`, which lets arbitrary browser origins read non-credentialed CORS responses under the Fetch CORS check.

Risk: low; default localhost-only CORS is unchanged, explicit origin allowlists are unchanged, and wildcard CORS still works with `--token` / `MCP_HTTP_TOKEN`.
Score: 3 severity x 2 reach / 1 effort = 6.
Tested: unauthenticated wildcard CORS repro returned 204 with `Access-Control-Allow-Origin: *` before the fix; npm test -- src/__tests__/regression-http-fixes.test.ts src/__tests__/http-server.test.ts; npm run typecheck; npm run lint; npm run verify.
Sources: https://fetch.spec.whatwg.org/#cors-check and https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS.

Greptile review is skipped because the trial review limit is exhausted.