### PR TITLE
fix: make canvas marker labels generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_note` and `get_daily_note` body and fragment marker labels are now generic; clients should use the requested tool arguments for note identity and read returned note text from inside the untrusted block body.
 - Failed-path warning marker labels for write, tag-rename, and semantic-index summaries are now generic; clients should read the failed path and error from inside the untrusted block body.
 - Link context and target marker labels are now generic; clients should read backlink context, outlink targets, and broken-link targets from inside the untrusted block body.
+- Canvas summary marker labels and trust metadata are now generic; clients should read Canvas paths, node ids, node previews, colors, endpoints, and edge labels from inside the untrusted block body.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/handlers/canvas.test.ts
+++ b/src/__tests__/handlers/canvas.test.ts
@@ -47,10 +47,13 @@ describe("canvas handlers — read_canvas", () => {
     expect(text).toContain("[n2] type=file");
     expect(text).toContain("note-a.md");
     expect(text).toContain("n1 -> n2");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas edge label: boards/test.canvas#e1]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas edge label]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas edge label: boards/test.canvas#e1]");
     expect(text).toContain("refs");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas node content: boards/test.canvas#n1]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas node content]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas node content: boards/test.canvas#n1]");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("read_canvas summary");
   });
 
   it("serves repeated reads without changing the rendered summary", async () => {
@@ -241,16 +244,21 @@ describe("canvas handlers — read_canvas", () => {
     });
     expect(isError(result)).toBe(false);
     const text = textContent(result);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas node identity: dirty.canvas#bad\\nnode]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas node identity]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas node identity: dirty.canvas#bad\\nnode]");
     expect(text).toContain("[bad\\nnode] type=text");
     expect(text).toContain("content:");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas node content: dirty.canvas#bad\\nnode]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas node content]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas node content: dirty.canvas#bad\\nnode]");
     expect(text).toContain("first\\nsecond");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas node color: dirty.canvas#bad\\nnode]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas node color]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas node color: dirty.canvas#bad\\nnode]");
     expect(text).toContain("red\\nblue");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas edge endpoints: dirty.canvas#edge-1]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas edge endpoints]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas edge endpoints: dirty.canvas#edge-1]");
     expect(text).toContain("bad\\nnode -> clean (from-side=left\\nside to-side=right)");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas edge label: dirty.canvas#edge-1]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas edge label]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas edge label: dirty.canvas#edge-1]");
     expect(text).toContain("label\\nspoof");
     expect(text).not.toContain("bad\nnode");
     expect(text).not.toContain("red\nblue");

--- a/src/tools/canvas.ts
+++ b/src/tools/canvas.ts
@@ -126,7 +126,7 @@ function renderCanvasSummary(canvasPath: string, data: CanvasData): string {
 
       lines.push("  Node:");
       lines.push(untrustedCanvasBlock(
-        `canvas node identity: ${canvasPath}#${node.id}`,
+        "read_canvas node identity",
         `[${displayCanvasValue(node.id)}] type=${displayCanvasValue(node.type)}`,
         "    ",
       ));
@@ -135,7 +135,7 @@ function renderCanvasSummary(canvasPath: string, data: CanvasData): string {
         lines.push("    content:");
         lines.push(indentBlock(
           formatUntrustedVaultContent(
-            `canvas node content: ${canvasPath}#${node.id}`,
+            "read_canvas node content",
             displayCanvasValue(preview),
           ),
           "      ",
@@ -144,7 +144,7 @@ function renderCanvasSummary(canvasPath: string, data: CanvasData): string {
       if (node.color) {
         lines.push("    color:");
         lines.push(untrustedCanvasBlock(
-          `canvas node color: ${canvasPath}#${node.id}`,
+          "read_canvas node color",
           displayCanvasValue(node.color),
           "      ",
         ));
@@ -168,7 +168,7 @@ function renderCanvasSummary(canvasPath: string, data: CanvasData): string {
       const sideInfo = sides ? ` (${sides})` : "";
       lines.push("  Edge:");
       lines.push(untrustedCanvasBlock(
-        `canvas edge endpoints: ${canvasPath}#${edge.id}`,
+        "read_canvas edge endpoints",
         `${displayCanvasValue(edge.fromNode)} -> ${displayCanvasValue(edge.toNode)}${sideInfo}`,
         "    ",
       ));
@@ -176,7 +176,7 @@ function renderCanvasSummary(canvasPath: string, data: CanvasData): string {
         lines.push("    label:");
         lines.push(indentBlock(
           formatUntrustedVaultContent(
-            `canvas edge label: ${canvasPath}#${edge.id}`,
+            "read_canvas edge label",
             displayCanvasValue(edge.label),
           ),
           "      ",
@@ -283,7 +283,7 @@ export function registerCanvasTools(server: McpServer, vaultPath: string): void 
           content: [{
             type: "text" as const,
             text,
-            _meta: untrustedVaultContentMeta(`canvas summary: ${canvasPath}`),
+            _meta: untrustedVaultContentMeta("read_canvas summary"),
           }],
         };
       } catch (err) {


### PR DESCRIPTION
Canvas summaries now use generic untrusted-content marker labels and generic trust metadata. Canvas paths, node ids, previews, colors, endpoints, and edge labels stay inside the untrusted block bodies instead of boundary labels.

Score: 3 severity x 2 reach / 1 effort = 6. Risk: this extends the unreleased 4.0.0 output-format migration for clients that parsed Canvas marker labels instead of block bodies.

Tested with `npm test -- src/__tests__/handlers/canvas.test.ts src/__tests__/regression-tools-canvas.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.