### PR TITLE
fix: reject symlink retargeting moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Folder-scoped permissions now preserve literal backslashes on POSIX so root-level filenames cannot mimic allowed subfolders.
 - Daily-note config reads now use the internal vault-boundary check, reject oversized config files, and ignore overlong fields.
 - Bulk reference rewrite apply now re-checks markdown note and Canvas file size caps before re-reading planned referrers.
+- `move_note` now rejects relative symlink moves whose copied destination link would resolve to a different target.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -576,6 +576,24 @@ describe("moveNote", () => {
     await expect(fs.access(path.join(vaultDir, "old.md"))).rejects.toThrow();
     await expect(fs.access(path.join(vaultDir, "new.md"))).resolves.toBeUndefined();
   });
+
+  it.skipIf(!SYMLINKS_SUPPORTED)("rejects relative symlink moves that would retarget the link", async () => {
+    await fs.mkdir(path.join(vaultDir, "links"), { recursive: true });
+    await fs.writeFile(path.join(vaultDir, "links", "target.md"), "target", "utf-8");
+    await fs.symlink("target.md", path.join(vaultDir, "links", "source.md"));
+
+    await expect(
+      moveNote(vaultDir, "links/source.md", "archive/source.md", { updateLinks: false }),
+    ).rejects.toThrow("Refusing to move symlink");
+
+    const sourceStat = await fs.lstat(path.join(vaultDir, "links", "source.md"));
+    expect(sourceStat.isSymbolicLink()).toBe(true);
+    await expect(fs.readlink(path.join(vaultDir, "links", "source.md"))).resolves.toBe(
+      "target.md",
+    );
+    await expect(fs.lstat(path.join(vaultDir, "archive", "source.md"))).rejects.toThrow();
+    await expect(readNote(vaultDir, "links/source.md")).resolves.toBe("target");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -968,14 +968,32 @@ async function linkOrCopyFileNoReplace(fullOldPath: string, fullNewPath: string)
   await fs.copyFile(fullOldPath, fullNewPath, fsConstants.COPYFILE_EXCL);
 }
 
-async function createDestinationNoReplace(fullOldPath: string, fullNewPath: string): Promise<void> {
+async function createDestinationNoReplace(
+  vaultPath: string,
+  fullOldPath: string,
+  fullNewPath: string,
+): Promise<void> {
   const sourceStat = await fs.lstat(fullOldPath);
   if (sourceStat.isSymbolicLink()) {
+    const sourceCanonical = await assertRealPathWithinVault(fullOldPath, vaultPath);
     const linkTarget = await fs.readlink(fullOldPath);
-    if (IS_WIN32) {
-      await fs.symlink(linkTarget, fullNewPath, "file");
-    } else {
-      await fs.symlink(linkTarget, fullNewPath);
+    let createdSymlink = false;
+    try {
+      if (IS_WIN32) {
+        await fs.symlink(linkTarget, fullNewPath, "file");
+      } else {
+        await fs.symlink(linkTarget, fullNewPath);
+      }
+      createdSymlink = true;
+      const destCanonical = await assertRealPathWithinVault(fullNewPath, vaultPath);
+      if (destCanonical.realPath !== sourceCanonical.realPath) {
+        throw new Error("Refusing to move symlink because the destination would point somewhere else");
+      }
+    } catch (err) {
+      if (createdSymlink) {
+        try { await fs.unlink(fullNewPath); } catch { /* ignore cleanup failure */ }
+      }
+      throw err;
     }
     return;
   }
@@ -983,13 +1001,14 @@ async function createDestinationNoReplace(fullOldPath: string, fullNewPath: stri
 }
 
 async function movePathNoReplace(
+  vaultPath: string,
   fullOldPath: string,
   fullNewPath: string,
   displayNewPath: string,
 ): Promise<void> {
   let createdDestination = false;
   try {
-    await createDestinationNoReplace(fullOldPath, fullNewPath);
+    await createDestinationNoReplace(vaultPath, fullOldPath, fullNewPath);
     createdDestination = true;
     await unlinkWithRetry(fullOldPath);
   } catch (err) {
@@ -1048,7 +1067,7 @@ export async function moveNote(
       return;
     }
     await fs.mkdir(path.dirname(fullNewPath), { recursive: true });
-    await movePathNoReplace(fullOldPath, fullNewPath, newPath);
+    await movePathNoReplace(vaultPath, fullOldPath, fullNewPath, newPath);
   };
 
   const performMove = async (): Promise<MoveNoteResult> => {


### PR DESCRIPTION
﻿What changed: `move_note` now validates symlink moves after creating the destination link but before unlinking the source. If the copied symlink would resolve to a different canonical target, the destination is cleaned up and the move fails.

Why: moving a relative symlink into another directory can change what the raw link target points at. The move path already validates source and destination paths, but the destination symlink did not exist yet when those checks ran.

Risk: low. Regular file moves are unchanged; symlink moves that preserve the same target still work, while retargeting moves now fail closed.

Score: 5 severity x 2 reach / 1 effort = 10.

Tests:
- `npm test -- src/__tests__/vault.test.ts`
- `CI_SYMLINKS=1 npm test -- src/__tests__/vault.test.ts -t "rejects relative symlink moves"`
- `npm run lint`
- `npm run typecheck`
- `npm run verify`

Greptile skipped because the trial review quota is exhausted.
