### PR TITLE
fix: make link context labels generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Base read and row-frontmatter marker labels are now generic; clients should read Base paths, row paths, and frontmatter values from inside the untrusted block body.
 - `get_note` and `get_daily_note` body and fragment marker labels are now generic; clients should use the requested tool arguments for note identity and read returned note text from inside the untrusted block body.
 - Failed-path warning marker labels for write, tag-rename, and semantic-index summaries are now generic; clients should read the failed path and error from inside the untrusted block body.
+- Link context and target marker labels are now generic; clients should read backlink context, outlink targets, and broken-link targets from inside the untrusted block body.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/handlers/links.test.ts
+++ b/src/__tests__/handlers/links.test.ts
@@ -86,7 +86,8 @@ describe("link handlers — get_backlinks", () => {
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     expect(text).toContain("Links to [[note-a]]\\twith tab.");
     expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_backlinks source path]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: backlink context: tab-backlink.md:");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_backlinks context]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: backlink context: tab-backlink.md:");
     expect(text).not.toContain("note-a]]\twith tab");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
   });
@@ -139,7 +140,8 @@ describe("link handlers — get_outlinks", () => {
     expect(isError(result)).toBe(false);
     expect(text).toContain("Outgoing links from:");
     expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks source path]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: outlink target: warm-new-source.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks target]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: outlink target: warm-new-source.md]");
     expect(text).toContain("note-a");
     expect(text).toContain("note-a.md");
   });
@@ -179,8 +181,9 @@ describe("link handlers — get_outlinks", () => {
     });
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: broken outlink target: tab-outlink.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks broken target]");
     expect(text).toContain("bad\\ttarget");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: broken outlink target: tab-outlink.md]");
     expect(text).not.toContain("bad\ttarget");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
   });
@@ -276,8 +279,9 @@ describe("link handlers — find_broken_links", () => {
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_broken_links source path]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: broken link target: tab-broken-report.md:");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_broken_links target]");
     expect(text).toContain("bad\\ttarget");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: broken link target: tab-broken-report.md:");
     expect(text).not.toContain("bad\ttarget");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
   });

--- a/src/__tests__/regression-tools-links.test.ts
+++ b/src/__tests__/regression-tools-links.test.ts
@@ -147,7 +147,8 @@ describe("H6: get_backlinks resolves alias references with line + context", () =
     // resolves to null, relevantLinks is empty, and the source is rendered
     // as `- linker.md` with no `:N → context` suffix.
     expect(text).toMatch(/linker\.md:\d+/);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: backlink context: linker.md:");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_backlinks context]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: backlink context: linker.md:");
     expect(text).toContain("I reference [[My Project]]");
   });
 });
@@ -174,7 +175,8 @@ describe("M11: get_outlinks resolves alias references via the link graph", () =>
     expect(text).toContain("aliased.md");
     // The valid-links section must retain the target text the user wrote,
     // but it is note-authored text, so it belongs inside an untrusted block.
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: outlink target: linker.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks target]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: outlink target: linker.md]");
     expect(text).toContain("My Project");
   });
 

--- a/src/tools/links.ts
+++ b/src/tools/links.ts
@@ -548,7 +548,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
           if (r.context) {
             outputLines.push(indentBlock(
               `→ ${formatUntrustedVaultContent(
-                `backlink context: ${r.source}:${r.line}`,
+                "get_backlinks context",
                 displayLinkValue(r.context),
               )}`,
               "  ",
@@ -640,7 +640,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
               `${displayLinkValue(r.resolvedPath ?? "")}${r.isEmbed ? " (embed)" : ""}`,
               "    ",
             ));
-            pushUntrustedLinkTarget(lines, `outlink target: ${resolvedSource}`, r.target, "    ");
+            pushUntrustedLinkTarget(lines, "get_outlinks target", r.target, "    ");
           }
         }
 
@@ -648,7 +648,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
           lines.push("\nBroken links:");
           for (const r of broken) {
             lines.push(`  - unresolved${r.isEmbed ? " (embed)" : ""}`);
-            pushUntrustedLinkTarget(lines, `broken outlink target: ${resolvedSource}`, r.target, "    ");
+            pushUntrustedLinkTarget(lines, "get_outlinks broken target", r.target, "    ");
           }
         }
 
@@ -846,7 +846,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
             if (shown >= maxResults) break;
             const lineStr = bl.line > 0 ? ` (line ${bl.line})` : "";
             lines.push(`  - broken link${lineStr}`);
-            pushUntrustedLinkTarget(lines, `broken link target: ${sourcePath}:${bl.line}`, bl.targetLink, "    ");
+            pushUntrustedLinkTarget(lines, "find_broken_links target", bl.targetLink, "    ");
             shown++;
           }
           lines.push("");


### PR DESCRIPTION
Link context and target outputs now use generic untrusted-content marker labels. Backlink context, outlink targets, and broken-link targets stay inside the untrusted block bodies without source note paths appearing in marker text.

Score: 3 severity x 3 reach / 2 effort = 4.5. Risk: this extends the unreleased 4.0.0 output-format migration for clients that parsed link marker labels instead of block bodies.

Tested with `npm test -- src/__tests__/handlers/links.test.ts src/__tests__/regression-tools-links.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.