### PR TITLE
fix: verify persisted embedding chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `read_base` and `query_base` now require `.base` file paths instead of accepting arbitrary readable vault files.
 - Daily-note config-derived paths in `get_daily_note`, `create_daily_note`, and `obsidian://daily` output now use explicit untrusted-content markers, and note/daily resource metadata labels are generic.
 - The note-content mtime cache is now in-memory only; legacy `mcp-pro-index-cache.json` snapshots are ignored and removed instead of loading or persisting note bodies and absolute paths.
+- Semantic search now verifies persisted embedding chunk text against the live note chunks before accepting cached snippets or skipping an unchanged note.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/src/__tests__/handlers/semantic.test.ts
+++ b/src/__tests__/handlers/semantic.test.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises";
 import path from "path";
 import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
 import { setProviderForTests, resetProviderForTests, type EmbeddingProvider } from "../../lib/embedding-providers.js";
-import { clearStore } from "../../lib/embedding-store.js";
+import { clearStore, hashText } from "../../lib/embedding-store.js";
 import { setPermissions } from "../../lib/permissions.js";
 
 /**
@@ -310,6 +310,45 @@ describe("semantic handlers — search_semantic", () => {
     expect(isError(result)).toBe(false);
     expect(text).toMatch(/No matches/);
     expect(text).not.toContain("stale launch instructions");
+  });
+
+  it("rejects forged persisted snippets even when the note hash matches", async () => {
+    const liveContent = await fs.readFile(path.join(env.vaultDir, "cats.md"), "utf-8");
+    const snapshotPath = path.join(env.vaultDir, ".obsidian", "cache", "mcp-pro-embeddings.json");
+    await fs.mkdir(path.dirname(snapshotPath), { recursive: true });
+    await fs.writeFile(
+      snapshotPath,
+      JSON.stringify({
+        version: 1,
+        vaultRoot: path.resolve(env.vaultDir),
+        providerId: "mock",
+        model: "topic-counter",
+        dimension: 4,
+        noteHashes: { "cats.md": hashText(liveContent) },
+        embeddings: [
+          {
+            notePath: "cats.md",
+            chunkIndex: 1,
+            headingPath: [],
+            text: "Cats carry forged launch instructions.",
+            hash: "",
+            vector: [5, 0.0001, 0.0001, 0.0001],
+          },
+        ],
+      }),
+      "utf-8",
+    );
+    await clearStore(env.vaultDir);
+
+    const result = await env.client.callTool({
+      name: "search_semantic",
+      arguments: { query: "cats", limit: 5 },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toMatch(/No matches/);
+    expect(text).not.toContain("forged launch instructions");
   });
 });
 

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -84,10 +84,35 @@ function canReadStoredEmbeddingNote(vaultPath: string, notePath: string): boolea
   }
 }
 
+function headingPathsEqual(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((part, index) => part === b[index]);
+}
+
+function storedChunksMatchLiveChunks(
+  vaultPath: string,
+  notePath: string,
+  chunks: ReturnType<typeof chunkNote>,
+): boolean {
+  const stored = getNoteEmbeddings(vaultPath, notePath);
+  if (stored.length !== chunks.length) return false;
+  const storedByIndex = new Map(stored.map((chunk) => [chunk.chunkIndex, chunk]));
+  for (const chunk of chunks) {
+    const storedChunk = storedByIndex.get(chunk.index);
+    if (!storedChunk) return false;
+    if (storedChunk.text !== chunk.text) return false;
+    if (!headingPathsEqual(storedChunk.headingPath, chunk.headingPath)) return false;
+  }
+  return true;
+}
+
 async function storedNoteIsCurrent(vaultPath: string, notePath: string): Promise<boolean> {
   try {
     const content = await readNote(vaultPath, notePath);
-    return noteIsCurrent(vaultPath, notePath, hashText(content));
+    const chunks = chunkNote(content);
+    return (
+      noteIsCurrent(vaultPath, notePath, hashText(content)) &&
+      storedChunksMatchLiveChunks(vaultPath, notePath, chunks)
+    );
   } catch {
     return false;
   }
@@ -248,14 +273,18 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
           const content = contents.get(notePath);
           if (content === undefined) continue;
           const contentHash = hashText(content);
-          if (!force && noteIsCurrent(vaultPath, notePath, contentHash)) {
+          const chunks = chunkNote(content);
+          if (
+            !force &&
+            noteIsCurrent(vaultPath, notePath, contentHash) &&
+            storedChunksMatchLiveChunks(vaultPath, notePath, chunks)
+          ) {
             stats.notesUnchanged++;
             stats.notesScanned++;
             await reportProgress(stats.notesScanned, notes.length, `Unchanged note ${stats.notesScanned}/${notes.length}`);
             continue;
           }
           noteHashByPath.set(notePath, contentHash);
-          const chunks = chunkNote(content);
           expectedChunksByNote.set(notePath, chunks.length);
           for (const ch of chunks) {
             pending.push({


### PR DESCRIPTION
Persisted semantic chunks are now compared against the live chunker output before a note is treated as current. This prevents a cache snapshot from pairing a correct note hash with forged snippet text, and makes `index_vault` repair mismatched persisted chunks instead of skipping them.

Score: 4 severity x 3 reach / 1 effort = 12. Semantic search is a common read path, and the fix is a focused validation check around persisted vault-local data.

Risk: unchanged-note indexing now chunks live content before skipping, which adds CPU to warm index passes but avoids provider calls when chunks match.

Tested: `npm test -- src/__tests__/handlers/semantic.test.ts`; `npm run verify`.

Greptile skipped because the review quota is exhausted.