### PR TITLE
fix: reject bounded redos groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `get_note` line fragments now reject unsafe line numbers and cap line-range scan/output bytes, while still allowing small targeted fragments from notes over the full-read cap.
+- `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.
 - `search_by_frontmatter` result path and frontmatter marker labels are now generic; clients should read those values from inside the untrusted block body.

--- a/src/__tests__/regression-tools-sections.test.ts
+++ b/src/__tests__/regression-tools-sections.test.ts
@@ -114,6 +114,26 @@ describe("regression: replace_in_note ReDoS guards (C3)", () => {
     expect(onDisk).toBe("aaaaaaaaaaaaaaaaab\n");
   });
 
+  it("rejects bounded repeated groups that contain quantified atoms", async () => {
+    await fs.writeFile(path.join(env.vaultDir, "redos-bounded.md"), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n", "utf-8");
+
+    const result = await env.client.callTool({
+      name: "replace_in_note",
+      arguments: {
+        path: "redos-bounded.md",
+        find: "^(a+){20}b$",
+        replace: "X",
+        regex: true,
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/unsafe regex pattern|nested quantifier/i);
+
+    const onDisk = await fs.readFile(path.join(env.vaultDir, "redos-bounded.md"), "utf-8");
+    expect(onDisk).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n");
+  });
+
   it("rejects invalid regex flags with a clean error mentioning the bad flag", async () => {
     const result = await env.client.callTool({
       name: "replace_in_note",

--- a/src/tools/sections.ts
+++ b/src/tools/sections.ts
@@ -91,26 +91,31 @@ function regexQuantifierLength(pattern: string, index: number): number {
   return pattern.charAt(i) === "}" ? i - index + 1 : 0;
 }
 
-function regexQuantifierIsUnboundedRepeat(pattern: string, index: number): boolean {
+function regexQuantifierCanRepeat(pattern: string, index: number): boolean {
   const ch = pattern.charAt(index);
   if (ch === "*" || ch === "+") return true;
+  if (ch === "?") return false;
   if (ch !== "{") return false;
 
   let i = index + 1;
-  let digits = 0;
+  let minText = "";
   while (i < pattern.length && isAsciiDigit(pattern.charAt(i))) {
+    minText += pattern.charAt(i);
     i += 1;
-    digits += 1;
   }
-  if (digits === 0 || pattern.charAt(i) !== ",") return false;
+  if (minText.length === 0) return false;
+  if (pattern.charAt(i) === "}") return Number(minText) > 1;
+  if (pattern.charAt(i) !== ",") return false;
 
   i += 1;
-  let maxDigits = 0;
+  let maxText = "";
   while (i < pattern.length && isAsciiDigit(pattern.charAt(i))) {
+    maxText += pattern.charAt(i);
     i += 1;
-    maxDigits += 1;
   }
-  return maxDigits === 0 && pattern.charAt(i) === "}";
+  if (pattern.charAt(i) !== "}") return false;
+  if (maxText.length === 0) return true;
+  return Number(maxText) > 1;
 }
 
 function regexCharacterClassEnd(pattern: string, openIndex: number): number {
@@ -319,7 +324,7 @@ function hasUnsafeRepeatedGroup(pattern: string): boolean {
     const body = group === undefined ? "" : pattern.slice(group.bodyStart, i);
     if (
       group !== undefined &&
-      regexQuantifierIsUnboundedRepeat(pattern, i + 1) &&
+      regexQuantifierCanRepeat(pattern, i + 1) &&
       (hasQuantifiedAtom(body) || hasAmbiguousAlternation(body))
     ) {
       return true;


### PR DESCRIPTION
Rejects repeated regex groups with bounded maxima above one when the group body already contains quantified atoms or ambiguous alternation. This closes the `^(a+){20}b$` class without changing normal literal replacement behavior.

Risk: low; this only broadens the existing unsafe-regex rejection path for `replace_in_note`.
Score: 5 severity x 3 reach / 1 effort = 15.

Tests: npm test -- src/__tests__/regression-tools-sections.test.ts src/__tests__/handlers/sections.test.ts; npm run lint; npm run typecheck; npm run verify.