### PR TITLE
fix: bound rewrite apply reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Attachment inventory and direct attachment reads now skip files inside hidden dot-directories, matching the existing hidden-dotfile boundary.
 - Folder-scoped permissions now preserve literal backslashes on POSIX so root-level filenames cannot mimic allowed subfolders.
 - Daily-note config reads now use the internal vault-boundary check, reject oversized config files, and ignore overlong fields.
+- Bulk reference rewrite apply now re-checks markdown note and Canvas file size caps before re-reading planned referrers.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/src/__tests__/link-rewriter.test.ts
+++ b/src/__tests__/link-rewriter.test.ts
@@ -2,7 +2,15 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
-import { deleteNote, listNotes, moveNote, readNote, writeNote } from "../lib/vault.js";
+import {
+  deleteNote,
+  listNotes,
+  moveNote,
+  readNote,
+  writeNote,
+  setMaxNoteFileBytesForTests,
+  MAX_CANVAS_FILE_BYTES,
+} from "../lib/vault.js";
 import { planMoveRewrites, planDeleteRewrites, applyRewrites } from "../lib/link-rewriter.js";
 
 let vaultDir: string;
@@ -12,6 +20,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  setMaxNoteFileBytesForTests(null);
   await fs.rm(vaultDir, { recursive: true, force: true });
 });
 
@@ -388,6 +397,63 @@ describe("applyRewrites — TOCTOU safety", () => {
     expect(result.failed).toEqual([]);
     expect(result.updated).toEqual(["ref.md"]);
     expect(await readNote(vaultDir, "ref.md")).toBe("See [[archive/idea]] please.");
+  });
+
+  it("fails when a planned markdown referrer grows past the note cap before apply", async () => {
+    await seed("inbox/idea.md", "# Idea");
+    await seed("ref.md", "See [[inbox/idea]].");
+
+    const preMoveNotes = await listNotes(vaultDir);
+    const plan = await planMoveRewrites(
+      vaultDir,
+      "inbox/idea.md",
+      "archive/idea.md",
+      preMoveNotes,
+    );
+
+    const racedContent = `See [[inbox/idea]].\n${"x".repeat(80)}`;
+    setMaxNoteFileBytesForTests(64);
+    await fs.writeFile(path.join(vaultDir, "ref.md"), racedContent, "utf-8");
+
+    const result = await applyRewrites(vaultDir, plan);
+
+    expect(result.updated).toEqual([]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].path).toBe("ref.md");
+    expect(result.failed[0].error).toContain("Note file exceeds size cap");
+    expect(await fs.readFile(path.join(vaultDir, "ref.md"), "utf-8")).toBe(racedContent);
+  });
+
+  it("fails when a planned canvas referrer grows past the canvas cap before apply", async () => {
+    await seed("inbox/idea.md", "# Idea");
+    await seed(
+      "board.canvas",
+      JSON.stringify({
+        nodes: [{ id: "n1", type: "file", file: "inbox/idea.md" }],
+        edges: [],
+      }),
+    );
+
+    const preMoveNotes = await listNotes(vaultDir);
+    const plan = await planMoveRewrites(
+      vaultDir,
+      "inbox/idea.md",
+      "archive/idea.md",
+      preMoveNotes,
+    );
+
+    const oversizedCanvas = `{"nodes":${"x".repeat(MAX_CANVAS_FILE_BYTES + 1)}}`;
+    await fs.writeFile(path.join(vaultDir, "board.canvas"), oversizedCanvas, "utf-8");
+
+    const result = await applyRewrites(vaultDir, plan);
+
+    expect(result.updated).toEqual([]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].path).toBe("board.canvas");
+    expect(result.failed[0].error).toContain("Canvas file exceeds size cap");
+    expect(await fs.readFile(path.join(vaultDir, "board.canvas"), "utf-8")).toBe(
+      oversizedCanvas,
+    );
   });
 });
 

--- a/src/lib/link-rewriter.ts
+++ b/src/lib/link-rewriter.ts
@@ -7,6 +7,8 @@ import {
   resolveVaultPathSafe,
   withFileLock,
   atomicWriteFile,
+  assertNoteFileSize,
+  MAX_CANVAS_FILE_BYTES,
 } from "./vault.js";
 import {
   extractAliases,
@@ -20,6 +22,14 @@ import { log } from "./logger.js";
 import type { CanvasData } from "../types.js";
 
 const SCAN_CONCURRENCY = 8;
+
+function assertCanvasApplyFileSize(relativePath: string, size: number): void {
+  if (size > MAX_CANVAS_FILE_BYTES) {
+    throw new Error(
+      `Canvas file exceeds size cap (${size} > ${MAX_CANVAS_FILE_BYTES} bytes): ${relativePath}`,
+    );
+  }
+}
 
 /** A single in-place edit on a referrer file, expressed as a byte-offset slice
  *  to replace. Edits within a file are listed in increasing-offset order.
@@ -351,6 +361,8 @@ export async function applyRewrites(
           // applyEditsBackToFront verifies each edit's `expected` slice
           // matches before splicing — a parallel `write_note` that landed
           // between plan and apply will fail the comparison.
+          const stats = await fs.stat(fullPath);
+          assertNoteFileSize(notePath, stats.size);
           const current = await fs.readFile(fullPath, "utf-8");
           let next = applyEditsBackToFront(current, edits);
           if (next === null) {
@@ -373,6 +385,7 @@ export async function applyRewrites(
             return;
           }
           if (next !== current) {
+            assertNoteFileSize(notePath, Buffer.byteLength(next, "utf-8"));
             await atomicWriteFile(fullPath, next);
             didWrite = true;
           }
@@ -391,6 +404,8 @@ export async function applyRewrites(
       const fullPath = await resolveVaultPathSafe(vaultPath, cp, "write");
       let didWrite = false;
       await withFileLock(fullPath, async () => {
+        const stats = await fs.stat(fullPath);
+        assertCanvasApplyFileSize(cp, stats.size);
         const raw = await fs.readFile(fullPath, "utf-8");
         let parsed: unknown;
         try {
@@ -409,7 +424,9 @@ export async function applyRewrites(
           }
         }
         if (mutated) {
-          await atomicWriteFile(fullPath, JSON.stringify({ ...obj, nodes }, null, 2));
+          const serialized = JSON.stringify({ ...obj, nodes }, null, 2);
+          assertCanvasApplyFileSize(cp, Buffer.byteLength(serialized, "utf-8"));
+          await atomicWriteFile(fullPath, serialized);
           didWrite = true;
         }
       });


### PR DESCRIPTION
What changed: bulk reference rewrite apply now checks current markdown note and Canvas file sizes inside the per-file lock before re-reading planned referrers, and checks rewritten output before writing.

Why: `move_note` and permanent `delete_note` plan against bounded files, but a referrer can grow after planning and before apply. Re-checking at apply time keeps the rewrite pass on the same size boundary as normal note and Canvas operations.

Risk: low. Normal rewrites are unchanged; oversized referrers now surface as failed referrers instead of being read and rewritten.

Score: 4 severity x 3 reach / 1 effort = 12.

Tests:
- `npm test -- src/__tests__/link-rewriter.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run verify`

Greptile skipped because the trial review quota is exhausted.