### PR TITLE
fix: redact double-quoted paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Embedding provider HTTP errors no longer include provider response bodies; clients receive the provider endpoint family and HTTP status only.
 - Error sanitization now fully redacts unquoted Windows absolute paths that contain spaces.
 - Error sanitization now redacts unquoted POSIX file paths that contain spaces while preserving surrounding diagnostics.
+- Error sanitization now redacts double-quoted path strings as well as single-quoted path strings.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -113,6 +113,13 @@ describe("stripPaths", () => {
   it("strips quoted paths", () => {
     expect(stripPaths("ENOENT, open '/tmp/foo/bar.md'")).toBe("ENOENT, open <path>");
   });
+
+  it("strips double-quoted paths", () => {
+    const text = stripPaths('ENOENT, open "/Users/me/My Vault/secret.md"');
+    expect(text).toBe("ENOENT, open <path>");
+    expect(text).not.toContain("My Vault");
+    expect(text).not.toContain("secret.md");
+  });
 });
 
 describe("redactUrlSecrets", () => {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -122,7 +122,7 @@ export function redactUrlSecrets(s: string): string {
 //   - POSIX: starts with `/` followed by a non-space char, including
 //     unquoted file-like paths with spaces
 //   - Windows: `C:\…` or `C:/…`, including unquoted paths with spaces
-//   - Quoted paths in fs error messages: `'…'`
+//   - Quoted paths in fs error messages: `'…'` or `"…"`
 //
 // Exported (alongside `sanitizeError`) so the logger can apply the same
 // stripping to structured log payloads before forwarding them to MCP
@@ -130,6 +130,7 @@ export function redactUrlSecrets(s: string): string {
 export function stripPaths(s: string): string {
   return s
     .replace(/'[^']*[\\/][^']*'/g, "<path>")
+    .replace(/"[^"]*[\\/][^"]*"/g, "<path>")
     .replace(/\b[a-zA-Z]:[\\/][^\r\n'"]+/g, "<path>")
     .replace(/(^|\s)\/[^'"\r\n]*?\.[A-Za-z0-9][A-Za-z0-9_-]{0,31}(?=$|[\s'",:;)\]])/g, "$1<path>")
     .replace(/(^|\s)\/[^\s'"]+/g, "$1<path>");


### PR DESCRIPTION
Error sanitization now redacts double-quoted path strings as well as single-quoted ones. This closes the quoted POSIX path case where a host path with spaces could bypass the slash-prefix matcher because the slash followed a quote.

Score: 4 severity x 3 reach / 1 effort = 12. Risk: low; double-quoted strings containing path separators now redact the same way single-quoted path strings already did.

Tested with `npm test -- src/__tests__/errors.test.ts src/__tests__/logger.test.ts src/__tests__/security.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.