### PR TITLE
fix: drop stale semantic hits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Display and error sanitization now escape Unicode bidi controls as `\uHHHH`, preventing vault-controlled names or snippets from visually reordering client output.
 - HTTP transport now refuses wildcard CORS (`--allow-origin=*`) unless bearer auth is configured, preventing unauthenticated loopback servers from exposing MCP responses to arbitrary browser origins.
+- `search_semantic` and `find_similar_notes` now prune stale embedding chunks before returning snippets or source-note vectors, preventing deleted or changed note text from persisting in semantic results.
 - Windows path resolution now rejects filename components ending in a space or period before permissions, excluded-directory checks, or attachment classification run.
 - `add_canvas_node` now accepts only absolute `http://` and `https://` URLs for Canvas link nodes, rejecting malformed, local-file, and application-protocol links before persistence.
 - Base YAML parsing now refuses anchors and aliases before `js-yaml` runs, preventing alias graphs from shaping Base filters, views, or serialized output.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Give AI assistants deep, structured access to your Obsidian knowledge base. Read
 - `index_vault` chunks each note (heading-aware), embeds via the configured provider, persists vectors to `<vault>/.obsidian/cache/`, and incrementally re-embeds only changed notes
 - `search_semantic` ranks notes by cosine similarity against an embedded query
 - `find_similar_notes` reuses an existing note's embeddings, with source-topic anchoring, to surface neighbors without a live API call
+- Stored snippets are returned only while the current note content hash still matches the indexed text; stale chunks are pruned on search
 
 ### MCP Resources
 - `obsidian://note/{path}` reads any note by its vault-relative path
@@ -314,7 +315,7 @@ Two caches live under `<vault>/.obsidian/cache/`:
 | File | Purpose |
 |------|---------|
 | `mcp-pro-index-cache.json` | mtime-keyed snapshot of recently read notes. The next process start hydrates from this and stat-passes against the live filesystem; only changed notes are re-read. |
-| `mcp-pro-embeddings.json` | Persisted embeddings for semantic search (only present once `index_vault` has run). Vault-relocation safe via an embedded `vaultRoot` check; switching providers / models invalidates entries automatically. |
+| `mcp-pro-embeddings.json` | Persisted embeddings for semantic search (only present once `index_vault` has run). Vault-relocation safe via an embedded `vaultRoot` check; switching providers/models or stale note content invalidates entries automatically. |
 
 Both are vault-local, are excluded from vault scans (`.obsidian/` is pruned), and can be deleted at any time. Oversized snapshots are ignored before loading so a corrupted or synced cache file cannot force an unbounded JSON parse. Persistence can be turned off entirely with `OBSIDIAN_CACHE_DISABLED=1`.
 
@@ -351,6 +352,7 @@ The server also declares the MCP [`logging` capability](https://modelcontextprot
 - **Regex edit safety** — `replace_in_note` caps regex pattern/input size and rejects backtracking-prone repeated groups before matching.
 - **Error and log sanitization** — filesystem error messages are stripped of absolute host paths before being returned to MCP clients, ASCII control bytes and Unicode bidi controls are escaped in displayed values, and note-derived duplicate-alias text is not copied into graph warnings. Uncaught HTTP errors respond with a generic `Internal server error` body; full detail stays in the server log.
 - **YAML parser boundaries** — Obsidian properties are parsed only from `---` YAML delimiter lines; non-YAML gray-matter language blocks stay as body text, oversized frontmatter is skipped on reads and refused for metadata updates, and note/Base YAML containing anchors or aliases is not parsed.
+- **Semantic index freshness** — `search_semantic` and `find_similar_notes` re-check current note content hashes before returning stored snippets or source-note embeddings, pruning stale cache entries instead of surfacing old note text.
 - **Bulk-write confirmations** — clients that support MCP elicitation are asked to re-type the destination path or new tag before `move_note` rewrites references or `rename_tag` writes across the vault. Dry runs and clients without elicitation keep their existing behavior.
 - **Atomic writes** — every note write (`create_note`, `append`, `prepend`, `update_frontmatter`, canvas mutations) stages content to a sibling temp file then renames onto the target, so a crash or kill mid-write never leaves a truncated file. Combined with per-path locks for the full read-modify-write cycle, concurrent callers can't lose each other's updates. The `install` subcommand uses the same pattern and keeps a backup of the previous config.
 - **Rate limiting + CORS allowlist** — optional `--rate-limit` caps per-IP request volume; `--allow-origin` restricts browser-facing CORS and refuses `*` unless bearer auth is enabled. `/health` and `/version` stay reachable under load for monitoring.

--- a/src/__tests__/embedding-store.test.ts
+++ b/src/__tests__/embedding-store.test.ts
@@ -8,6 +8,7 @@ import {
   hashText,
   noteIsCurrent,
   setNoteChunks,
+  dropNoteChunks,
   pruneMissingNotes,
   searchEmbeddings,
   cosineSimilarity,
@@ -244,6 +245,18 @@ describe("noteIsCurrent / pruneMissingNotes", () => {
     expect(pruned).toBe(1);
     const snap = snapshotForTests(vaultDir);
     expect(snap.totalNotes).toBe(1);
+  });
+
+  it("dropNoteChunks removes stored chunks and note hashes", async () => {
+    await loadStore(vaultDir);
+    setNoteChunks(vaultDir, "stale.md", "old-hash", [
+      { notePath: "stale.md", chunkIndex: 1, headingPath: [], text: "old", hash: "th", vector: [1] },
+    ], "test", "m");
+
+    expect(dropNoteChunks(vaultDir, "stale.md")).toBe(true);
+    expect(dropNoteChunks(vaultDir, "stale.md")).toBe(false);
+    expect(noteIsCurrent(vaultDir, "stale.md", "old-hash")).toBe(false);
+    expect(searchEmbeddings(vaultDir, [1], { limit: 5 })).toEqual([]);
   });
 });
 

--- a/src/__tests__/handlers/semantic.test.ts
+++ b/src/__tests__/handlers/semantic.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
 import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
 import { setProviderForTests, resetProviderForTests, type EmbeddingProvider } from "../../lib/embedding-providers.js";
 import { clearStore } from "../../lib/embedding-store.js";
@@ -199,6 +201,35 @@ describe("semantic handlers — search_semantic", () => {
     expect(text).not.toContain("private/secret.md");
     expect(text).not.toContain("private launch notes");
   });
+
+  it("drops stale snippets when an indexed note has changed", async () => {
+    await env.cleanup();
+    await clearStore(env.vaultDir, { removeSnapshot: true });
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "cats.md": "# Cats\n\nCats carry the stale launch instructions.",
+        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+      },
+    });
+
+    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await fs.writeFile(
+      path.join(env.vaultDir, "cats.md"),
+      "# Dogs\n\nThe current note is only about dogs.",
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "search_semantic",
+      arguments: { query: "cats", limit: 5 },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toMatch(/No matches/);
+    expect(text).not.toContain("stale launch instructions");
+  });
 });
 
 describe("semantic handlers — find_similar_notes", () => {
@@ -309,6 +340,36 @@ describe("semantic handlers — find_similar_notes", () => {
     expect(isError(result)).toBe(false);
     expect(text).toContain("public/dogs.md");
     expect(text).not.toContain("private/secret.md");
+  });
+
+  it("refuses stale source-note embeddings", async () => {
+    await env.cleanup();
+    await clearStore(env.vaultDir, { removeSnapshot: true });
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "source.md": "# Cats\n\nCats are the original source topic.",
+        "target.md": "# Target\n\nCats are nearby.",
+        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+      },
+    });
+
+    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await fs.writeFile(
+      path.join(env.vaultDir, "source.md"),
+      "# Weather\n\nThe current source topic is rain.",
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "find_similar_notes",
+      arguments: { path: "source.md", limit: 5 },
+    });
+
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toMatch(/No current embeddings found/);
+    expect(text).not.toContain("target.md");
   });
 });
 

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -412,6 +412,19 @@ export function setNoteChunks(
   state.dirty = true;
 }
 
+export function dropNoteChunks(vaultPath: string, notePath: string): boolean {
+  const state = stateFor(vaultPath);
+  const owned = state.byNote.get(notePath);
+  const hadHash = state.noteHashes.delete(notePath);
+  if (!owned && !hadHash) return false;
+  if (owned) {
+    for (const k of owned) state.byKey.delete(k);
+  }
+  state.byNote.delete(notePath);
+  state.dirty = true;
+  return true;
+}
+
 /** Drop chunks for notes that no longer exist in the vault. Called at the
  *  end of an index pass. */
 export function pruneMissingNotes(vaultPath: string, currentNotes: Iterable<string>): number {
@@ -420,15 +433,8 @@ export function pruneMissingNotes(vaultPath: string, currentNotes: Iterable<stri
   let pruned = 0;
   for (const note of Array.from(state.byNote.keys())) {
     if (live.has(note)) continue;
-    const owned = state.byNote.get(note);
-    if (owned) {
-      for (const k of owned) state.byKey.delete(k);
-    }
-    state.byNote.delete(note);
-    state.noteHashes.delete(note);
-    pruned++;
+    if (dropNoteChunks(vaultPath, note)) pruned++;
   }
-  if (pruned > 0) state.dirty = true;
   return pruned;
 }
 

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { listNotes, resolveVaultPath, vaultRewriteLockKey, withFileLock } from "../lib/vault.js";
+import { listNotes, readNote, resolveVaultPath, vaultRewriteLockKey, withFileLock } from "../lib/vault.js";
 import { readAllCached } from "../lib/index-cache.js";
 import { chunkNote } from "../lib/chunker.js";
 import { getActiveProvider } from "../lib/embedding-providers.js";
@@ -10,6 +10,7 @@ import {
   hashText,
   noteIsCurrent,
   setNoteChunks,
+  dropNoteChunks,
   pruneMissingNotes,
   searchEmbeddings,
   getNoteEmbeddings,
@@ -17,6 +18,7 @@ import {
   snapshotForTests,
   invalidateIfIncompatible,
   type ChunkEmbedding,
+  type SearchHit,
 } from "../lib/embedding-store.js";
 import { makeProgressReporter } from "../lib/progress.js";
 import { escapeControlChars, sanitizeError } from "../lib/errors.js";
@@ -51,6 +53,69 @@ function canReadStoredEmbeddingNote(vaultPath: string, notePath: string): boolea
   } catch {
     return false;
   }
+}
+
+async function storedNoteIsCurrent(vaultPath: string, notePath: string): Promise<boolean> {
+  try {
+    const content = await readNote(vaultPath, notePath);
+    return noteIsCurrent(vaultPath, notePath, hashText(content));
+  } catch {
+    return false;
+  }
+}
+
+async function pruneStaleStoredNote(vaultPath: string, notePath: string): Promise<boolean> {
+  const current = await storedNoteIsCurrent(vaultPath, notePath);
+  if (current) return false;
+  return dropNoteChunks(vaultPath, notePath);
+}
+
+interface FreshSearchOptions {
+  limit: number;
+  folder?: string;
+  excludeNotes?: ReadonlySet<string>;
+  filterNote?: (notePath: string) => boolean;
+}
+
+async function searchFreshEmbeddings(
+  vaultPath: string,
+  queryVector: number[],
+  options: FreshSearchOptions,
+): Promise<{ hits: SearchHit[]; stalePruned: number }> {
+  const hits: SearchHit[] = [];
+  const accepted = new Set<string>();
+  const stale = new Set<string>();
+  let stalePruned = 0;
+  for (let pass = 0; pass < 10 && hits.length < options.limit; pass++) {
+    const exclude = new Set<string>(options.excludeNotes);
+    for (const notePath of accepted) exclude.add(notePath);
+    for (const notePath of stale) exclude.add(notePath);
+    const batchLimit = Math.min(100, Math.max(options.limit - hits.length, 20));
+    const candidates = searchEmbeddings(vaultPath, queryVector, {
+      limit: batchLimit,
+      ...(options.folder ? { folder: options.folder } : {}),
+      ...(exclude.size > 0 ? { excludeNotes: exclude } : {}),
+      ...(options.filterNote ? { filterNote: options.filterNote } : {}),
+    });
+    if (candidates.length === 0) break;
+    let advanced = false;
+    for (const hit of candidates) {
+      if (accepted.has(hit.notePath)) continue;
+      if (await pruneStaleStoredNote(vaultPath, hit.notePath)) {
+        stale.add(hit.notePath);
+        stalePruned++;
+        advanced = true;
+        continue;
+      }
+      hits.push(hit);
+      accepted.add(hit.notePath);
+      advanced = true;
+      if (hits.length >= options.limit) break;
+    }
+    if (!advanced) break;
+  }
+  if (stalePruned > 0) await saveStore(vaultPath);
+  return { hits, stalePruned };
 }
 
 interface IndexProgress {
@@ -333,7 +398,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         if (!Array.isArray(vector)) {
           return errorResult("Provider did not return a vector for the query.");
         }
-        const hits = searchEmbeddings(vaultPath, vector, {
+        const { hits } = await searchFreshEmbeddings(vaultPath, vector, {
           limit,
           ...(folder ? { folder } : {}),
           filterNote: (notePath) => canReadStoredEmbeddingNote(vaultPath, notePath),
@@ -403,9 +468,15 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
             `No embeddings found for "${displaySemanticValue(notePath)}". Run \`index_vault\` first (or check the path is correct).`,
           );
         }
+        if (await pruneStaleStoredNote(vaultPath, notePath)) {
+          await saveStore(vaultPath);
+          return errorResult(
+            `No current embeddings found for "${displaySemanticValue(notePath)}". Run \`index_vault\` to refresh it.`,
+          );
+        }
         const queryVector = buildSimilarNotesQueryVector(ownChunks);
         const exclude = new Set([notePath]);
-        const hits = searchEmbeddings(vaultPath, queryVector, {
+        const { hits } = await searchFreshEmbeddings(vaultPath, queryVector, {
           limit,
           excludeNotes: exclude,
           filterNote: (hitPath) => canReadStoredEmbeddingNote(vaultPath, hitPath),


### PR DESCRIPTION
Semantic search now checks that stored note chunks still match the current note content before returning snippets or source-note vectors. Stale entries are pruned when search sees changed or missing notes, so old note text cannot keep showing up through `search_semantic` or drive `find_similar_notes` after the source note changed.

Risk: moderate; semantic searches may do a few live note reads for candidate freshness, but stale cache entries now self-heal and fresh indexed results keep the same ranking path.
Score: 3 severity x 2 reach / 2 effort = 3.
Tested: npm test -- src/__tests__/embedding-store.test.ts src/__tests__/handlers/semantic.test.ts src/__tests__/regression-embedding-fixes.test.ts src/__tests__/regression-embedding-fn.test.ts; npm run typecheck; npm run lint; npm run verify.

Greptile review is skipped because the trial review limit is exhausted.