### PR TITLE
fix: redact forwarded log URL secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error sanitization now redacts unquoted POSIX file paths that contain spaces while preserving surrounding diagnostics.
 - Error sanitization now redacts double-quoted path strings as well as single-quoted path strings.
 - MCP-forwarded log payloads now escape control characters and Unicode bidi controls recursively after path redaction.
+- MCP-forwarded log payloads now redact secret-bearing URLs recursively.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.
 - Search outputs now mark matching note path headings from `search_notes` and `search_by_frontmatter` as untrusted vault content.
 - Semantic outputs now mark ranked note result paths from `search_semantic` and `find_similar_notes`, plus failed note rows from `index_vault`, as untrusted vault content.

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -220,6 +220,30 @@ describe("logger", () => {
     expect(params.data.err.stack).toContain("\\n");
   });
 
+  it("redacts secret-bearing URLs from forwarded MCP payloads", () => {
+    const sendLoggingMessage = vi.fn().mockResolvedValue(undefined);
+    const fakeServer = { server: { sendLoggingMessage } } as unknown as McpServer;
+    configureLogger({ level: "info", format: "text", mcpServer: fakeServer });
+
+    log.warn("provider rejected https://alice:pa55@example.internal/v1?token=abc#debug", {
+      endpoint: "https://api.example.internal/v1?api_key=secret",
+      plainUrl: "https://status.example.test/health",
+      nested: { callback: "https://callback.example.test/path?sig=hidden" },
+      err: new Error("bad https://bob:pw@host.test/path#frag"),
+    });
+
+    const [params] = sendLoggingMessage.mock.calls[0];
+    const dataStr = JSON.stringify(params.data);
+    expect(dataStr).not.toContain("alice");
+    expect(dataStr).not.toContain("pa55");
+    expect(dataStr).not.toContain("api_key");
+    expect(dataStr).not.toContain("bob");
+    expect(dataStr).not.toContain("host.test");
+    expect(dataStr).not.toContain("sig=hidden");
+    expect(dataStr).toContain("https://<redacted-url>");
+    expect(params.data.plainUrl).toBe("https://status.example.test/health");
+  });
+
   it("swallows sendLoggingMessage rejections (logging must never fail a call)", async () => {
     const sendLoggingMessage = vi.fn().mockRejectedValue(new Error("not connected"));
     const fakeServer = { server: { sendLoggingMessage } } as unknown as McpServer;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -15,7 +15,7 @@
 // logging never becomes a failure mode of the server.
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { stripPaths, escapeControlChars } from "./errors.js";
+import { stripPaths, escapeControlChars, redactUrlSecrets } from "./errors.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "silent";
 export type LogFormat = "text" | "json";
@@ -154,7 +154,7 @@ function emit(level: LogLevel, msg: string, fields?: Record<string, unknown>): v
   // detail because the operator is reading it on their own machine.
   if (mcpServer && level !== "silent") {
     const mcpLevel = MCP_LEVEL[level];
-    const data: Record<string, unknown> = { msg: escapeControlChars(stripPaths(msg)) };
+    const data: Record<string, unknown> = { msg: sanitizeForwardedString(msg) };
     if (fields && Object.keys(fields).length > 0) {
       Object.assign(data, sanitizeLogData(serialized));
     }
@@ -174,6 +174,10 @@ function sanitizeLogData(input: Record<string, unknown>): Record<string, unknown
     out[k] = sanitizeValue(k, v);
   }
   return out;
+}
+
+function sanitizeForwardedString(value: string): string {
+  return escapeControlChars(stripPaths(redactUrlSecrets(value)));
 }
 
 function isVaultPathField(key: string): boolean {
@@ -204,7 +208,7 @@ function looksLikeVaultPath(value: string): boolean {
 function sanitizeValue(key: string, v: unknown, redactVaultPath = false): unknown {
   const shouldRedactVaultPath = redactVaultPath || isVaultPathField(key);
   if (typeof v === "string") {
-    const stripped = stripPaths(v);
+    const stripped = stripPaths(redactUrlSecrets(v));
     if (stripped !== v) return escapeControlChars(stripped);
     return shouldRedactVaultPath && looksLikeVaultPath(stripped)
       ? "<vault path>"


### PR DESCRIPTION
MCP-forwarded log payloads now redact secret-bearing URLs recursively using the same URL scrubber as client-facing errors. Plain diagnostic URLs stay visible, while credentials, query strings, and fragments are collapsed before log notifications leave the server.

Score: 4 severity x 3 reach / 1 effort = 12. Risk: low; local stderr keeps operator detail, and forwarded plain URLs without credentials/query/fragment stay unchanged.

Tested with `npm test -- src/__tests__/logger.test.ts src/__tests__/errors.test.ts src/__tests__/security.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.