### PR TITLE
fix: mark daily config paths untrusted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `move_note` now rejects relative symlink moves whose copied destination link would resolve to a different target.
 - Direct note reads, note read-modify-write helpers, and direct attachment reads now require regular files before reading content.
 - `read_base` and `query_base` now require `.base` file paths instead of accepting arbitrary readable vault files.
+- Daily-note config-derived paths in `get_daily_note`, `create_daily_note`, and `obsidian://daily` output now use explicit untrusted-content markers, and note/daily resource metadata labels are generic.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -552,8 +552,11 @@ describe("read handlers — get_daily_note", () => {
     });
     expect(isError(result)).toBe(true);
     const text = textContent(result);
-    expect(text).toContain('expected at "daily\\nnotes/1999-01-01.md"');
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_daily_note expected path]");
+    expect(text).toContain("daily\\nnotes/1999-01-01.md");
     expect(text).not.toContain("daily\nnotes");
+    const content = result.content[0] as { _meta?: Record<string, unknown> };
+    expect(content._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("get_daily_note expected path");
   });
 
   it("escapes generated daily-note frontmatter labels", async () => {

--- a/src/__tests__/handlers/resources.test.ts
+++ b/src/__tests__/handlers/resources.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import { createTestEnv, type TestEnv } from "./harness.js";
+import { formatMomentDate } from "../../lib/dates.js";
 
 let env: TestEnv;
 
@@ -49,6 +50,8 @@ describe("MCP resources", () => {
       mimeType: "text/markdown",
     });
     expect(content?._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(content?._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("note resource body");
+    expect(content?._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).not.toContain("nested/note-d.md");
     expect(firstText(result.contents)).toContain("Nested note that references [[note-a]].");
   });
 
@@ -102,7 +105,28 @@ describe("MCP resources", () => {
     expect(text).not.toContain(dirtyPath);
   });
 
-  it("escapes configured daily-note paths in missing daily resource errors", async () => {
+  it("uses generic metadata labels for daily resource bodies", async () => {
+    const today = formatMomentDate(new Date(), "YYYY-MM-DD");
+    await fs.writeFile(
+      path.join(env.vaultDir, "daily", `${today}.md`),
+      "# Today\n\nDaily resource fixture.",
+      "utf-8",
+    );
+
+    const result = await env.client.readResource({ uri: "obsidian://daily" });
+    const content = result.contents[0];
+
+    expect(content).toMatchObject({
+      uri: "obsidian://daily",
+      mimeType: "text/markdown",
+    });
+    expect(content?._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(content?._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("daily note resource body");
+    expect(content?._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).not.toContain(`daily/${today}.md`);
+    expect(firstText(result.contents)).toContain("Daily resource fixture.");
+  });
+
+  it("marks configured daily-note paths in missing daily resource errors as untrusted", async () => {
     const dirtyFolder = "daily\nnotes";
     await fs.writeFile(
       path.join(env.vaultDir, ".obsidian", "daily-notes.json"),
@@ -116,6 +140,7 @@ describe("MCP resources", () => {
       message = err instanceof Error ? err.message : String(err);
     }
 
+    expect(message).toContain("[BEGIN UNTRUSTED VAULT CONTENT: daily note resource expected path]");
     expect(message).toContain("daily\\nnotes/");
     expect(message).not.toContain(dirtyFolder);
   });

--- a/src/__tests__/handlers/write.test.ts
+++ b/src/__tests__/handlers/write.test.ts
@@ -314,11 +314,39 @@ describe("write handlers — create_daily_note", () => {
     });
 
     expect(isError(result)).toBe(false);
-    expect(textContent(result)).toContain("daily\\x7fnotes/2026-05-07.md");
-    expect(textContent(result)).not.toContain(`${dirtyFolder}/2026-05-07.md`);
+    const text = textContent(result);
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: create_daily_note path]");
+    expect(text).toContain("daily\\x7fnotes/2026-05-07.md");
+    expect(text).not.toContain(`${dirtyFolder}/2026-05-07.md`);
+    const content = result.content[0] as { _meta?: Record<string, unknown> };
+    expect(content._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("create_daily_note path");
     await expect(
       fs.access(path.join(env.vaultDir, dirtyFolder, "2026-05-07.md")),
     ).resolves.toBeUndefined();
+  });
+
+  it("marks configured daily-note paths in already-exists output as untrusted", async () => {
+    const dirtyFolder = "daily\x7fnotes";
+    await fs.writeFile(
+      path.join(env.vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: dirtyFolder, format: "YYYY-MM-DD" }),
+      "utf-8",
+    );
+    await fs.mkdir(path.join(env.vaultDir, dirtyFolder), { recursive: true });
+    await fs.writeFile(path.join(env.vaultDir, dirtyFolder, "2026-05-07.md"), "Already here.", "utf-8");
+
+    const result = await env.client.callTool({
+      name: "create_daily_note",
+      arguments: { date: "2026-05-07", content: "May 7 entry." },
+    });
+
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: create_daily_note path]");
+    expect(text).toContain("daily\\x7fnotes/2026-05-07.md");
+    expect(text).not.toContain(`${dirtyFolder}/2026-05-07.md`);
+    const content = result.content[0] as { _meta?: Record<string, unknown> };
+    expect(content._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("create_daily_note path");
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { flushAllCachesAsync, readAllCached } from "./lib/index-cache.js";
 import { extractTags } from "./lib/markdown.js";
 import { log, configureLogger } from "./lib/logger.js";
 import { escapeControlChars, sanitizeError } from "./lib/errors.js";
-import { untrustedVaultContentMeta } from "./lib/tool-output.js";
+import { formatUntrustedVaultContent, untrustedVaultContentMeta } from "./lib/tool-output.js";
 import { formatMomentDate } from "./lib/dates.js";
 import { registerReadTools } from "./tools/read.js";
 import { registerWriteTools } from "./tools/write.js";
@@ -235,7 +235,7 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
               uri: uri.href,
               mimeType: "text/markdown",
               text: content,
-              _meta: untrustedVaultContentMeta(`note resource: ${notePath}`),
+              _meta: untrustedVaultContentMeta("note resource body"),
             },
           ],
         };
@@ -299,7 +299,7 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
             uri: uri.href,
             mimeType: "text/markdown",
             text: content,
-            _meta: untrustedVaultContentMeta(`daily note resource: ${notePath}`),
+            _meta: untrustedVaultContentMeta("daily note resource body"),
           },
         ],
       };
@@ -308,7 +308,10 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
       // response with body "No daily note found..." is indistinguishable to
       // MCP clients from a real note whose first line happens to say the
       // same thing — clients need a proper error so they can branch on it.
-      throw new Error(`No daily note found for today (expected at ${displayResourceValue(notePath)})`);
+      const pathLabel = "daily note resource expected path";
+      throw new Error(
+        `No daily note found for today.\n${formatUntrustedVaultContent(pathLabel, displayResourceValue(notePath))}`,
+      );
     }
   });
 

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -54,8 +54,11 @@ function untrustedReadBlock(label: string, text: string, indent = ""): string {
 }
 
 export function registerReadTools(server: McpServer, vaultPath: string): void {
-  function errorResult(text: string) {
-    return { content: [{ type: "text" as const, text }], isError: true as const };
+  function errorResult(text: string, meta?: Record<string, unknown>) {
+    return {
+      content: [{ type: "text" as const, text, ...(meta ? { _meta: meta } : {}) }],
+      isError: true as const,
+    };
   }
 
   server.registerTool(
@@ -386,7 +389,11 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         try {
           content = await readNote(vaultPath, notePath);
         } catch {
-          return errorResult(`Daily note not found for ${displayReadValue(targetDate)} (expected at "${displayReadValue(notePath)}")`);
+          const pathLabel = "get_daily_note expected path";
+          return errorResult(
+            `Daily note not found for ${displayReadValue(targetDate)}.\n${untrustedReadBlock(pathLabel, displayReadValue(notePath))}`,
+            untrustedVaultContentMeta(pathLabel),
+          );
         }
 
         const { data: dailyFrontmatter, content: dailyBody } = parseFrontmatter(content);

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -12,7 +12,11 @@ import {
 import { updateFrontmatter } from "../lib/markdown.js";
 import { getDailyNoteConfig } from "../config.js";
 import { escapeControlChars, sanitizeError } from "../lib/errors.js";
-import { formatUntrustedFailedPath, untrustedVaultContentMeta } from "../lib/tool-output.js";
+import {
+  formatUntrustedFailedPath,
+  formatUntrustedVaultContent,
+  untrustedVaultContentMeta,
+} from "../lib/tool-output.js";
 import { formatMomentDate, parseLocalDateOnly } from "../lib/dates.js";
 import { elicitTextConfirmation } from "../lib/confirmation.js";
 import { log } from "../lib/logger.js";
@@ -21,8 +25,11 @@ function textResult(text: string, meta?: Record<string, unknown>) {
   return { content: [{ type: "text" as const, text, ...(meta ? { _meta: meta } : {}) }] };
 }
 
-function errorResult(text: string) {
-  return { content: [{ type: "text" as const, text }], isError: true as const };
+function errorResult(text: string, meta?: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text, ...(meta ? { _meta: meta } : {}) }],
+    isError: true as const,
+  };
 }
 
 const displayWriteValue = escapeControlChars;
@@ -325,11 +332,19 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
           await writeNote(vaultPath, notePath, finalContent, { exclusive: true });
         } catch (err) {
           if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-            return errorResult(`Error: Daily note already exists at '${displayWriteValue(notePath)}'.`);
+            const pathLabel = "create_daily_note path";
+            return errorResult(
+              `Error: Daily note already exists.\n${formatUntrustedVaultContent(pathLabel, displayWriteValue(notePath))}`,
+              untrustedVaultContentMeta(pathLabel),
+            );
           }
           throw err;
         }
-        return textResult(`Created daily note at '${displayWriteValue(notePath)}'.`);
+        const pathLabel = "create_daily_note path";
+        return textResult(
+          `Created daily note.\n${formatUntrustedVaultContent(pathLabel, displayWriteValue(notePath))}`,
+          untrustedVaultContentMeta(pathLabel),
+        );
       } catch (err) {
         log.error("create_daily_note failed", { tool: "create_daily_note", err: err as Error });
         return errorResult(`Error creating daily note: ${sanitizeError(err)}`);


### PR DESCRIPTION
Daily-note paths derived from vault config now stay inside untrusted-content blocks for `get_daily_note`, `create_daily_note`, and `obsidian://daily` errors. Note and daily resource metadata labels are generic so `_meta` does not carry vault-authored paths.

Score: 4 severity x 3 reach / 1 effort = 12. These paths are config-derived vault data shown in common read, write, and resource flows.

Risk: output text and metadata labels change, but this follows the 4.0.0 untrusted-content migration and keeps note bodies and resource bytes unchanged.

Tested: `npm test -- src/__tests__/handlers/read.test.ts src/__tests__/handlers/write.test.ts src/__tests__/handlers/resources.test.ts`; `npm run verify`.

Greptile skipped because the review quota is exhausted.