### PR TITLE
fix: make failed-path labels generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Semantic search and similar-note result path, heading, and snippet marker labels are now generic; clients should read those values from inside the untrusted block body.
 - Base read and row-frontmatter marker labels are now generic; clients should read Base paths, row paths, and frontmatter values from inside the untrusted block body.
 - `get_note` and `get_daily_note` body and fragment marker labels are now generic; clients should use the requested tool arguments for note identity and read returned note text from inside the untrusted block body.
+- Failed-path warning marker labels for write, tag-rename, and semantic-index summaries are now generic; clients should read the failed path and error from inside the untrusted block body.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/handlers/semantic.test.ts
+++ b/src/__tests__/handlers/semantic.test.ts
@@ -167,8 +167,9 @@ describe("semantic handlers — index_vault", () => {
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     expect(isError(result)).toBe(false);
     expect(text).toContain("Failures:        1");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: index_vault failed note: dirty\\x7fsemantic.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: index_vault failed note]");
     expect(text).toContain("dirty\\x7fsemantic.md: provider failed");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: index_vault failed note: dirty\\x7fsemantic.md]");
     expect(text).not.toContain(dirtyPath);
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
     expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("index_vault failed notes");

--- a/src/__tests__/handlers/tags.test.ts
+++ b/src/__tests__/handlers/tags.test.ts
@@ -252,8 +252,9 @@ describe("tag handlers — rename_tag", () => {
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     expect(isError(result)).toBe(false);
     expect(text).toContain("Skipped due to errors: 1");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: rename_tag failed note: dirty\\x7ffailed.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: rename_tag failed note]");
     expect(text).toContain("dirty\\x7ffailed.md: Note file exceeds size cap");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: rename_tag failed note: dirty\\x7ffailed.md]");
     expect(text).not.toContain(dirtyPath);
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
     expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("rename_tag failed notes");

--- a/src/__tests__/handlers/write.test.ts
+++ b/src/__tests__/handlers/write.test.ts
@@ -471,8 +471,9 @@ describe("write handlers — move_note", () => {
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     expect(isError(result)).toBe(false);
     expect(text).toContain("Warning: 1 file(s) could not be updated:");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: move_note failed referrer: dirty\\x7fref.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: move_note failed referrer]");
     expect(text).toContain("dirty\\x7fref.md: content changed during move; references not updated");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: move_note failed referrer: dirty\\x7fref.md]");
     expect(text).not.toContain(dirtyPath);
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
     expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("move_note failed referrers");
@@ -564,8 +565,9 @@ describe("write handlers — delete_note", () => {
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     expect(isError(result)).toBe(false);
     expect(text).toContain("Warning: 1 file(s) could not be updated:");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: delete_note failed referrer: dirty\\x7fdelete-ref.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: delete_note failed referrer]");
     expect(text).toContain("dirty\\x7fdelete-ref.md: content changed during move; references not updated");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: delete_note failed referrer: dirty\\x7fdelete-ref.md]");
     expect(text).not.toContain(dirtyPath);
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
     expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("delete_note failed referrers");

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -355,7 +355,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
           lines.push(`  Failures:        ${stats.failed.length}`);
           for (const f of stats.failed.slice(0, 5)) {
             lines.push(formatUntrustedFailedPath(
-              `index_vault failed note: ${f.path}`,
+              "index_vault failed note",
               f.path,
               f.error,
               "    ",

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -443,7 +443,7 @@ export function registerTagTools(server: McpServer, vaultPath: string): void {
           lines.push(`  Skipped due to errors: ${failed.length}`);
           for (const f of failed.slice(0, 5)) {
             lines.push(formatUntrustedFailedPath(
-              `rename_tag failed note: ${f.path}`,
+              "rename_tag failed note",
               f.path,
               f.error,
               "    ",

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -414,7 +414,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
             lines.push(`Warning: ${result.failedReferrers.length} file(s) could not be updated:`);
             for (const f of result.failedReferrers.slice(0, MAX_DISPLAY)) {
               lines.push(formatUntrustedFailedPath(
-                `move_note failed referrer: ${f.path}`,
+                "move_note failed referrer",
                 f.path,
                 f.error,
               ));
@@ -561,7 +561,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
             lines.push(`Warning: ${result.failedReferrers.length} file(s) could not be updated:`);
             for (const f of result.failedReferrers.slice(0, MAX_DISPLAY)) {
               lines.push(formatUntrustedFailedPath(
-                `delete_note failed referrer: ${f.path}`,
+                "delete_note failed referrer",
                 f.path,
                 f.error,
               ));


### PR DESCRIPTION
Failed-path warnings for write referrers, tag rename skips, and semantic indexing now use generic untrusted-content marker labels. The failed path and sanitized error remain inside each untrusted block body without vault-authored filenames appearing in marker text.

Score: 3 severity x 3 reach / 1 effort = 9. Risk: this extends the unreleased 4.0.0 output-format migration for clients that parsed warning marker labels instead of block bodies.

Tested with `npm test -- src/__tests__/handlers/write.test.ts src/__tests__/regression-tools-write.test.ts src/__tests__/handlers/tags.test.ts src/__tests__/regression-tools-tags.test.ts src/__tests__/handlers/semantic.test.ts src/__tests__/regression-tools-semantic.test.ts src/__tests__/regression-embedding-fixes.test.ts src/__tests__/regression-embedding-fn.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.