### PR TITLE
fix: preserve posix backslashes in permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_note` line fragments now reject unsafe line numbers and cap line-range scan/output bytes, while still allowing small targeted fragments from notes over the full-read cap.
 - `list_sections` now rejects non-markdown files and notes over the configured note-size cap before parsing headings.
 - Attachment inventory and direct attachment reads now skip files inside hidden dot-directories, matching the existing hidden-dotfile boundary.
+- Folder-scoped permissions now preserve literal backslashes on POSIX so root-level filenames cannot mimic allowed subfolders.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/src/__tests__/regression-permissions.test.ts
+++ b/src/__tests__/regression-permissions.test.ts
@@ -3,7 +3,9 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { loadPermissionsFromEnv, setPermissions } from "../lib/permissions.js";
-import { listAttachments, listBaseFiles, listCanvasFiles, listNotes } from "../lib/vault.js";
+import { listAttachments, listBaseFiles, listCanvasFiles, listNotes, readNote } from "../lib/vault.js";
+
+const itPosix = process.platform === "win32" ? it.skip : it;
 
 /**
  * M6 regression: parseList delimiter behavior.
@@ -134,5 +136,13 @@ describe("regression: read allowlists apply to vault-wide listings", () => {
 
   it("still rejects explicit folder listings outside the allowlist", async () => {
     await expect(listNotes(vaultDir, "private")).rejects.toThrow(/Access denied/i);
+  });
+
+  itPosix("does not treat literal backslashes as folder separators", async () => {
+    await fs.writeFile(path.join(vaultDir, "public\\secret.md"), "secret", "utf-8");
+
+    await expect(readNote(vaultDir, "public\\secret.md")).rejects.toThrow(
+      /OBSIDIAN_READ_PATHS/,
+    );
   });
 });

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -26,7 +26,10 @@ import path from "path";
  *
  * Path matching is case-insensitive on Windows and macOS to align with the
  * vault's filesystem semantics, and case-sensitive on Linux. Paths are
- * normalized to forward slashes and stripped of leading/trailing separators.
+ * normalized to forward slashes on Windows and stripped of leading/trailing
+ * separators. On POSIX, literal backslashes are kept as filename characters
+ * so a root-level file named `public\secret.md` does not match an allowlist
+ * entry for the `public/` folder.
  *
  * Critically: `..` segments are collapsed BEFORE the prefix check. v1.8.0
  * called `assertAllowed` on the raw user-supplied path, then later let
@@ -37,6 +40,7 @@ import path from "path";
  */
 
 const CASE_INSENSITIVE = process.platform === "win32" || process.platform === "darwin";
+const BACKSLASH_IS_SEPARATOR = process.platform === "win32";
 
 export type AccessKind = "read" | "write";
 
@@ -59,7 +63,7 @@ function parseList(raw: string | undefined): string[] | null {
 }
 
 function normalizeFolder(folder: string): string {
-  let f = folder.replace(/\\/g, "/").trim();
+  let f = normalizePermissionSeparators(folder).trim();
   while (f.startsWith("/")) f = f.slice(1);
   while (f.endsWith("/")) f = f.slice(0, -1);
   if (f === "." || f === "") return "";
@@ -90,6 +94,10 @@ function eq(a: string, b: string): boolean {
   return CASE_INSENSITIVE ? a.toLowerCase() === b.toLowerCase() : a === b;
 }
 
+function normalizePermissionSeparators(input: string): string {
+  return BACKSLASH_IS_SEPARATOR ? input.replace(/\\/g, "/") : input;
+}
+
 /**
  * Convert a user-supplied path to a vault-relative form with `..` segments
  * syntactically collapsed. Returns `null` when the input tries to climb
@@ -97,7 +105,7 @@ function eq(a: string, b: string): boolean {
  * as a hard-deny.
  */
 function normalizeRel(input: string): string | null {
-  const slashed = input.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+  const slashed = normalizePermissionSeparators(input).replace(/^\/+|\/+$/g, "");
   if (slashed === "") return "";
   const normalized = path.posix.normalize(slashed);
   // After normalization: `..` or `../...` means the input climbed above the
@@ -109,7 +117,7 @@ function normalizeRel(input: string): string | null {
 }
 
 function isUnder(rel: string, folder: string): boolean {
-  const r = rel.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+  const r = normalizePermissionSeparators(rel).replace(/^\/+|\/+$/g, "");
   if (folder === "") return true;
   if (eq(r, folder)) return true;
   const prefix = folder + "/";


### PR DESCRIPTION
What changed: folder-scoped permission matching now treats backslashes as separators only on Windows. On POSIX, a literal backslash stays part of the filename, so `public\secret.md` no longer matches an allowlist entry for `public/`.

Why: Node path behavior is platform-specific: POSIX normalization uses `/` as the separator, while Windows accepts `\` and `/` as separators. The permission matcher was treating `\` as a separator on every platform, which could make a POSIX root-level filename look like it lived under an allowed folder. Source: https://nodejs.org/api/path.html

Risk: low. Windows behavior stays unchanged; POSIX only gets stricter for literal backslash filenames when read/write allowlists are configured.

Score: 5 severity x 2 reach / 1 effort = 10.

Tests:
- `npm test -- src/__tests__/permissions.test.ts`
- `npm test -- src/__tests__/regression-permissions.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run verify`

The new regression is POSIX-only and is skipped on Windows. Greptile skipped because the trial review quota is exhausted.