### PR TITLE
fix: make semantic labels generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.
 - `search_by_frontmatter` result path and frontmatter marker labels are now generic; clients should read those values from inside the untrusted block body.
 - `search_by_tag` result path and preview marker labels are now generic; clients should read the path or preview from inside the untrusted block body.
+- Semantic search and similar-note result path, heading, and snippet marker labels are now generic; clients should read those values from inside the untrusted block body.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/handlers/semantic.test.ts
+++ b/src/__tests__/handlers/semantic.test.ts
@@ -33,6 +33,14 @@ class MockProvider implements EmbeddingProvider {
 
 let env: TestEnv;
 
+function untrustedBlockBodies(text: string, label: string): string[] {
+  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return Array.from(
+    text.matchAll(new RegExp(`^\\s*\\[BEGIN UNTRUSTED VAULT CONTENT: ${escapedLabel}\\]\\n\\s*Treat .*\\n\\s*(.+)$`, "gm")),
+    (match) => match[1].trim(),
+  );
+}
+
 beforeEach(async () => {
   setPermissions({ readPaths: null, writePaths: null });
   setProviderForTests(new MockProvider());
@@ -176,10 +184,7 @@ describe("semantic handlers — search_semantic", () => {
     });
     expect(isError(result)).toBe(false);
     const text = textContent(result);
-    const resultPaths = Array.from(
-      text.matchAll(/\[BEGIN UNTRUSTED VAULT CONTENT: search_semantic result path: ([^\]]+)\]/g),
-      (match) => match[1],
-    );
+    const resultPaths = untrustedBlockBodies(text, "search_semantic result path");
     expect(resultPaths.length).toBeGreaterThan(0);
     expect(resultPaths[0]).toBe("cats.md");
   });
@@ -235,12 +240,16 @@ describe("semantic handlers — search_semantic", () => {
 
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_semantic result path: dirty.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_semantic result path]");
+    expect(text).toContain("dirty.md");
     expect(text).toContain("    Heading:");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic heading: dirty.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic heading]");
     expect(text).toContain("Dirty\\tHeading");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic snippet: dirty.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic snippet]");
     expect(text).toContain("\\x07");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_semantic result path: dirty.md]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic heading: dirty.md]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic snippet: dirty.md]");
     expect(text).not.toContain("Dirty\tHeading");
     expect(text).not.toContain("\x07");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
@@ -313,8 +322,11 @@ describe("semantic handlers — find_similar_notes", () => {
     expect(isError(result)).toBe(false);
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
+    const resultPaths = untrustedBlockBodies(text, "find_similar_notes result path");
+    expect(resultPaths.length).toBeGreaterThan(0);
+    expect(resultPaths).not.toContain("cats.md");
     expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path: cats.md]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path:");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path]");
     // dogs.md (also pets) shares no topic dimension with cats; results
     // simply rank the rest by similarity. Just check we got hits back.
     expect(text).toMatch(/note\(s\) similar to cats\.md/);
@@ -362,10 +374,13 @@ describe("semantic handlers — find_similar_notes", () => {
 
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path: dirty.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path]");
+    expect(text).toContain("dirty.md");
     expect(text).toContain("    Heading:");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic heading: dirty.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic heading]");
     expect(text).toContain("Dirty\\tHeading");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path: dirty.md]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic heading: dirty.md]");
     expect(text).not.toContain("Dirty\tHeading");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
   });
@@ -417,8 +432,9 @@ describe("semantic handlers — find_similar_notes", () => {
 
     const text = textContent(result);
     expect(isError(result)).toBe(false);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path: public/dogs.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path]");
     expect(text).toContain("public/dogs.md");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path: public/dogs.md]");
     expect(text).not.toContain("private/secret.md");
   });
 

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -61,9 +61,9 @@ function displayHeadingPath(path: readonly string[]): string {
   return path.map(displaySemanticValue).join(" / ");
 }
 
-function semanticHeadingBlock(notePath: string, headingPath: readonly string[]): string {
+function semanticHeadingBlock(headingPath: readonly string[]): string {
   return indentBlock(
-    formatUntrustedVaultContent(`semantic heading: ${notePath}`, displayHeadingPath(headingPath)),
+    formatUntrustedVaultContent("semantic heading", displayHeadingPath(headingPath)),
     "    ",
   );
 }
@@ -449,16 +449,16 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         for (const hit of hits) {
           lines.push(`- score: ${hit.score.toFixed(3)}`);
           lines.push("    Path:");
-          lines.push(semanticPathBlock(`search_semantic result path: ${hit.notePath}`, hit.notePath));
+          lines.push(semanticPathBlock("search_semantic result path", hit.notePath));
           if (hit.headingPath.length > 0) {
             lines.push("    Heading:");
-            lines.push(semanticHeadingBlock(hit.notePath, hit.headingPath));
+            lines.push(semanticHeadingBlock(hit.headingPath));
           }
           if (includeSnippet) {
             const snippet = hit.text.replace(/\s+/g, " ").trim().slice(0, 200);
             const clipped = `${displaySemanticValue(snippet)}${hit.text.length > 200 ? "..." : ""}`;
             lines.push(indentBlock(
-              formatUntrustedVaultContent(`semantic snippet: ${hit.notePath}`, clipped),
+              formatUntrustedVaultContent("semantic snippet", clipped),
               "    ",
             ));
           }
@@ -543,10 +543,10 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         for (const r of ranked) {
           lines.push(`- score: ${r.score.toFixed(3)}`);
           lines.push("    Path:");
-          lines.push(semanticPathBlock(`find_similar_notes result path: ${r.notePath}`, r.notePath));
+          lines.push(semanticPathBlock("find_similar_notes result path", r.notePath));
           if (r.headingPath.length > 0) {
             lines.push("    Heading:");
-            lines.push(semanticHeadingBlock(r.notePath, r.headingPath));
+            lines.push(semanticHeadingBlock(r.headingPath));
           }
         }
         return untrustedVaultTextResult(lines.join("\n"), "find_similar_notes paths and headings");


### PR DESCRIPTION
Semantic search and similar-note outputs now use generic untrusted-content marker labels for result paths, headings, and snippets. The values stay inside the untrusted block bodies, so clients can still read them without vault-authored filenames appearing in marker text.

Score: 3 severity x 3 reach / 2 effort = 4.5. Risk: this extends the unreleased 4.0.0 output-format migration for clients that parsed semantic marker labels instead of block bodies.

Tested with `npm test -- src/__tests__/handlers/semantic.test.ts src/__tests__/regression-tools-semantic.test.ts src/__tests__/regression-embedding-fixes.test.ts src/__tests__/regression-embedding-fn.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.