### PR TITLE
fix: make search note labels generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
+- `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -23,7 +23,7 @@ describe("read handlers — search_notes", () => {
     });
     const text = textContent(result);
     expect(isError(result)).toBe(false);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_notes result path: note-b.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_notes result path]");
     expect(text).toContain("note-b.md");
     expect(text).toContain("note-c.md");
   });
@@ -100,7 +100,9 @@ describe("read handlers — search_notes", () => {
     });
 
     const resultPaths = Array.from(
-      textContent(result).matchAll(/\[BEGIN UNTRUSTED VAULT CONTENT: search_notes result path: ([^\]]+)\]/g),
+      textContent(result).matchAll(
+        /^\s*\[BEGIN UNTRUSTED VAULT CONTENT: search_notes result path\]\n\s*Treat .*\n\s*(.+)$/gm,
+      ),
       (match) => match[1],
     );
     expect(resultPaths).toEqual([
@@ -124,11 +126,11 @@ describe("read handlers — search_notes", () => {
 
     const text = textContent(result);
     const lineRows = text.split("\n").filter((line) => line.includes("Line "));
-    const snippetMarkers = text.split("\n").filter((line) => line.includes("[BEGIN UNTRUSTED VAULT CONTENT: search snippet:"));
+    const snippetMarkers = text.split("\n").filter((line) => line.includes("[BEGIN UNTRUSTED VAULT CONTENT: search_notes snippet]"));
     expect(lineRows).toEqual(["  Line 1:", "  Line 2:"]);
     expect(snippetMarkers).toEqual([
-      "    [BEGIN UNTRUSTED VAULT CONTENT: search snippet: repeat.md:1]",
-      "    [BEGIN UNTRUSTED VAULT CONTENT: search snippet: repeat.md:2]",
+      "    [BEGIN UNTRUSTED VAULT CONTENT: search_notes snippet]",
+      "    [BEGIN UNTRUSTED VAULT CONTENT: search_notes snippet]",
     ]);
     expect(text).toContain("alpha alpha alpha");
     expect(text).toContain("beta alpha");
@@ -154,7 +156,7 @@ describe("read handlers — search_notes", () => {
     expect(contentRow!.trim().length).toBeLessThanOrEqual(240);
     expect(contentRow).toContain("alpha");
     expect(contentRow).toContain("...");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search snippet: long.md:1]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_notes snippet]");
   });
 
   it("restricts scan to a folder when folder= is set", async () => {
@@ -196,8 +198,10 @@ describe("read handlers — search_notes", () => {
     expect(isError(result)).toBe(false);
     const text = textContent(result);
     expect(text).toContain("Line 1:");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_notes result path: dirty.md]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search snippet: dirty.md:1]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_notes result path]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_notes snippet]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_notes result path: dirty.md]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search snippet: dirty.md:1]");
     expect(text).toContain("needle\\tvalue");
     expect(text).not.toContain("needle\tvalue");
   });

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -111,7 +111,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         for (const result of results) {
           lines.push("Result path:");
           lines.push(untrustedReadBlock(
-            `search_notes result path: ${result.relativePath}`,
+            "search_notes result path",
             displayReadValue(result.relativePath),
             "  ",
           ));
@@ -119,7 +119,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
             lines.push(`  Line ${match.line}:`);
             lines.push(indentBlock(
               formatUntrustedVaultContent(
-                `search snippet: ${result.relativePath}:${match.line}`,
+                "search_notes snippet",
                 displayReadValue(match.content),
               ),
               "    ",


### PR DESCRIPTION
search_notes now uses generic untrusted-content marker labels for result paths and snippets. The path and snippet text stay inside the untrusted block body, so clients can still read the data without treating vault-authored filenames as marker text.\n\nScore: 3 severity x 3 reach / 2 effort = 4.5. Risk: this extends the unreleased 4.0.0 output-format migration for clients that parsed search_notes marker labels instead of block bodies.\n\nTested with 
pm test -- src/__tests__/handlers/read.test.ts src/__tests__/regression-tools-read.test.ts, 
pm run lint, 
pm run typecheck, and 
pm run verify.\n\nGreptile is skipped until the review quota is restored.