### PR TITLE
fix: make attachment text label generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Link context and target marker labels are now generic; clients should read backlink context, outlink targets, and broken-link targets from inside the untrusted block body.
 - Canvas summary marker labels and trust metadata are now generic; clients should read Canvas paths, node ids, node previews, colors, endpoints, and edge labels from inside the untrusted block body.
 - Section heading marker labels and trust metadata are now generic; clients should read listed and resolved heading text from inside the untrusted block body.
+- SVG attachment text marker labels and trust metadata are now generic; clients should read attachment text from inside the untrusted block body.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/handlers/attachments.test.ts
+++ b/src/__tests__/handlers/attachments.test.ts
@@ -259,9 +259,14 @@ describe("attachments handlers — get_attachment", () => {
     const resourceBlock = blocks.find((b) => b.type === "resource");
     expect(resourceBlock).toBeDefined();
     expect(resourceBlock!._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(resourceBlock!._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("get_attachment text");
     expect(resourceBlock!.resource!._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(resourceBlock!.resource!._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("get_attachment text");
     expect(resourceBlock!.resource!.mimeType).toBe("text/plain");
     expect(resourceBlock!.resource!.text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_attachment text]",
+    );
+    expect(resourceBlock!.resource!.text).not.toContain(
       "[BEGIN UNTRUSTED VAULT CONTENT: attachment text: assets/vector.svg]",
     );
     expect(resourceBlock!.resource!.text).toContain(

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -552,7 +552,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         // plain text instead of as an image embed.
         if (mime === "image/svg+xml") {
           const svgText = bytes.toString("utf-8");
-          const trustLabel = `attachment text: ${relPath}`;
+          const trustLabel = "get_attachment text";
           return {
             content: [
               {


### PR DESCRIPTION
SVG attachment text now uses a generic untrusted-content marker label and matching trust metadata. The attachment body remains wrapped as vault content, while the attachment path no longer appears in marker labels.

Score: 3 severity x 2 reach / 1 effort = 6. Risk: this extends the unreleased 4.0.0 output-format migration for clients that parsed SVG attachment marker labels instead of block bodies.

Tested with `npm test -- src/__tests__/handlers/attachments.test.ts src/__tests__/attachments-display.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.