### PR TITLE
fix: make note read labels generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `search_by_tag` result path and preview marker labels are now generic; clients should read the path or preview from inside the untrusted block body.
 - Semantic search and similar-note result path, heading, and snippet marker labels are now generic; clients should read those values from inside the untrusted block body.
 - Base read and row-frontmatter marker labels are now generic; clients should read Base paths, row paths, and frontmatter values from inside the untrusted block body.
+- `get_note` and `get_daily_note` body and fragment marker labels are now generic; clients should use the requested tool arguments for note identity and read returned note text from inside the untrusted block body.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -229,7 +229,8 @@ describe("read handlers — get_note", () => {
     expect(text).toContain("Tags:");
     expect(text).toContain("draft");
     expect(text).toContain("Links to");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: note: note-a.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_note body]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: note: note-a.md]");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
   });
 
@@ -307,7 +308,8 @@ describe("read handlers — get_note", () => {
 
     expect(isError(result)).toBe(false);
     const text = textContent(result);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: note fragment: long.md lines 2-2]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_note fragment]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: note fragment: long.md lines 2-2]");
     expect(text).toContain("\nsecond\n");
   });
 
@@ -383,7 +385,8 @@ describe("read handlers — get_note", () => {
 
     expect(isError(result)).toBe(false);
     const text = textContent(result);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: note fragment: line-fragment.md lines 5-6]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_note fragment]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: note fragment: line-fragment.md lines 5-6]");
     expect(text).toContain("\ntwo\nthree\n");
     expect(text).not.toContain("Frontmatter");
     expect(text).not.toContain("Tags:");
@@ -419,7 +422,8 @@ describe("read handlers — get_note", () => {
 
     expect(isError(after)).toBe(false);
     const text = textContent(after);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: note fragment: fresh-lines.md lines 2-2]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_note fragment]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: note fragment: fresh-lines.md lines 2-2]");
     expect(text).toContain("\nnew\n");
   });
 });
@@ -491,6 +495,8 @@ describe("read handlers — get_daily_note", () => {
     });
     const text = textContent(result);
     expect(isError(result)).toBe(false);
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_daily_note body]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: daily note: daily/2026-04-24.md]");
     expect(text).toContain("Daily Note: 2026-04-24");
     expect(text).toContain("daily/2026-04-24.md");
     expect(text).toContain("Daily note fixture");

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -188,7 +188,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
               return errorResult(`Line ${range.pastEndLine.requested} is past end of file (${range.pastEndLine.total} lines)`);
             }
             return {
-              content: [untrustedTextContent(`note fragment: ${notePath} lines ${a}-${b}`, range.text)],
+              content: [untrustedTextContent("get_note fragment", range.text)],
             };
           }
         }
@@ -205,7 +205,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
             return errorResult(`Section not found: "${displayReadValue(section)}" in ${displayReadValue(notePath)}`);
           }
           return {
-            content: [untrustedTextContent(`note section: ${notePath}#${section}`, content.slice(found.start, found.end))],
+            content: [untrustedTextContent("get_note section", content.slice(found.start, found.end))],
           };
         }
 
@@ -215,7 +215,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
             return errorResult(`Block not found: "^${displayReadValue(block)}" in ${displayReadValue(notePath)}`);
           }
           return {
-            content: [untrustedTextContent(`note block: ${notePath}^${block}`, stripBlockId(content.slice(found.start, found.end)))],
+            content: [untrustedTextContent("get_note block", stripBlockId(content.slice(found.start, found.end)))],
           };
         }
 
@@ -230,7 +230,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
           }
           const slice = allLines.slice(a - 1, Math.min(b, allLines.length));
           return {
-            content: [untrustedTextContent(`note fragment: ${notePath} lines ${a}-${b}`, slice.join("\n"))],
+            content: [untrustedTextContent("get_note fragment", slice.join("\n"))],
           };
         }
 
@@ -259,8 +259,8 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
           content: [
             {
               type: "text" as const,
-              text: formatUntrustedVaultContent(`note: ${notePath}`, renderedNote),
-              _meta: untrustedVaultContentMeta(`note: ${notePath}`),
+              text: formatUntrustedVaultContent("get_note body", renderedNote),
+              _meta: untrustedVaultContentMeta("get_note body"),
             },
           ],
         };
@@ -395,8 +395,8 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
           content: [
             {
               type: "text" as const,
-              text: formatUntrustedVaultContent(`daily note: ${notePath}`, header.join("\n") + dailyBody),
-              _meta: untrustedVaultContentMeta(`daily note: ${notePath}`),
+              text: formatUntrustedVaultContent("get_daily_note body", header.join("\n") + dailyBody),
+              _meta: untrustedVaultContentMeta("get_daily_note body"),
             },
           ],
         };


### PR DESCRIPTION
`get_note` and `get_daily_note` now use generic untrusted-content marker labels for full bodies, fragments, sections, and blocks. Returned note text is unchanged inside the blocks; clients should use the tool arguments for note identity instead of parsing marker labels.

Score: 3 severity x 3 reach / 2 effort = 4.5. Risk: this extends the unreleased 4.0.0 output-format migration for clients that parsed note marker labels instead of using tool arguments and block bodies.

Tested with `npm test -- src/__tests__/handlers/read.test.ts src/__tests__/regression-tools-read.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.