### PR TITLE
fix: redact spaced Windows paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SVG attachment text marker labels and trust metadata are now generic; clients should read attachment text from inside the untrusted block body.
 - Embedding vector validation errors no longer include note paths; failed note paths remain reported through the existing untrusted failed-note blocks.
 - Embedding provider HTTP errors no longer include provider response bodies; clients receive the provider endpoint family and HTTP status only.
+- Error sanitization now fully redacts unquoted Windows absolute paths that contain spaces.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -90,6 +90,13 @@ describe("stripPaths", () => {
     );
   });
 
+  it("strips unquoted Windows drive paths containing spaces", () => {
+    const text = stripPaths("can't open C:\\Users\\me\\My Vault\\secret.md");
+    expect(text).toBe("can't open <path>");
+    expect(text).not.toContain("My Vault");
+    expect(text).not.toContain("secret.md");
+  });
+
   it("strips quoted paths", () => {
     expect(stripPaths("ENOENT, open '/tmp/foo/bar.md'")).toBe("ENOENT, open <path>");
   });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -120,7 +120,7 @@ export function redactUrlSecrets(s: string): string {
 
 // Replace anything that looks like an absolute path with `<path>`. Covers:
 //   - POSIX: starts with `/` followed by a non-space char
-//   - Windows: `C:\…` or `C:/…`
+//   - Windows: `C:\…` or `C:/…`, including unquoted paths with spaces
 //   - Quoted paths in fs error messages: `'…'`
 //
 // Exported (alongside `sanitizeError`) so the logger can apply the same
@@ -129,6 +129,6 @@ export function redactUrlSecrets(s: string): string {
 export function stripPaths(s: string): string {
   return s
     .replace(/'[^']*[\\/][^']*'/g, "<path>")
-    .replace(/\b[a-zA-Z]:[\\/][^\s'"]+/g, "<path>")
+    .replace(/\b[a-zA-Z]:[\\/][^\r\n'"]+/g, "<path>")
     .replace(/(^|\s)\/[^\s'"]+/g, "$1<path>");
 }


### PR DESCRIPTION
Error sanitization now fully redacts unquoted Windows drive paths that contain spaces. This prevents the tail of host paths such as vault folder names or filenames from remaining in MCP-visible errors or forwarded log payloads.

Score: 4 severity x 3 reach / 1 effort = 12. Risk: low; some diagnostics may redact more of a Windows-path error line, but host path privacy is safer.

Tested with `npm test -- src/__tests__/errors.test.ts src/__tests__/logger.test.ts src/__tests__/security.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.