### PR TITLE
fix: make section marker labels generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Failed-path warning marker labels for write, tag-rename, and semantic-index summaries are now generic; clients should read the failed path and error from inside the untrusted block body.
 - Link context and target marker labels are now generic; clients should read backlink context, outlink targets, and broken-link targets from inside the untrusted block body.
 - Canvas summary marker labels and trust metadata are now generic; clients should read Canvas paths, node ids, node previews, colors, endpoints, and edge labels from inside the untrusted block body.
+- Section heading marker labels and trust metadata are now generic; clients should read listed and resolved heading text from inside the untrusted block body.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/regression-tools-sections.test.ts
+++ b/src/__tests__/regression-tools-sections.test.ts
@@ -521,10 +521,12 @@ describe("regression: section tool output escaping", () => {
     expect(isError(result)).toBe(false);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     const text = textContent(result);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: section headings: dirty-heading.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: list_sections headings]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: section headings: dirty-heading.md]");
     expect(text).toContain("## Dirty\\tHeading");
     expect(text).not.toContain("Dirty\tHeading");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("list_sections headings");
   });
 
   it("re-renders list_sections after a same-size heading edit", async () => {
@@ -579,10 +581,12 @@ describe("regression: section tool output escaping", () => {
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     const text = textContent(result);
     expect(text).toContain("Updated section in update-dirty-heading.md");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: section heading: update-dirty-heading.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: update_section resolved heading]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: section heading: update-dirty-heading.md]");
     expect(text).toContain("Dirty\\tHeading");
     expect(text).not.toContain("Dirty\tHeading");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("update_section resolved heading");
   });
 
   it("escapes control characters in insert_at_section success output", async () => {
@@ -606,10 +610,12 @@ describe("regression: section tool output escaping", () => {
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     const text = textContent(result);
     expect(text).toContain("bytes (append) in insert-dirty-heading.md");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: section heading: insert-dirty-heading.md]");
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: insert_at_section resolved heading]");
+    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: section heading: insert-dirty-heading.md]");
     expect(text).toContain("Dirty\\tHeading");
     expect(text).not.toContain("Dirty\tHeading");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("insert_at_section resolved heading");
   });
 
   it("escapes control characters in invalid regex flag errors", async () => {

--- a/src/tools/sections.ts
+++ b/src/tools/sections.ts
@@ -454,9 +454,9 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
         return textResultWithMeta(
           [
             `Updated section in ${displaySectionValue(notePath)} (${bodyBytes} bytes of new body)`,
-            renderResolvedHeading(`section heading: ${notePath}`, resolvedHeading),
+            renderResolvedHeading("update_section resolved heading", resolvedHeading),
           ].join("\n"),
-          `section heading: ${notePath}`,
+          "update_section resolved heading",
         );
       } catch (err) {
         log.error("update_section failed", { tool: "update_section", err: err as Error });
@@ -526,9 +526,9 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
         return textResultWithMeta(
           [
             `Inserted ${Buffer.byteLength(content, "utf-8")} bytes (${position}) in ${displaySectionValue(notePath)}`,
-            renderResolvedHeading(`section heading: ${notePath}`, resolvedHeading),
+            renderResolvedHeading("insert_at_section resolved heading", resolvedHeading),
           ].join("\n"),
-          `section heading: ${notePath}`,
+          "insert_at_section resolved heading",
         );
       } catch (err) {
         log.error("insert_at_section failed", { tool: "insert_at_section", err: err as Error });
@@ -556,7 +556,7 @@ export function registerSectionTools(server: McpServer, vaultPath: string): void
       try {
         return {
           content: [untrustedTextContent(
-            `section headings: ${notePath}`,
+            "list_sections headings",
             await readSectionListCached(vaultPath, notePath),
           )],
         };


### PR DESCRIPTION
Section tools now use generic untrusted-content marker labels and trust metadata for heading output. Listed headings and resolved edit headings stay inside untrusted block bodies without note paths appearing in marker labels.

Score: 3 severity x 2 reach / 1 effort = 6. Risk: this extends the unreleased 4.0.0 output-format migration for clients that parsed section marker labels instead of block bodies.

Tested with `npm test -- src/__tests__/regression-tools-sections.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.