### PR TITLE
fix: omit note paths from embedding vector errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Canvas summary marker labels and trust metadata are now generic; clients should read Canvas paths, node ids, node previews, colors, endpoints, and edge labels from inside the untrusted block body.
 - Section heading marker labels and trust metadata are now generic; clients should read listed and resolved heading text from inside the untrusted block body.
 - SVG attachment text marker labels and trust metadata are now generic; clients should read attachment text from inside the untrusted block body.
+- Embedding vector validation errors no longer include note paths; failed note paths remain reported through the existing untrusted failed-note blocks.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/regression-embedding-fixes.test.ts
+++ b/src/__tests__/regression-embedding-fixes.test.ts
@@ -217,6 +217,36 @@ describe("live embedding vector validation", () => {
     expect(hits[0]!.notePath).toBe("a.md");
   });
 
+  it("does not include note paths in vector validation errors", async () => {
+    await loadStore(vaultDir);
+    const dirtyPath = "dirty\nembedding.md";
+
+    expect(() =>
+      setNoteChunks(
+        vaultDir,
+        dirtyPath,
+        "bad",
+        [{ notePath: dirtyPath, chunkIndex: 1, headingPath: [], text: "x", hash: "th", vector: [Number.NaN, 0, 0] }],
+        "test",
+        "m",
+      ),
+    ).toThrow(/Invalid embedding vector at chunk 1: vector contains a non-finite value/);
+
+    try {
+      setNoteChunks(
+        vaultDir,
+        dirtyPath,
+        "bad",
+        [{ notePath: dirtyPath, chunkIndex: 1, headingPath: [], text: "x", hash: "th", vector: [Number.NaN, 0, 0] }],
+        "test",
+        "m",
+      );
+    } catch (err) {
+      expect((err as Error).message).not.toContain("dirty");
+      expect((err as Error).message).not.toContain("embedding.md");
+    }
+  });
+
   it("rejects mixed dimensions before mutating existing note chunks", async () => {
     await loadStore(vaultDir);
     setNoteChunks(

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -384,7 +384,7 @@ export function setNoteChunks(
   for (const ch of chunks) {
     const error = validateVector(ch.vector, nextDimension);
     if (error !== null) {
-      throw new Error(`Invalid embedding for ${ch.notePath}#${ch.chunkIndex}: ${error}`);
+      throw new Error(`Invalid embedding vector at chunk ${ch.chunkIndex}: ${error}`);
     }
     if (nextDimension === null) nextDimension = ch.vector.length;
   }


### PR DESCRIPTION
Embedding vector validation errors no longer include note paths. Invalid vectors still report the chunk number and validation reason, while failed note paths continue through the existing untrusted failed-note blocks.

Score: 3 severity x 2 reach / 1 effort = 6. Risk: low; this only removes path detail from an error message used on invalid embedding vectors.

Tested with `npm test -- src/__tests__/regression-embedding-fixes.test.ts src/__tests__/embedding-store.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.