### PR TITLE
fix: bound note line fragment reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `get_note` line fragments now reject unsafe line numbers and cap line-range scan/output bytes, while still allowing small targeted fragments from notes over the full-read cap.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.
 - `search_by_frontmatter` result path and frontmatter marker labels are now generic; clients should read those values from inside the untrusted block body.

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
-import { setMaxNoteFileBytesForTests } from "../../lib/vault.js";
+import { setMaxNoteFileBytesForTests, setMaxNoteLineRangeBytesForTests } from "../../lib/vault.js";
 
 let env: TestEnv;
 
@@ -12,6 +12,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   setMaxNoteFileBytesForTests(null);
+  setMaxNoteLineRangeBytesForTests(null);
   await env.cleanup();
 });
 
@@ -311,6 +312,33 @@ describe("read handlers — get_note", () => {
     expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_note fragment]");
     expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: note fragment: long.md lines 2-2]");
     expect(text).toContain("\nsecond\n");
+  });
+
+  it("rejects oversized line fragments without returning note content", async () => {
+    setMaxNoteLineRangeBytesForTests(10);
+    await fs.writeFile(path.join(env.vaultDir, "oversized-line.md"), "private-body", "utf-8");
+
+    const result = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "oversized-line.md", lines: "1" },
+    });
+
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toMatch(/note line fragment exceeds size cap/i);
+    expect(text).not.toContain("private-body");
+  });
+
+  it("rejects line ranges outside safe integer bounds before reading", async () => {
+    await fs.writeFile(path.join(env.vaultDir, "safe-lines.md"), "one\ntwo", "utf-8");
+
+    const result = await env.client.callTool({
+      name: "get_note",
+      arguments: { path: "safe-lines.md", lines: "999999999999999999999999" },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toContain('Invalid lines format: "999999999999999999999999"');
   });
 
   it("rejects non-markdown vault files", async () => {

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -19,6 +19,7 @@ import {
   readCanvasFile,
   MAX_CANVAS_FILE_BYTES,
   setMaxNoteFileBytesForTests,
+  setMaxNoteLineRangeBytesForTests,
   getNoteStats,
   getVaultRootRealPath,
 } from "../lib/vault.js";
@@ -35,6 +36,7 @@ beforeEach(async () => {
 afterEach(async () => {
   vi.restoreAllMocks();
   setMaxNoteFileBytesForTests(null);
+  setMaxNoteLineRangeBytesForTests(null);
   setPermissions({ readPaths: null, writePaths: null });
   await fs.rm(vaultDir, { recursive: true, force: true });
 });
@@ -231,6 +233,24 @@ describe("readNote", () => {
     await expect(readNoteLineRange(vaultDir, "long.md", 2, 2)).resolves.toEqual({
       text: "second",
     });
+  });
+
+  it("rejects a line fragment that exceeds the line-range byte cap", async () => {
+    setMaxNoteLineRangeBytesForTests(10);
+    await fs.writeFile(path.join(vaultDir, "oversized-line.md"), "x".repeat(11), "utf-8");
+
+    await expect(readNoteLineRange(vaultDir, "oversized-line.md", 1, 1)).rejects.toThrow(
+      /Note line fragment exceeds size cap \(11 > 10 bytes\): oversized-line\.md/,
+    );
+  });
+
+  it("rejects line range scans that exceed the line-range byte cap", async () => {
+    setMaxNoteLineRangeBytesForTests(12);
+    await fs.writeFile(path.join(vaultDir, "many-lines.md"), "one\ntwo\nthree\nfour", "utf-8");
+
+    await expect(readNoteLineRange(vaultDir, "many-lines.md", 99, 99)).rejects.toThrow(
+      /Note line fragment exceeds size cap \(13 > 12 bytes\): many-lines\.md/,
+    );
   });
 });
 

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -20,8 +20,11 @@ const SEARCH_REPEATED_SAME_LINE_PENALTY = 0.5;
 const SEARCH_SNIPPET_MAX_CHARS = 240;
 const SEARCH_SNIPPET_OMISSION = "...";
 const MAX_NOTE_FILE_BYTES_DEFAULT = 5 * 1024 * 1024;
+const MAX_NOTE_LINE_RANGE_BYTES_DEFAULT = MAX_NOTE_FILE_BYTES_DEFAULT;
 let maxNoteFileBytes = MAX_NOTE_FILE_BYTES_DEFAULT;
+let maxNoteLineRangeBytes = MAX_NOTE_LINE_RANGE_BYTES_DEFAULT;
 export const MAX_NOTE_FILE_BYTES = MAX_NOTE_FILE_BYTES_DEFAULT;
+export const MAX_NOTE_LINE_RANGE_BYTES = MAX_NOTE_LINE_RANGE_BYTES_DEFAULT;
 export const MAX_CANVAS_FILE_BYTES = 1_048_576;
 const MAX_CANVAS_NODES = 10_000;
 const MAX_CANVAS_EDGES = 20_000;
@@ -38,6 +41,10 @@ function assertMarkdownNotePath(relativePath: string): void {
 
 export function setMaxNoteFileBytesForTests(bytes: number | null): void {
   maxNoteFileBytes = bytes === null ? MAX_NOTE_FILE_BYTES_DEFAULT : bytes;
+}
+
+export function setMaxNoteLineRangeBytesForTests(bytes: number | null): void {
+  maxNoteLineRangeBytes = bytes === null ? MAX_NOTE_LINE_RANGE_BYTES_DEFAULT : bytes;
 }
 
 export function assertNoteFileSize(relativePath: string, size: number): void {
@@ -58,6 +65,14 @@ async function assertResolvedNoteFileSize(
 
 function assertNoteContentSize(relativePath: string, content: string): void {
   assertNoteFileSize(relativePath, Buffer.byteLength(content, "utf-8"));
+}
+
+function assertNoteLineRangeBytes(relativePath: string, size: number): void {
+  if (size > maxNoteLineRangeBytes) {
+    throw new Error(
+      `Note line fragment exceeds size cap (${size} > ${maxNoteLineRangeBytes} bytes): ${relativePath}`,
+    );
+  }
 }
 
 // Legacy DOS device names reserved by the Windows filesystem at any depth.
@@ -544,6 +559,14 @@ export async function readNoteLineRange(
   endLine: number,
 ): Promise<NoteLineRangeRead> {
   assertMarkdownNotePath(relativePath);
+  if (
+    !Number.isSafeInteger(startLine) ||
+    !Number.isSafeInteger(endLine) ||
+    startLine < 1 ||
+    endLine < startLine
+  ) {
+    throw new Error(`Invalid line range for note: ${relativePath}`);
+  }
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
   let handle: fs.FileHandle | undefined;
   try {
@@ -553,9 +576,15 @@ export async function readNoteLineRange(
     const collected: string[] = [];
     let pending = "";
     let currentLine = 1;
+    let scannedBytes = 0;
+    let outputBytes = 0;
 
     const processLine = (line: string): boolean => {
       if (currentLine >= startLine && currentLine <= endLine) {
+        const lineBytes = Buffer.byteLength(line, "utf-8");
+        const separatorBytes = collected.length > 0 ? 1 : 0;
+        assertNoteLineRangeBytes(relativePath, outputBytes + separatorBytes + lineBytes);
+        outputBytes += separatorBytes + lineBytes;
         collected.push(line);
       }
       const reachedRequestedEnd = currentLine >= endLine;
@@ -564,8 +593,12 @@ export async function readNoteLineRange(
     };
 
     while (true) {
-      const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+      const remainingBytes = maxNoteLineRangeBytes - scannedBytes;
+      const bytesToRead = Math.min(buffer.length, Math.max(remainingBytes + 1, 1));
+      const { bytesRead } = await handle.read(buffer, 0, bytesToRead, null);
       if (bytesRead === 0) break;
+      scannedBytes += bytesRead;
+      assertNoteLineRangeBytes(relativePath, scannedBytes);
 
       let chunk = decoder.write(buffer.subarray(0, bytesRead));
       while (true) {

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -32,6 +32,23 @@ function displayReadValue(value: string): string {
   return escapeControlChars(value);
 }
 
+function parseRequestedLine(value: string): number | null {
+  const line = Number(value);
+  if (!Number.isSafeInteger(line) || line < 0) return null;
+  return Math.max(1, line);
+}
+
+function parseRequestedLineRange(value: string): { start: number; end: number } | null {
+  const m = /^(\d+)(?:-(\d+))?$/.exec(value);
+  if (!m) return null;
+  const [, startText, endText] = m;
+  if (!startText) return null;
+  const start = parseRequestedLine(startText);
+  const requestedEnd = endText ? parseRequestedLine(endText) : start;
+  if (start === null || requestedEnd === null) return null;
+  return { start, end: Math.max(start, requestedEnd) };
+}
+
 function untrustedReadBlock(label: string, text: string, indent = ""): string {
   return indentBlock(formatUntrustedVaultContent(label, text), indent);
 }
@@ -179,18 +196,17 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
     async ({ path: notePath, section, block, lines }) => {
       try {
         if (!section && !block && lines) {
-          const m = /^(\d+)(?:-(\d+))?$/.exec(lines);
-          if (m) {
-            const a = Math.max(1, Number(m[1]));
-            const b = m[2] ? Math.max(a, Number(m[2])) : a;
-            const range = await readNoteLineRange(vaultPath, notePath, a, b);
-            if (range.pastEndLine) {
-              return errorResult(`Line ${range.pastEndLine.requested} is past end of file (${range.pastEndLine.total} lines)`);
-            }
-            return {
-              content: [untrustedTextContent("get_note fragment", range.text)],
-            };
+          const parsedRange = parseRequestedLineRange(lines);
+          if (!parsedRange) {
+            return errorResult(`Invalid lines format: "${displayReadValue(lines)}"`);
           }
+          const range = await readNoteLineRange(vaultPath, notePath, parsedRange.start, parsedRange.end);
+          if (range.pastEndLine) {
+            return errorResult(`Line ${range.pastEndLine.requested} is past end of file (${range.pastEndLine.total} lines)`);
+          }
+          return {
+            content: [untrustedTextContent("get_note fragment", range.text)],
+          };
         }
 
         const content = await readNote(vaultPath, notePath);
@@ -221,14 +237,12 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
 
         if (lines) {
           const allLines = content.split("\n");
-          const m = /^(\d+)(?:-(\d+))?$/.exec(lines);
-          if (!m) return errorResult(`Invalid lines format: "${displayReadValue(lines)}"`);
-          const a = Math.max(1, Number(m[1]));
-          const b = m[2] ? Math.max(a, Number(m[2])) : a;
-          if (a > allLines.length) {
-            return errorResult(`Line ${a} is past end of file (${allLines.length} lines)`);
+          const parsedRange = parseRequestedLineRange(lines);
+          if (!parsedRange) return errorResult(`Invalid lines format: "${displayReadValue(lines)}"`);
+          if (parsedRange.start > allLines.length) {
+            return errorResult(`Line ${parsedRange.start} is past end of file (${allLines.length} lines)`);
           }
-          const slice = allLines.slice(a - 1, Math.min(b, allLines.length));
+          const slice = allLines.slice(parsedRange.start - 1, Math.min(parsedRange.end, allLines.length));
           return {
             content: [untrustedTextContent("get_note fragment", slice.join("\n"))],
           };


### PR DESCRIPTION
Caps `get_note` line-fragment scan/output bytes and rejects unsafe line numbers before the streaming path runs. This keeps small targeted fragments from oversized notes working while blocking giant single-line reads, huge ranges, and absurd line numbers from turning into resource exhaustion.

Risk: low; the schema and normal fragment output shape are unchanged, but pathological line fragments now fail closed.
Score: 4 severity x 3 reach / 1 effort = 12.

Tests: npm test -- src/__tests__/vault.test.ts src/__tests__/handlers/read.test.ts; npm run lint; npm run typecheck; npm run verify.