### PR TITLE
fix: require semantic indexing confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Migration
 
 - `get_note`, `get_daily_note`, `search_notes`, `search_by_frontmatter`, `list_notes`, `get_recent_notes`, `get_vault_stats`, `resolve_alias`, `list_tags`, `search_by_tag` result paths and previews, `rename_tag` skipped note rows, `index_vault` failed note rows, `search_semantic` result paths and snippets, semantic heading paths, `find_similar_notes` result paths, `move_note`/`delete_note` failed referrers, `get_backlinks`, `get_outlinks`, `find_orphans`, `find_broken_links`, `get_graph_neighbors`, `list_attachments` paths and extension summaries, `find_unused_attachments`, `list_bases`, `list_canvases`, `read_canvas` paths, node identities, node colors, edge endpoints, node previews, and edge labels, `read_base`, `query_base`, SVG attachment text, section-heading output, backlink context output, and note/daily resource bodies now wrap vault-authored text or path summaries in `[BEGIN UNTRUSTED VAULT CONTENT: ...]` / `[END UNTRUSTED VAULT CONTENT: ...]` markers. Clients that parsed raw note fragments, path rows, attachment extension summaries, failed-referrer rows, skipped-note rows, failed-note rows, search result headings, tag values, headings, link targets, canvas labels, canvas identifiers, resource bodies, or snippets should extract the text between those markers.
+- `index_vault` now requires `confirm: "send-vault-text-to-embedding-provider"` on each call before it reads notes and sends chunks to the configured embedding provider.
 
 ### Added
 
@@ -55,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Note and daily resources now wrap returned markdown bodies in visible untrusted-content markers instead of relying only on `_meta` trust metadata.
 - The note-content mtime cache is now in-memory only; legacy `mcp-pro-index-cache.json` snapshots are ignored and removed instead of loading or persisting note bodies and absolute paths.
 - Semantic search now verifies persisted embedding chunk text against the live note chunks before accepting cached snippets or skipping an unchanged note.
+- `index_vault` now has a hard confirmation latch before any readable note chunks are sent to the active embedding provider.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Give AI assistants deep, structured access to your Obsidian knowledge base. Read
 
 ### Semantic Search (optional, Ollama or OpenAI)
 - `index_vault` chunks each note (heading-aware), embeds via the configured provider, persists vectors to `<vault>/.obsidian/cache/`, and incrementally re-embeds only changed notes
+- Because indexing sends readable note chunks to the configured embedding provider, `index_vault` requires `confirm: "send-vault-text-to-embedding-provider"` on each call
 - `search_semantic` ranks notes by cosine similarity against an embedded query
 - `find_similar_notes` reuses an existing note's embeddings, with source-topic anchoring, to surface neighbors without a live API call
 - Stored snippets are returned only while the current note content hash still matches the indexed text; stale chunks are pruned on search
@@ -336,6 +337,14 @@ The semantic-search tools (`index_vault`, `search_semantic`, `find_similar_notes
 
 For local Ollama: install [Ollama](https://ollama.com/), then `ollama pull nomic-embed-text`. The semantic tools register even when no provider is configured, so they're discoverable; calls return a configuration hint until set up.
 
+`index_vault` sends readable note chunks to that provider. Calls must include:
+
+```json
+{ "confirm": "send-vault-text-to-embedding-provider" }
+```
+
+This latch is per call so scripted index refreshes have to keep the privacy decision visible.
+
 ### Observability
 
 Logs stream to stderr as either plain text (default) or single-line JSON, controlled by `LOG_LEVEL` (`debug`/`info`/`warn`/`error`/`silent`) and `LOG_FORMAT` (`text`/`json`).
@@ -358,6 +367,7 @@ The server also declares the MCP [`logging` capability](https://modelcontextprot
 - **Untrusted vault text boundaries** — tool outputs that include note bodies, read, search result, semantic result, semantic index failure, write rewrite-warning, link-graph, attachment, Base, and Canvas path summaries, attachment extension summaries, search snippets, semantic snippets and heading paths, tag lists, tag search result paths and previews, tag rename skipped-note rows, frontmatter values, Base data, wikilink targets in link-analysis output, SVG attachment text, section headings, Canvas node identities, colors, previews, edge endpoints, and edge labels, or backlink context wrap those vault-authored portions in `[BEGIN UNTRUSTED VAULT CONTENT: ...]` / `[END UNTRUSTED VAULT CONTENT: ...]` markers before they enter an MCP client's model context. Note and daily resources use the same visible boundaries for markdown bodies and carry `_meta["obsidian-mcp-pro/contentTrust"] = "untrusted-vault-content"`.
 - **YAML parser boundaries** — Obsidian properties are parsed only from `---` YAML delimiter lines; non-YAML gray-matter language blocks stay as body text, oversized frontmatter is skipped on reads and refused for metadata updates, and note/Base YAML containing anchors or aliases is not parsed.
 - **Semantic index freshness** — `search_semantic` and `find_similar_notes` re-check current note content hashes before returning stored snippets or source-note embeddings, pruning stale cache entries instead of surfacing old note text.
+- **Semantic indexing confirmation** — `index_vault` refuses to read and embed vault notes unless the call includes `confirm: "send-vault-text-to-embedding-provider"`, making provider-bound note transfer explicit.
 - **Bulk-write confirmations** — clients that support MCP elicitation are asked to re-type the destination path or new tag before `move_note` rewrites references or `rename_tag` writes across the vault. Dry runs and clients without elicitation keep their existing behavior.
 - **Atomic writes** — every note write (`create_note`, `append`, `prepend`, `update_frontmatter`, canvas mutations) stages content to a sibling temp file then renames onto the target, so a crash or kill mid-write never leaves a truncated file. Combined with per-path locks for the full read-modify-write cycle, concurrent callers can't lose each other's updates. The `install` subcommand uses the same pattern and keeps a backup of the previous config.
 - **Rate limiting + CORS allowlist** — optional `--rate-limit` caps per-IP request volume; `--allow-origin` restricts browser-facing CORS and refuses `*` unless bearer auth is enabled. `/health` and `/version` stay reachable under load for monitoring.
@@ -463,7 +473,7 @@ Tag extraction is similarly case-tolerant: `tags`, `Tags`, `TAGS`, `tag`, and `T
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
-| `index_vault` | Build / refresh the embedding index (incremental, progress events) | `force`, `folder` |
+| `index_vault` | Build / refresh the embedding index (incremental, progress events) | `force`, `folder`, `confirm` |
 | `search_semantic` | Cosine search the embedding index for a natural-language query | `query`, `limit`, `folder`, `includeSnippet` |
 | `find_similar_notes` | Surface notes most similar to a source note, anchored to its opening topic (no live API call) | `path`, `limit` |
 

--- a/src/__tests__/handlers/semantic.test.ts
+++ b/src/__tests__/handlers/semantic.test.ts
@@ -32,6 +32,14 @@ class MockProvider implements EmbeddingProvider {
 }
 
 let env: TestEnv;
+const INDEX_CONFIRM = "send-vault-text-to-embedding-provider";
+
+function indexVault(args: Record<string, unknown> = {}) {
+  return env.client.callTool({
+    name: "index_vault",
+    arguments: { confirm: INDEX_CONFIRM, ...args },
+  });
+}
 
 function untrustedBlockBodies(text: string, label: string): string[] {
   const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -64,11 +72,29 @@ afterEach(async () => {
 });
 
 describe("semantic handlers — index_vault", () => {
-  it("indexes all notes via the mock provider", async () => {
+  it("requires explicit confirmation before sending note chunks to the provider", async () => {
+    class CountingProvider extends MockProvider {
+      calls = 0;
+      override embed(texts: string[]): Promise<number[][]> {
+        this.calls += texts.length;
+        return super.embed(texts);
+      }
+    }
+    const provider = new CountingProvider();
+    setProviderForTests(provider);
+
     const result = await env.client.callTool({
       name: "index_vault",
       arguments: {},
     });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toContain("send-vault-text-to-embedding-provider");
+    expect(provider.calls).toBe(0);
+  });
+
+  it("indexes all notes via the mock provider", async () => {
+    const result = await indexVault();
     expect(isError(result)).toBe(false);
     const text = textContent(result);
     expect(text).toMatch(/Indexed/);
@@ -77,19 +103,16 @@ describe("semantic handlers — index_vault", () => {
   });
 
   it("skips unchanged notes on a second pass", async () => {
-    await env.client.callTool({ name: "index_vault", arguments: {} });
-    const second = await env.client.callTool({ name: "index_vault", arguments: {} });
+    await indexVault();
+    const second = await indexVault();
     const text = textContent(second);
     expect(text).toMatch(/Notes unchanged:\s+4/);
     expect(text).toMatch(/Notes embedded:\s+0/);
   });
 
   it("force=true re-embeds even unchanged notes", async () => {
-    await env.client.callTool({ name: "index_vault", arguments: {} });
-    const forced = await env.client.callTool({
-      name: "index_vault",
-      arguments: { force: true },
-    });
+    await indexVault();
+    const forced = await indexVault({ force: true });
     const text = textContent(forced);
     expect(text).toMatch(/Notes embedded:\s+4/);
   });
@@ -104,7 +127,7 @@ describe("semantic handlers — index_vault", () => {
     const messages: string[] = [];
 
     const result = await env.client.callTool(
-      { name: "index_vault", arguments: { force: true } },
+      { name: "index_vault", arguments: { force: true, confirm: INDEX_CONFIRM } },
       undefined,
       {
         onprogress: (progress) => {
@@ -126,10 +149,7 @@ describe("semantic handlers — index_vault", () => {
     }
     setProviderForTests(new DirtyProvider());
 
-    const result = await env.client.callTool({
-      name: "index_vault",
-      arguments: {},
-    });
+    const result = await indexVault();
 
     const text = textContent(result);
     expect(text).toContain("via mock\\nprovider/topic\\tcounter");
@@ -158,10 +178,7 @@ describe("semantic handlers — index_vault", () => {
     });
     setProviderForTests(new FailingProvider());
 
-    const result = await env.client.callTool({
-      name: "index_vault",
-      arguments: {},
-    });
+    const result = await indexVault();
 
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
@@ -178,7 +195,7 @@ describe("semantic handlers — index_vault", () => {
 
 describe("semantic handlers — search_semantic", () => {
   it("returns the most semantically relevant note for a query", async () => {
-    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await indexVault();
     const result = await env.client.callTool({
       name: "search_semantic",
       arguments: { query: "I want to learn about kittens and feline behavior", limit: 3 },
@@ -200,7 +217,7 @@ describe("semantic handlers — search_semantic", () => {
   });
 
   it("respects the folder filter", async () => {
-    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await indexVault();
     // Force the search to a folder that contains nothing.
     const result = await env.client.callTool({
       name: "search_semantic",
@@ -210,7 +227,7 @@ describe("semantic handlers — search_semantic", () => {
   });
 
   it("escapes query labels when no matches are found", async () => {
-    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await indexVault();
 
     const result = await env.client.callTool({
       name: "search_semantic",
@@ -233,7 +250,7 @@ describe("semantic handlers — search_semantic", () => {
       },
     });
 
-    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await indexVault();
     const result = await env.client.callTool({
       name: "search_semantic",
       arguments: { query: "cats", limit: 1 },
@@ -268,7 +285,7 @@ describe("semantic handlers — search_semantic", () => {
       },
     });
 
-    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await indexVault();
     setPermissions({ readPaths: ["public"], writePaths: null });
 
     const result = await env.client.callTool({
@@ -294,7 +311,7 @@ describe("semantic handlers — search_semantic", () => {
       },
     });
 
-    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await indexVault();
     await fs.writeFile(
       path.join(env.vaultDir, "cats.md"),
       "# Dogs\n\nThe current note is only about dogs.",
@@ -354,7 +371,7 @@ describe("semantic handlers — search_semantic", () => {
 
 describe("semantic handlers — find_similar_notes", () => {
   it("returns the most similar notes excluding the source", async () => {
-    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await indexVault();
     const result = await env.client.callTool({
       name: "find_similar_notes",
       arguments: { path: "cats.md", limit: 3 },
@@ -406,7 +423,7 @@ describe("semantic handlers — find_similar_notes", () => {
       },
     });
 
-    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await indexVault();
     const result = await env.client.callTool({
       name: "find_similar_notes",
       arguments: { path: "source.md", limit: 1 },
@@ -437,7 +454,7 @@ describe("semantic handlers — find_similar_notes", () => {
       },
     });
 
-    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await indexVault();
     setPermissions({ readPaths: ["public"], writePaths: null });
 
     const result = await env.client.callTool({
@@ -462,7 +479,7 @@ describe("semantic handlers — find_similar_notes", () => {
       },
     });
 
-    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await indexVault();
     setPermissions({ readPaths: ["public"], writePaths: null });
 
     const result = await env.client.callTool({
@@ -490,7 +507,7 @@ describe("semantic handlers — find_similar_notes", () => {
       },
     });
 
-    await env.client.callTool({ name: "index_vault", arguments: {} });
+    await indexVault();
     await fs.writeFile(
       path.join(env.vaultDir, "source.md"),
       "# Weather\n\nThe current source topic is rain.",
@@ -512,7 +529,7 @@ describe("semantic handlers — find_similar_notes", () => {
 describe("semantic handlers — provider missing", () => {
   it("each tool returns a configuration hint when no provider is set", async () => {
     setProviderForTests(null);
-    const r1 = await env.client.callTool({ name: "index_vault", arguments: {} });
+    const r1 = await indexVault();
     expect(isError(r1)).toBe(true);
     expect(textContent(r1)).toMatch(/OBSIDIAN_EMBEDDING_PROVIDER/);
 
@@ -528,7 +545,7 @@ describe("semantic handlers — provider missing", () => {
       "ftp://user:pa55@example.internal:11434/v1?token=secret#debug";
     process.env.OBSIDIAN_EMBEDDING_MODEL = "test-model";
     try {
-      const result = await env.client.callTool({ name: "index_vault", arguments: {} });
+      const result = await indexVault();
       const text = textContent(result);
       expect(isError(result)).toBe(true);
       expect(text).toContain("OBSIDIAN_EMBEDDING_URL scheme/host not allowed");
@@ -546,3 +563,4 @@ describe("semantic handlers — provider missing", () => {
     }
   });
 });
+

--- a/src/__tests__/regression-embedding-fn.test.ts
+++ b/src/__tests__/regression-embedding-fn.test.ts
@@ -19,6 +19,8 @@ import {
 import { log } from "../lib/logger.js";
 import { createTestEnv, isError, textContent, type TestEnv } from "./handlers/harness.js";
 
+const INDEX_CONFIRM = "send-vault-text-to-embedding-provider";
+
 // Regression coverage for the second wave of embedding-stack findings:
 //   - FN-H1: OllamaProvider probe used to be followed by a full embedBatched
 //          over the whole input, double-embedding chunk 0 on every cold
@@ -256,8 +258,8 @@ describe("index_vault per-vault serialization (FN-M2)", () => {
     setProviderForTests(new TaggingProvider("A"));
 
     const [r1, r2] = await Promise.all([
-      env.client.callTool({ name: "index_vault", arguments: {} }),
-      env.client.callTool({ name: "index_vault", arguments: {} }),
+      env.client.callTool({ name: "index_vault", arguments: { confirm: INDEX_CONFIRM } }),
+      env.client.callTool({ name: "index_vault", arguments: { confirm: INDEX_CONFIRM } }),
     ]);
 
     expect(isError(r1)).toBe(false);
@@ -314,14 +316,14 @@ describe("index_vault partial-note failures", () => {
 
   it("does not mark a note current unless every chunk embeds successfully", async () => {
     setProviderForTests(new PartialProvider(false));
-    const partial = await env.client.callTool({ name: "index_vault", arguments: {} });
+    const partial = await env.client.callTool({ name: "index_vault", arguments: { confirm: INDEX_CONFIRM } });
     expect(isError(partial)).toBe(false);
     expect(textContent(partial)).toMatch(/Failures:\s+1/);
     expect(snapshotForTests(env.vaultDir).totalChunks).toBe(0);
     expect(snapshotForTests(env.vaultDir).totalNotes).toBe(0);
 
     setProviderForTests(new PartialProvider(true));
-    const complete = await env.client.callTool({ name: "index_vault", arguments: {} });
+    const complete = await env.client.callTool({ name: "index_vault", arguments: { confirm: INDEX_CONFIRM } });
     expect(isError(complete)).toBe(false);
     expect(textContent(complete)).toContain("Notes embedded:  1");
     expect(snapshotForTests(env.vaultDir).totalChunks).toBe(2);

--- a/src/__tests__/regression-tools-semantic.test.ts
+++ b/src/__tests__/regression-tools-semantic.test.ts
@@ -60,6 +60,7 @@ class PartiallyFailingProvider implements EmbeddingProvider {
 
 let env: TestEnv;
 let provider: PartiallyFailingProvider;
+const INDEX_CONFIRM = "send-vault-text-to-embedding-provider";
 
 beforeEach(async () => {
   provider = new PartiallyFailingProvider(3); // every 3rd chunk is invalid
@@ -84,7 +85,7 @@ describe("M8: index_vault chunksEmbedded reflects only successful embeddings", (
   it("reports chunksEmbedded == valid vectors and failures == invalid vectors", async () => {
     const result = await env.client.callTool({
       name: "index_vault",
-      arguments: {},
+      arguments: { confirm: INDEX_CONFIRM },
     });
     expect(isError(result)).toBe(false);
     const text = textContent(result);

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -35,6 +35,7 @@ const MISSING_PROVIDER_HINT =
   "Set OBSIDIAN_EMBEDDING_PROVIDER=ollama (default) and run an Ollama server with `ollama pull nomic-embed-text`. " +
   "For OpenAI, set OBSIDIAN_EMBEDDING_PROVIDER=openai and OBSIDIAN_EMBEDDING_API_KEY.";
 
+const INDEX_VAULT_CONFIRMATION = "send-vault-text-to-embedding-provider";
 const EMBED_BATCH_SIZE = 16;
 
 function textResult(text: string) {
@@ -187,7 +188,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
     {
       title: "Index Vault for Semantic Search",
       description:
-        "Build or refresh the embedding index used by `search_semantic` and `find_similar_notes`. Splits each note into heading-aware chunks, embeds them via the configured provider (Ollama by default, OpenAI optional), and persists the index to `<vault>/.obsidian/cache/mcp-pro-embeddings.json`. Incremental: notes whose content hash matches the prior pass are skipped. Use `force: true` to re-embed everything (e.g., after switching models). Emits progress notifications when the client subscribes.",
+        "Build or refresh the embedding index used by `search_semantic` and `find_similar_notes`. Splits readable notes into heading-aware chunks, sends those chunks to the configured embedding provider (Ollama by default, OpenAI optional), and persists the index to `<vault>/.obsidian/cache/mcp-pro-embeddings.json`. Requires `confirm: \"send-vault-text-to-embedding-provider\"` so callers explicitly acknowledge that vault text will leave this tool boundary. Incremental: notes whose content hash matches the prior pass are skipped. Use `force: true` to re-embed everything (e.g., after switching models). Emits progress notifications when the client subscribes.",
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -205,9 +206,15 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
           .max(500)
           .optional()
           .describe("Restrict the indexing pass to this folder. Notes outside the folder are left untouched."),
+        confirm: z
+          .literal(INDEX_VAULT_CONFIRMATION)
+          .optional()
+          .describe(
+            `Required safety latch. Set exactly to "${INDEX_VAULT_CONFIRMATION}" to acknowledge that readable note chunks will be sent to the configured embedding provider.`,
+          ),
       },
     },
-    async ({ force, folder }, extra) => {
+    async ({ force, folder, confirm }, extra) => {
       // Serialize the entire index pass against itself per-vault. Two
       // concurrent index_vault calls would otherwise interleave
       // `setNoteChunks` + `pruneMissingNotes` operations on the same
@@ -222,6 +229,12 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         if (!provider) {
           return errorResult(
             `Semantic search has no embedding provider configured. ${MISSING_PROVIDER_HINT}`,
+          );
+        }
+        if (confirm !== INDEX_VAULT_CONFIRMATION) {
+          return errorResult(
+            `index_vault sends readable note chunks to the configured embedding provider (${displaySemanticValue(provider.id)}/${displaySemanticValue(provider.model)}). ` +
+              `Set confirm to "${INDEX_VAULT_CONFIRMATION}" to proceed.`,
           );
         }
 


### PR DESCRIPTION
`index_vault` now requires `confirm: send-vault-text-to-embedding-provider` before it reads notes and sends chunks to the active embedding provider. The docs and unreleased 4.0 migration note now make that provider-bound vault text transfer explicit.

Score: 5 severity x 3 reach / 1 effort = 15. Semantic indexing can touch every readable note and may target a hosted provider, so a hard per-call latch is cheap risk reduction.

Risk: scripts and clients that call `index_vault` must add the confirmation string. This rides the unreleased 4.0.0 migration surface.

Tested: `npm test -- src/__tests__/handlers/semantic.test.ts src/__tests__/regression-embedding-fn.test.ts src/__tests__/regression-tools-semantic.test.ts`; `npm run verify`.

Greptile skipped because the review quota is exhausted.