### PR TITLE
fix: redact backtick-quoted paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error sanitization now fully redacts unquoted Windows absolute paths that contain spaces.
 - Error sanitization now redacts unquoted POSIX file paths that contain spaces while preserving surrounding diagnostics.
 - Error sanitization now redacts double-quoted path strings as well as single-quoted path strings.
+- Error sanitization now redacts backtick-quoted path strings.
 - MCP-forwarded log payloads now escape control characters and Unicode bidi controls recursively after path redaction.
 - MCP-forwarded log payloads now redact secret-bearing URLs recursively.
 - Read-tool inventory outputs now mark listed note paths, recent-note rows, vault-stat most-recent paths, and alias-resolution path groups as untrusted vault content.

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -120,6 +120,15 @@ describe("stripPaths", () => {
     expect(text).not.toContain("My Vault");
     expect(text).not.toContain("secret.md");
   });
+
+  it("strips backtick-quoted paths", () => {
+    expect(stripPaths("ENOENT, open `/Users/me/My Vault/secret.md`")).toBe(
+      "ENOENT, open <path>",
+    );
+    expect(stripPaths("ENOENT, open `C:\\Users\\me\\My Vault\\secret.md`")).toBe(
+      "ENOENT, open <path>",
+    );
+  });
 });
 
 describe("redactUrlSecrets", () => {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -122,7 +122,7 @@ export function redactUrlSecrets(s: string): string {
 //   - POSIX: starts with `/` followed by a non-space char, including
 //     unquoted file-like paths with spaces
 //   - Windows: `C:\…` or `C:/…`, including unquoted paths with spaces
-//   - Quoted paths in fs error messages: `'…'` or `"…"`
+//   - Quoted paths in fs error messages: `'…'`, `"…"`, or `` `…` ``
 //
 // Exported (alongside `sanitizeError`) so the logger can apply the same
 // stripping to structured log payloads before forwarding them to MCP
@@ -131,6 +131,7 @@ export function stripPaths(s: string): string {
   return s
     .replace(/'[^']*[\\/][^']*'/g, "<path>")
     .replace(/"[^"]*[\\/][^"]*"/g, "<path>")
+    .replace(/`[^`]*[\\/][^`]*`/g, "<path>")
     .replace(/\b[a-zA-Z]:[\\/][^\r\n'"]+/g, "<path>")
     .replace(/(^|\s)\/[^'"\r\n]*?\.[A-Za-z0-9][A-Za-z0-9_-]{0,31}(?=$|[\s'",:;)\]])/g, "$1<path>")
     .replace(/(^|\s)\/[^\s'"]+/g, "$1<path>");


### PR DESCRIPTION
Error sanitization now redacts backtick-quoted path strings. This closes the last quoted-path delimiter case, covering both POSIX and Windows paths wrapped in code-style quotes.

Score: 4 severity x 2 reach / 1 effort = 8. Risk: low; backtick-quoted strings containing path separators now redact like single- and double-quoted path strings.

Tested with `npm test -- src/__tests__/errors.test.ts src/__tests__/logger.test.ts src/__tests__/security.test.ts`, `npm run lint`, `npm run typecheck`, and `npm run verify`.

Greptile is skipped until the review quota is restored.