### PR TITLE
fix: redact spaced POSIX paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Embedding vector validation errors no longer include note paths; failed note paths remain reported through the existing untrusted failed-note blocks.
 - Embedding provider HTTP errors no longer include provider response bodies; clients receive the provider endpoint family and HTTP status only.
 - Error sanitization now fully redacts unquoted Windows absolute paths that contain spaces.
+- Error sanitization now redacts unquoted POSIX file paths that contain spaces while preserving surrounding diagnostics.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -97,6 +97,19 @@ describe("stripPaths", () => {
     expect(text).not.toContain("secret.md");
   });
 
+  it("strips unquoted POSIX file paths containing spaces", () => {
+    const text = stripPaths("can't open /Users/me/My Vault/secret.md: permission denied");
+    expect(text).toBe("can't open <path>: permission denied");
+    expect(text).not.toContain("My Vault");
+    expect(text).not.toContain("secret.md");
+  });
+
+  it("keeps diagnostic text after URL-path-like values", () => {
+    expect(stripPaths("Ollama /api/embed returned HTTP 500")).toBe(
+      "Ollama <path> returned HTTP 500",
+    );
+  });
+
   it("strips quoted paths", () => {
     expect(stripPaths("ENOENT, open '/tmp/foo/bar.md'")).toBe("ENOENT, open <path>");
   });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -119,7 +119,8 @@ export function redactUrlSecrets(s: string): string {
 }
 
 // Replace anything that looks like an absolute path with `<path>`. Covers:
-//   - POSIX: starts with `/` followed by a non-space char
+//   - POSIX: starts with `/` followed by a non-space char, including
+//     unquoted file-like paths with spaces
 //   - Windows: `C:\…` or `C:/…`, including unquoted paths with spaces
 //   - Quoted paths in fs error messages: `'…'`
 //
@@ -130,5 +131,6 @@ export function stripPaths(s: string): string {
   return s
     .replace(/'[^']*[\\/][^']*'/g, "<path>")
     .replace(/\b[a-zA-Z]:[\\/][^\r\n'"]+/g, "<path>")
+    .replace(/(^|\s)\/[^'"\r\n]*?\.[A-Za-z0-9][A-Za-z0-9_-]{0,31}(?=$|[\s'",:;)\]])/g, "$1<path>")
     .replace(/(^|\s)\/[^\s'"]+/g, "$1<path>");
 }


### PR DESCRIPTION
Error sanitization now redacts unquoted POSIX file paths that contain spaces through the file name. URL-path-style diagnostic strings keep their status text, so provider errors remain useful while host path tails are hidden.

Score: 4 severity x 3 reach / 1 effort = 12. Risk: low; file-like absolute paths with spaces redact more completely, while ordinary slash-path diagnostics keep surrounding text.

Tested with `npm test -- src/__tests__/errors.test.ts src/__tests__/logger.test.ts src/__tests__/security.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.