### PR TITLE
fix: escape forwarded log controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error sanitization now fully redacts unquoted Windows absolute paths that contain spaces.
 - Error sanitization now redacts unquoted POSIX file paths that contain spaces while preserving surrounding diagnostics.
 - Error sanitization now redacts double-quoted path strings as well as single-quoted path strings.
+- MCP-forwarded log payloads now escape control characters and Unicode bidi controls recursively after path redaction.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -200,6 +200,26 @@ describe("logger", () => {
     expect(dataStr).not.toContain("secret.md");
   });
 
+  it("escapes controls recursively in forwarded MCP payloads", () => {
+    const sendLoggingMessage = vi.fn().mockResolvedValue(undefined);
+    const fakeServer = { server: { sendLoggingMessage } } as unknown as McpServer;
+    configureLogger({ level: "info", format: "text", mcpServer: fakeServer });
+
+    log.warn("line\nbreak", {
+      detail: "name\r\nIGNORE PREVIOUS",
+      nested: { label: "safe\u202ecod.exe" },
+      err: new Error("boom\nnext"),
+    });
+
+    const [params] = sendLoggingMessage.mock.calls[0];
+    expect(params.data.msg).toBe("line\\nbreak");
+    expect(params.data.detail).toBe("name\\r\\nIGNORE PREVIOUS");
+    expect(params.data.nested).toMatchObject({ label: "safe\\u202ecod.exe" });
+    expect(params.data.err.message).toBe("boom\\nnext");
+    expect(params.data.err.stack).not.toContain("\n");
+    expect(params.data.err.stack).toContain("\\n");
+  });
+
   it("swallows sendLoggingMessage rejections (logging must never fail a call)", async () => {
     const sendLoggingMessage = vi.fn().mockRejectedValue(new Error("not connected"));
     const fakeServer = { server: { sendLoggingMessage } } as unknown as McpServer;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -154,7 +154,7 @@ function emit(level: LogLevel, msg: string, fields?: Record<string, unknown>): v
   // detail because the operator is reading it on their own machine.
   if (mcpServer && level !== "silent") {
     const mcpLevel = MCP_LEVEL[level];
-    const data: Record<string, unknown> = { msg: stripPaths(msg) };
+    const data: Record<string, unknown> = { msg: escapeControlChars(stripPaths(msg)) };
     if (fields && Object.keys(fields).length > 0) {
       Object.assign(data, sanitizeLogData(serialized));
     }
@@ -164,10 +164,10 @@ function emit(level: LogLevel, msg: string, fields?: Record<string, unknown>): v
   }
 }
 
-// Recursively strip absolute paths from log payload values before forwarding
-// to an MCP client. Applies to strings and to the `.message`/`.stack` of
-// already-serialized Error objects (where stack traces embed host paths).
-// Non-string leaf values pass through unchanged.
+// Recursively strip absolute paths and escape control characters from log
+// payload values before forwarding to an MCP client. Applies to strings and
+// to the `.message`/`.stack` of already-serialized Error objects (where stack
+// traces embed host paths). Non-string leaf values pass through unchanged.
 function sanitizeLogData(input: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(input)) {
@@ -205,8 +205,10 @@ function sanitizeValue(key: string, v: unknown, redactVaultPath = false): unknow
   const shouldRedactVaultPath = redactVaultPath || isVaultPathField(key);
   if (typeof v === "string") {
     const stripped = stripPaths(v);
-    if (stripped !== v) return stripped;
-    return shouldRedactVaultPath && looksLikeVaultPath(stripped) ? "<vault path>" : stripped;
+    if (stripped !== v) return escapeControlChars(stripped);
+    return shouldRedactVaultPath && looksLikeVaultPath(stripped)
+      ? "<vault path>"
+      : escapeControlChars(stripped);
   }
   if (Array.isArray(v)) {
     return v.map((inner) => sanitizeValue(key, inner, shouldRedactVaultPath));


### PR DESCRIPTION
MCP-forwarded log payloads now escape control characters and Unicode bidi controls recursively after path redaction. Local stderr still keeps operator detail, while remote log notifications receive line-safe strings for messages, fields, nested values, and serialized error stacks.

Score: 4 severity x 3 reach / 1 effort = 12. Risk: low; forwarded log strings now use escaped control text, while non-string values and local logs keep existing behavior.

Tested with `npm test -- src/__tests__/logger.test.ts src/__tests__/errors.test.ts src/__tests__/security.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.