### PR TITLE
fix: require regular files for direct reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Daily-note config reads now use the internal vault-boundary check, reject oversized config files, and ignore overlong fields.
 - Bulk reference rewrite apply now re-checks markdown note and Canvas file size caps before re-reading planned referrers.
 - `move_note` now rejects relative symlink moves whose copied destination link would resolve to a different target.
+- Direct note reads, note read-modify-write helpers, and direct attachment reads now require regular files before reading content.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/src/__tests__/handlers/attachments.test.ts
+++ b/src/__tests__/handlers/attachments.test.ts
@@ -342,6 +342,19 @@ describe("attachments handlers — get_attachment", () => {
     expect(text).not.toContain(Buffer.from("PNG-hidden-dir").toString("base64"));
   });
 
+  it("rejects directory attachment paths before reading bytes", async () => {
+    await fs.mkdir(path.join(env.vaultDir, "assets", "not-file.bin"));
+
+    const result = await env.client.callTool({
+      name: "get_attachment",
+      arguments: { path: "assets/not-file.bin" },
+    });
+
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain('Attachment "assets/not-file.bin" is not a regular file.');
+  });
+
   itSymlink("rejects symlinked attachment files skipped by the inventory", async () => {
     await fs.symlink(
       path.join(env.vaultDir, "assets", "used-image.png"),

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -222,6 +222,17 @@ describe("readNote", () => {
     );
   });
 
+  it("rejects markdown directories before reading note content", async () => {
+    await fs.mkdir(path.join(vaultDir, "directory.md"));
+
+    await expect(readNote(vaultDir, "directory.md")).rejects.toThrow(
+      "Not a regular file: directory.md",
+    );
+    await expect(readNoteLineRange(vaultDir, "directory.md", 1, 1)).rejects.toThrow(
+      "Not a regular file: directory.md",
+    );
+  });
+
   it("still streams line fragments from notes over the full-read cap", async () => {
     setMaxNoteFileBytesForTests(10);
     await fs.writeFile(
@@ -344,6 +355,20 @@ describe("writeNote", () => {
     );
     await expect(fs.readFile(path.join(vaultDir, "oversized.md"), "utf-8"))
       .resolves.toBe(oversized);
+  });
+
+  it("refuses to read-modify-write markdown directories", async () => {
+    await fs.mkdir(path.join(vaultDir, "directory.md"));
+
+    await expect(updateNote(vaultDir, "directory.md", () => "small")).rejects.toThrow(
+      "Not a regular file: directory.md",
+    );
+    await expect(appendToNote(vaultDir, "directory.md", "tail")).rejects.toThrow(
+      "Not a regular file: directory.md",
+    );
+    await expect(prependToNote(vaultDir, "directory.md", "head")).rejects.toThrow(
+      "Not a regular file: directory.md",
+    );
   });
 });
 

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1,5 +1,5 @@
 import fs from "fs/promises";
-import { constants as fsConstants } from "fs";
+import { constants as fsConstants, type Stats } from "fs";
 import path from "path";
 import { randomBytes } from "crypto";
 import { StringDecoder } from "string_decoder";
@@ -55,11 +55,26 @@ export function assertNoteFileSize(relativePath: string, size: number): void {
   }
 }
 
+function assertRegularFile(relativePath: string, stats: Stats): void {
+  if (!stats.isFile()) {
+    throw new Error(`Not a regular file: ${relativePath}`);
+  }
+}
+
+async function assertResolvedRegularFile(
+  fullPath: string,
+  relativePath: string,
+): Promise<Stats> {
+  const stats = await fs.stat(fullPath);
+  assertRegularFile(relativePath, stats);
+  return stats;
+}
+
 async function assertResolvedNoteFileSize(
   fullPath: string,
   relativePath: string,
 ): Promise<void> {
-  const stats = await fs.stat(fullPath);
+  const stats = await assertResolvedRegularFile(fullPath, relativePath);
   assertNoteFileSize(relativePath, stats.size);
 }
 
@@ -571,6 +586,7 @@ export async function readNoteLineRange(
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
   let handle: fs.FileHandle | undefined;
   try {
+    await assertResolvedRegularFile(fullPath, relativePath);
     handle = await fs.open(fullPath, "r");
     const decoder = new StringDecoder("utf8");
     const buffer = Buffer.allocUnsafe(64 * 1024);

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -528,10 +528,21 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         const limit = maxBytes ?? DEFAULT_GET_ATTACHMENT_LIMIT;
         const fullPath = await resolveVaultPathSafe(vaultPath, relPath);
         await assertNoSymlinkAttachmentPath(vaultPath, fullPath, relPath);
+        const preOpenStat = await fs.stat(fullPath);
+        if (!preOpenStat.isFile()) {
+          return errorResult(
+            `Attachment "${displayAttachmentValue(relPath)}" is not a regular file.`,
+          );
+        }
         const handle = await fs.open(fullPath, "r");
         let bytes: Buffer;
         try {
           const stat = await handle.stat();
+          if (!stat.isFile()) {
+            return errorResult(
+              `Attachment "${displayAttachmentValue(relPath)}" is not a regular file.`,
+            );
+          }
           if (stat.size > limit) {
             return errorResult(
               `Attachment "${displayAttachmentValue(relPath)}" is ${stat.size.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`,


### PR DESCRIPTION
﻿What changed: direct note reads, line-fragment reads, note read-modify-write helpers, and direct attachment reads now require the target to be a regular file before reading content. Attachments also re-check the opened handle before reading bytes.

Why: path validation and size checks should not let directory or special-file shapes fall through to `readFile` or streaming reads. Keeping direct reads on regular files matches the broad vault walkers, which already only enumerate files.

Risk: low. Ordinary notes and attachments are unchanged; non-file paths now fail earlier with a clearer error.

Score: 4 severity x 3 reach / 1 effort = 12.

Tests:
- `npm test -- src/__tests__/vault.test.ts`
- `npm test -- src/__tests__/handlers/attachments.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run verify`

Greptile skipped because the trial review quota is exhausted.
