### PR TITLE
fix: require base file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bulk reference rewrite apply now re-checks markdown note and Canvas file size caps before re-reading planned referrers.
 - `move_note` now rejects relative symlink moves whose copied destination link would resolve to a different target.
 - Direct note reads, note read-modify-write helpers, and direct attachment reads now require regular files before reading content.
+- `read_base` and `query_base` now require `.base` file paths instead of accepting arbitrary readable vault files.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/src/__tests__/handlers/bases.test.ts
+++ b/src/__tests__/handlers/bases.test.ts
@@ -10,6 +10,24 @@ afterEach(async () => {
 });
 
 describe("base handlers — read_base", () => {
+  it("rejects non-Base file paths before parsing", async () => {
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "secret.yaml": "properties:\n  token:\n    displayName: Secret\n",
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "read_base",
+      arguments: { path: "secret.yaml" },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/end in \.base|not a base file/i);
+    expect(textContent(result)).not.toContain("Secret");
+  });
+
   it("rejects oversized Base files before parsing", async () => {
     env = await createTestEnv({
       skipFixtures: true,
@@ -93,6 +111,33 @@ describe("base handlers - list_bases", () => {
 });
 
 describe("base handlers — query_base", () => {
+  it("rejects non-Base query paths without returning readable rows", async () => {
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "note.md": [
+          "---",
+          "secret: readable",
+          "---",
+          "# Note",
+          "",
+        ].join("\n"),
+        "query.yaml": "filters:\n  - file.name.contains(\"note\")\n",
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "query_base",
+      arguments: { path: "query.yaml", includeFrontmatter: true },
+    });
+
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toMatch(/end in \.base|not a base file/i);
+    expect(text).not.toContain("note.md");
+    expect(text).not.toContain("secret");
+  });
+
   it("rejects oversized Base files without returning readable rows", async () => {
     env = await createTestEnv({
       skipFixtures: true,

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1337,8 +1337,12 @@ export async function readBaseFile(
   vaultPath: string,
   relativePath: string,
 ): Promise<string> {
+  if (!relativePath.toLowerCase().endsWith(".base")) {
+    throw new Error(`Not a Base file: ${relativePath}`);
+  }
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
   const stats = await fs.stat(fullPath);
+  assertRegularFile(relativePath, stats);
   if (stats.size > MAX_BASE_FILE_BYTES) {
     throw new Error(
       `Base file exceeds size cap (${stats.size} > ${MAX_BASE_FILE_BYTES} bytes)`,

--- a/src/tools/bases.ts
+++ b/src/tools/bases.ts
@@ -81,6 +81,7 @@ export function registerBaseTools(server: McpServer, vaultPath: string): void {
           .string()
           .min(1)
           .max(500)
+          .regex(/\.base$/i, "Path must end in .base")
           .describe("Vault-relative path to the .base file."),
       },
     },
@@ -140,6 +141,7 @@ export function registerBaseTools(server: McpServer, vaultPath: string): void {
           .string()
           .min(1)
           .max(500)
+          .regex(/\.base$/i, "Path must end in .base")
           .describe("Vault-relative path to the .base file."),
         view: z
           .string()


### PR DESCRIPTION
﻿What changed: `read_base` and `query_base` now require paths ending in `.base` at the schema boundary, and `readBaseFile` enforces the same check before resolving and reading files.

Why: Base discovery only lists `.base` files, but direct Base tools previously accepted any readable small vault file and parsed it as a Base document. That widened the file-type boundary and could expose YAML-like metadata from non-Base files.

Risk: low. Valid Base files are unchanged; non-Base paths now fail early with a clear validation error.

Score: 4 severity x 2 reach / 1 effort = 8.

Tests:
- `npm test -- src/__tests__/handlers/bases.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run verify`

Greptile skipped because the trial review quota is exhausted.
