### PR TITLE
fix: make tag search labels generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.
 - `search_by_frontmatter` result path and frontmatter marker labels are now generic; clients should read those values from inside the untrusted block body.
+- `search_by_tag` result path and preview marker labels are now generic; clients should read the path or preview from inside the untrusted block body.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/handlers/tags.test.ts
+++ b/src/__tests__/handlers/tags.test.ts
@@ -90,10 +90,12 @@ describe("tag handlers — search_by_tag", () => {
     });
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: note-a.md]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: note-b.md]");
+    const pathMarkers = [...text.matchAll(/\[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path\]/g)];
+    expect(pathMarkers).toHaveLength(2);
     expect(text).toContain("note-a.md");
     expect(text).toContain("note-b.md");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: note-a.md]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: note-b.md]");
     expect(text).not.toContain("orphan.md");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
   });
@@ -148,13 +150,15 @@ describe("tag handlers — search_by_tag", () => {
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     // The body of note-b starts with its frontmatter delimiter in a preview.
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: note-a.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path]");
     expect(text).toContain("note-a.md");
     expect(text).toContain("note-b.md");
     // Frontmatter is now stripped from previews, so verify body content appears instead.
     expect(text).toMatch(/Note A|Note B/);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: tag preview: note-a.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag preview]");
     expect(text).toContain("# Note A\\n\\nLinks to [[note-b]]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: note-a.md]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: tag preview: note-a.md]");
     expect(text).not.toContain("# Note A\n\nLinks to [[note-b]]");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
   });
@@ -186,8 +190,9 @@ describe("tag handlers — search_by_tag", () => {
 
     expect(isError(result)).toBe(false);
     const text = textContent(result);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: fresh-tag.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path]");
     expect(text).toContain("fresh-tag.md");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: fresh-tag.md]");
   });
 });
 

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -263,14 +263,14 @@ export function registerTagTools(server: McpServer, vaultPath: string): void {
         for (const note of matchingNotes) {
           lines.push("Path:");
           lines.push(untrustedTagBlock(
-            `search_by_tag result path: ${note.path}`,
+            "search_by_tag result path",
             displayTagValue(note.path),
             "  ",
           ));
           if (note.preview) {
             lines.push("  Preview:");
             lines.push(indentBlock(
-              formatUntrustedVaultContent(`tag preview: ${note.path}`, displayTagValue(note.preview)),
+              formatUntrustedVaultContent("search_by_tag preview", displayTagValue(note.preview)),
               "    ",
             ));
             lines.push("");


### PR DESCRIPTION
`search_by_tag` now uses generic untrusted-content marker labels for result paths and previews. The path and preview values stay inside the untrusted block bodies, so clients can still read them without vault-authored filenames appearing in marker text.

Score: 3 severity x 2 reach / 2 effort = 3. Risk: this extends the unreleased 4.0.0 output-format migration for clients that parsed tag-search marker labels instead of block bodies.

Tested with `npm test -- src/__tests__/handlers/tags.test.ts src/__tests__/regression-tools-tags.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.