### PR TITLE
fix: make frontmatter search labels generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.
+- `search_by_frontmatter` result path and frontmatter marker labels are now generic; clients should read those values from inside the untrusted block body.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -573,8 +573,9 @@ describe("read handlers — search_by_frontmatter", () => {
     });
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_frontmatter result path: note-a.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_frontmatter result path]");
     expect(text).toContain("note-a.md");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_frontmatter result path: note-a.md]");
     expect(text).not.toContain("note-b.md");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
   });
@@ -657,8 +658,12 @@ describe("read handlers — search_by_frontmatter", () => {
     expect(isError(result)).toBe(false);
     const text = textContent(result);
     expect(text).toContain('"status" matches "tab\\tvalue"');
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_frontmatter result path: frontmatter-dirty.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_frontmatter result path]");
+    expect(text).toContain("frontmatter-dirty.md");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_frontmatter values]");
     expect(text).toContain('status: "tab\\tvalue"');
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_frontmatter result path: frontmatter-dirty.md]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: frontmatter: frontmatter-dirty.md]");
     expect(text).not.toContain("tab\tvalue");
   });
 

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -491,7 +491,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         for (const match of matches) {
           lines.push("Result path:");
           lines.push(untrustedReadBlock(
-            `search_by_frontmatter result path: ${match.path}`,
+            "search_by_frontmatter result path",
             displayReadValue(match.path),
             "  ",
           ));
@@ -501,7 +501,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
           }
           if (frontmatterLines.length > 0) {
             lines.push(indentBlock(
-              formatUntrustedVaultContent(`frontmatter: ${match.path}`, frontmatterLines.join("\n")),
+              formatUntrustedVaultContent("search_by_frontmatter values", frontmatterLines.join("\n")),
               "  ",
             ));
           }


### PR DESCRIPTION
`search_by_frontmatter` now uses generic untrusted-content marker labels for result paths and frontmatter rows. The path and frontmatter values stay inside the untrusted block bodies, so clients can still read them without vault-authored filenames appearing in marker text.

Score: 3 severity x 2 reach / 2 effort = 3. Risk: this extends the unreleased 4.0.0 output-format migration for clients that parsed frontmatter-search marker labels instead of block bodies.

Tested with `npm test -- src/__tests__/handlers/read.test.ts src/__tests__/regression-tools-read.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.