### PR TITLE
fix: bound daily-note config reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `list_sections` now rejects non-markdown files and notes over the configured note-size cap before parsing headings.
 - Attachment inventory and direct attachment reads now skip files inside hidden dot-directories, matching the existing hidden-dotfile boundary.
 - Folder-scoped permissions now preserve literal backslashes on POSIX so root-level filenames cannot mimic allowed subfolders.
+- Daily-note config reads now use the internal vault-boundary check, reject oversized config files, and ignore overlong fields.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { getDailyNoteConfig } from "../config.js";
+
+let vaultDir: string;
+
+beforeEach(async () => {
+  vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "config-test-"));
+  await fs.mkdir(path.join(vaultDir, ".obsidian"), { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.rm(vaultDir, { recursive: true, force: true });
+});
+
+async function writeDailyConfig(content: string): Promise<void> {
+  await fs.writeFile(path.join(vaultDir, ".obsidian", "daily-notes.json"), content, "utf-8");
+}
+
+describe("getDailyNoteConfig", () => {
+  it("uses defaults when daily-notes.json exceeds the size cap", async () => {
+    await writeDailyConfig(JSON.stringify({
+      folder: "daily",
+      format: "YYYY-MM-DD",
+      filler: "x".repeat(70 * 1024),
+    }));
+
+    await expect(getDailyNoteConfig(vaultDir)).resolves.toEqual({
+      folder: "",
+      format: "YYYY-MM-DD",
+    });
+  });
+
+  it("ignores overlong daily-note config fields", async () => {
+    await writeDailyConfig(JSON.stringify({
+      folder: "a".repeat(501),
+      format: "Y".repeat(501),
+      template: "t".repeat(501),
+    }));
+
+    await expect(getDailyNoteConfig(vaultDir)).resolves.toEqual({
+      folder: "",
+      format: "YYYY-MM-DD",
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,11 @@ import * as path from "path";
 import * as os from "os";
 import type { VaultConfig, DailyNoteConfig } from "./types.js";
 import { log } from "./lib/logger.js";
+import { resolveVaultInternalPathSafe } from "./lib/vault.js";
+
+const DAILY_NOTES_CONFIG_REL_PATH = ".obsidian/daily-notes.json";
+const MAX_DAILY_NOTES_CONFIG_BYTES = 64 * 1024;
+const MAX_DAILY_NOTES_CONFIG_FIELD_CHARS = 500;
 
 interface ObsidianVaultEntry {
   path: string;
@@ -54,6 +59,17 @@ function isObsidianConfig(value: unknown): value is ObsidianConfig {
   }
 
   return true;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function boundedDailyConfigString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  if (value.length > MAX_DAILY_NOTES_CONFIG_FIELD_CHARS) return undefined;
+  if (value.includes("\0")) return undefined;
+  return value;
 }
 
 function isValidVaultPath(vaultPath: string): boolean {
@@ -201,14 +217,28 @@ export async function getDailyNoteConfig(vaultPath?: string): Promise<DailyNoteC
   };
 
   const resolvedVaultPath = vaultPath ?? getVaultConfig().vaultPath;
-  const dailyNotesConfigPath = path.join(
-    resolvedVaultPath,
-    ".obsidian",
-    "daily-notes.json"
-  );
+  let dailyNotesConfigPath: string;
+  try {
+    dailyNotesConfigPath = await resolveVaultInternalPathSafe(
+      resolvedVaultPath,
+      DAILY_NOTES_CONFIG_REL_PATH,
+    );
+  } catch (err) {
+    log.warn("Failed to resolve daily notes config path", { err: err as Error });
+    return defaults;
+  }
 
   let raw: string;
   try {
+    const stats = await fsp.stat(dailyNotesConfigPath);
+    if (!stats.isFile()) return defaults;
+    if (stats.size > MAX_DAILY_NOTES_CONFIG_BYTES) {
+      log.warn("Daily notes config exceeds size cap; using defaults", {
+        bytes: stats.size,
+        max: MAX_DAILY_NOTES_CONFIG_BYTES,
+      });
+      return defaults;
+    }
     raw = await fsp.readFile(dailyNotesConfigPath, "utf-8");
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return defaults;
@@ -220,12 +250,15 @@ export async function getDailyNoteConfig(vaultPath?: string): Promise<DailyNoteC
   }
 
   try {
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isPlainObject(parsed)) return defaults;
+    const folder = boundedDailyConfigString(parsed.folder);
+    const format = boundedDailyConfigString(parsed.format);
+    const template = boundedDailyConfigString(parsed.template);
     return {
-      folder: typeof parsed.folder === "string" ? parsed.folder : defaults.folder,
-      format: typeof parsed.format === "string" ? parsed.format : defaults.format,
-      template:
-        typeof parsed.template === "string" ? parsed.template : undefined,
+      folder: folder ?? defaults.folder,
+      format: format ?? defaults.format,
+      template,
     };
   } catch (err) {
     log.warn("Failed to parse daily notes config", {


### PR DESCRIPTION
What changed: daily-note config reads now resolve `.obsidian/daily-notes.json` through the internal vault-boundary helper, stat before reading, reject config files over 64 KiB, and accept only bounded string fields.

Why: the daily-note config is vault-controlled input that feeds `get_daily_note`, `create_daily_note`, and the daily resource path. Keeping it on the internal path boundary and bounded avoids oversized config reads and pathological folder/format/template values.

Risk: low. Valid daily-note settings continue to parse; malformed, oversized, or overlong settings fall back to defaults.

Score: 4 severity x 3 reach / 1 effort = 12.

Tests:
- `npm test -- src/__tests__/config.test.ts`
- `npm test -- src/__tests__/handlers/read.test.ts`
- `npm test -- src/__tests__/handlers/write.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run verify`

Greptile skipped because the trial review quota is exhausted.