### PR TITLE
fix: block hidden attachment directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `get_note` line fragments now reject unsafe line numbers and cap line-range scan/output bytes, while still allowing small targeted fragments from notes over the full-read cap.
 - `list_sections` now rejects non-markdown files and notes over the configured note-size cap before parsing headings.
+- Attachment inventory and direct attachment reads now skip files inside hidden dot-directories, matching the existing hidden-dotfile boundary.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/src/__tests__/handlers/attachments.test.ts
+++ b/src/__tests__/handlers/attachments.test.ts
@@ -24,6 +24,7 @@ beforeEach(async () => {
         "</svg>",
       ].join("\n"),
       "assets/.env": "TOKEN=hidden",
+      "assets/.private/private-image.png": "PNG-hidden-dir",
       "embed-host.md": "# Embed host\n\n![[used-image.png]]\n\nAlso linked: [doc](assets/notes.pdf)\n",
     },
   });
@@ -53,6 +54,8 @@ describe("attachments handlers — list_attachments", () => {
     expect(text).not.toMatch(/embed-host\.md/);
     // Hidden dotfiles are skipped by the inventory and direct reads.
     expect(text).not.toMatch(/\.env/);
+    // Hidden directories follow the same boundary.
+    expect(text).not.toMatch(/private-image\.png/);
   });
 
   it("filters by extension", async () => {
@@ -326,6 +329,17 @@ describe("attachments handlers — get_attachment", () => {
     const text = textContent(result);
     expect(text).toContain('Refusing to fetch hidden attachment "assets/.env"');
     expect(text).not.toContain("TOKEN=hidden");
+  });
+
+  it("rejects attachments inside hidden directories skipped by the inventory", async () => {
+    const result = await env.client.callTool({
+      name: "get_attachment",
+      arguments: { path: "assets/.private/private-image.png" },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain('Refusing to fetch hidden attachment "assets/.private/private-image.png"');
+    expect(text).not.toContain(Buffer.from("PNG-hidden-dir").toString("base64"));
   });
 
   itSymlink("rejects symlinked attachment files skipped by the inventory", async () => {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -292,6 +292,7 @@ async function walkVaultExcluding(
       if (entry.isSymbolicLink()) continue;
 
       if (entry.isDirectory()) {
+        if (name.startsWith(".")) continue;
         if (EXCLUDED_SET.has(name.toLowerCase())) continue;
         const nextPrefix = relPrefix === "" ? name : `${relPrefix}/${name}`;
         await walk(fullEntry, nextPrefix);

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -87,9 +87,14 @@ function safeResourceMimeType(mime: string): string {
   return ACTIVE_TEXT_MIME_TYPES.has(mime.toLowerCase()) ? "text/plain" : mime;
 }
 
-function hiddenAttachmentBasename(relPath: string): string | null {
-  const basename = path.posix.basename(relPath.replace(/\\/g, "/"));
-  return basename.startsWith(".") ? basename : null;
+function hiddenAttachmentSegment(relPath: string): string | null {
+  const segments = relPath.replace(/\\/g, "/").split("/");
+  return segments.find((segment) =>
+    segment !== "" &&
+    segment !== "." &&
+    segment !== ".." &&
+    segment.startsWith(".")
+  ) ?? null;
 }
 
 async function assertNoSymlinkAttachmentPath(
@@ -496,7 +501,7 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
     },
     async ({ path: relPath, maxBytes }) => {
       try {
-        const hiddenName = hiddenAttachmentBasename(relPath);
+        const hiddenName = hiddenAttachmentSegment(relPath);
         if (hiddenName) {
           return errorResult(
             `Refusing to fetch hidden attachment "${displayAttachmentValue(relPath)}" via get_attachment.`,


### PR DESCRIPTION
What changed: attachment inventory now prunes hidden dot-directories, and `get_attachment` rejects any hidden path segment instead of only hidden basenames.

Why: hidden dotfiles were already outside the attachment surface, but files under paths like `assets/.private/file.png` could still be listed or fetched directly.

Risk: low. This only turns hidden-directory attachment paths into the same error path used for hidden dotfiles.

Score: 5 severity x 3 reach / 1 effort = 15.

Tests:
- `npm test -- src/__tests__/handlers/attachments.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run verify`

Greptile skipped because the trial review quota is exhausted.