### PR TITLE
fix: bound list_sections note reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `get_note` line fragments now reject unsafe line numbers and cap line-range scan/output bytes, while still allowing small targeted fragments from notes over the full-read cap.
+- `list_sections` now rejects non-markdown files and notes over the configured note-size cap before parsing headings.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/src/__tests__/regression-tools-sections.test.ts
+++ b/src/__tests__/regression-tools-sections.test.ts
@@ -8,6 +8,7 @@ import {
   type TestEnv,
 } from "./handlers/harness.js";
 import { setPermissions } from "../lib/permissions.js";
+import { setMaxNoteFileBytesForTests } from "../lib/vault.js";
 
 /**
  * Regression tests for src/tools/sections.ts.
@@ -27,11 +28,13 @@ const TOO_LARGE_FIND = "x".repeat(4097);
 
 beforeEach(async () => {
   setPermissions({ readPaths: null, writePaths: null });
+  setMaxNoteFileBytesForTests(null);
   env = await createTestEnv();
 });
 
 afterEach(async () => {
   setPermissions({ readPaths: null, writePaths: null });
+  setMaxNoteFileBytesForTests(null);
   await env.cleanup();
 });
 
@@ -521,7 +524,35 @@ describe("regression: surgical edits only target markdown notes", () => {
 
     expect(isError(update)).toBe(true);
     expect(textContent(update)).toMatch(/not a markdown note/i);
+
+    const list = await env.client.callTool({
+      name: "list_sections",
+      arguments: { path: "asset.txt" },
+    });
+
+    expect(isError(list)).toBe(true);
+    expect(textContent(list)).toMatch(/not a markdown note/i);
     await expect(fs.readFile(assetPath, "utf-8")).resolves.toBe(original);
+  });
+});
+
+describe("regression: list_sections respects note read bounds", () => {
+  it("rejects oversized notes before parsing headings", async () => {
+    setMaxNoteFileBytesForTests(16);
+    await fs.writeFile(
+      path.join(env.vaultDir, "oversized-sections.md"),
+      "# Heading\n\nThis note is larger than the test cap.\n",
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "list_sections",
+      arguments: { path: "oversized-sections.md" },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/exceeds size cap/i);
+    expect(textContent(result)).not.toContain("# Heading");
   });
 });
 

--- a/src/tools/sections.ts
+++ b/src/tools/sections.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import fs from "fs/promises";
 import path from "path";
-import { readNote, resolveVaultPathSafe, updateNote } from "../lib/vault.js";
+import { assertNoteFileSize, readNote, resolveVaultPathSafe, updateNote } from "../lib/vault.js";
 import {
   findSection,
   findBlockById,
@@ -338,6 +338,12 @@ function splitHeadingPath(section: string): string[] {
   return section.split("/").map((s) => s.trim()).filter(Boolean);
 }
 
+function assertMarkdownSectionListPath(relativePath: string): void {
+  if (!relativePath.toLowerCase().endsWith(".md")) {
+    throw new Error(`Not a markdown note: ${relativePath}`);
+  }
+}
+
 function sectionListCacheKey(vaultPath: string, notePath: string): string {
   return `${path.resolve(vaultPath)}\0${notePath}`;
 }
@@ -346,9 +352,11 @@ async function getSectionListSignature(
   vaultPath: string,
   notePath: string,
 ): Promise<{ fullPath: string; size: number; mtimeMs: number }> {
+  assertMarkdownSectionListPath(notePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, notePath);
   try {
     const stats = await fs.stat(fullPath);
+    assertNoteFileSize(notePath, stats.size);
     return { fullPath, size: stats.size, mtimeMs: stats.mtimeMs };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {


### PR DESCRIPTION
What changed: `list_sections` now rejects non-markdown paths and notes over the configured note-size cap before cache lookup or heading parsing.

Why: the section-list warm path used a direct read and skipped the guards used by normal note reads, so non-note or oversized content could be parsed and returned as headings.

Risk: low. Tool schema and success output stay the same; invalid targets fail earlier.

Score: 4 severity x 3 reach / 1 effort = 12.

Tests:
- `npm test -- src/__tests__/regression-tools-sections.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run verify`

Greptile skipped because the trial review quota is exhausted.