### PR TITLE
fix: require bulk rewrite confirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `get_note`, `get_daily_note`, `search_notes`, `search_by_frontmatter`, `list_notes`, `get_recent_notes`, `get_vault_stats`, `resolve_alias`, `list_tags`, `search_by_tag` result paths and previews, `rename_tag` skipped note rows, `index_vault` failed note rows, `search_semantic` result paths and snippets, semantic heading paths, `find_similar_notes` result paths, `move_note`/`delete_note` failed referrers, `get_backlinks`, `get_outlinks`, `find_orphans`, `find_broken_links`, `get_graph_neighbors`, `list_attachments` paths and extension summaries, `find_unused_attachments`, `list_bases`, `list_canvases`, `read_canvas` paths, node identities, node colors, edge endpoints, node previews, and edge labels, `read_base`, `query_base`, SVG attachment text, section-heading output, backlink context output, and note/daily resource bodies now wrap vault-authored text or path summaries in `[BEGIN UNTRUSTED VAULT CONTENT: ...]` / `[END UNTRUSTED VAULT CONTENT: ...]` markers. Clients that parsed raw note fragments, path rows, attachment extension summaries, failed-referrer rows, skipped-note rows, failed-note rows, search result headings, tag values, headings, link targets, canvas labels, canvas identifiers, resource bodies, or snippets should extract the text between those markers.
 - `index_vault` now requires `confirm: "send-vault-text-to-embedding-provider"` on each call before it reads notes and sends chunks to the configured embedding provider.
+- `move_note` now requires `confirmPath` to match the destination path when `updateLinks` is true, and `rename_tag` now requires `confirmTag` to match the new tag when `dryRun` is false.
 
 ### Added
 
@@ -57,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The note-content mtime cache is now in-memory only; legacy `mcp-pro-index-cache.json` snapshots are ignored and removed instead of loading or persisting note bodies and absolute paths.
 - Semantic search now verifies persisted embedding chunk text against the live note chunks before accepting cached snippets or skipping an unchanged note.
 - `index_vault` now has a hard confirmation latch before any readable note chunks are sent to the active embedding provider.
+- `move_note` and `rename_tag` now have hard confirmation latches before vault-wide rewrites, so clients without MCP elicitation cannot silently skip the confirmation boundary.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The server exposes five starter prompts that clients (Claude Desktop, Cursor) su
 - **Folder-scoped permissions**: `OBSIDIAN_READ_PATHS` / `OBSIDIAN_WRITE_PATHS` allowlists gate every tool at the path-resolution choke point
 - **In-memory mtime cache** speeds repeated vault scans within a running process without persisting note bodies to disk
 - **Progress notifications** (`notifications/progress`) on `rename_tag`, `find_unused_attachments`, and `index_vault` when the client subscribes via `_meta.progressToken`
-- **Elicitation** prompts the user for typed confirmation on `delete_note(permanent: true)`, `move_note` reference rewrites, and `rename_tag` bulk writes when the client supports it
+- **Hard bulk-write latches** require `confirmPath` for default `move_note` reference rewrites, `confirmTag` for non-dry-run `rename_tag`, and `confirm=true` for permanent deletion; clients with elicitation support also get typed prompts
 
 ---
 
@@ -368,7 +368,7 @@ The server also declares the MCP [`logging` capability](https://modelcontextprot
 - **YAML parser boundaries** — Obsidian properties are parsed only from `---` YAML delimiter lines; non-YAML gray-matter language blocks stay as body text, oversized frontmatter is skipped on reads and refused for metadata updates, and note/Base YAML containing anchors or aliases is not parsed.
 - **Semantic index freshness** — `search_semantic` and `find_similar_notes` re-check current note content hashes before returning stored snippets or source-note embeddings, pruning stale cache entries instead of surfacing old note text.
 - **Semantic indexing confirmation** — `index_vault` refuses to read and embed vault notes unless the call includes `confirm: "send-vault-text-to-embedding-provider"`, making provider-bound note transfer explicit.
-- **Bulk-write confirmations** — clients that support MCP elicitation are asked to re-type the destination path or new tag before `move_note` rewrites references or `rename_tag` writes across the vault. Dry runs and clients without elicitation keep their existing behavior.
+- **Bulk-write confirmations** — `move_note` reference rewrites require `confirmPath` to match the destination path, and non-dry-run `rename_tag` requires `confirmTag` to match the new tag. Clients that support MCP elicitation are also asked to re-type the destination path or new tag before the rewrite runs.
 - **Atomic writes** — every note write (`create_note`, `append`, `prepend`, `update_frontmatter`, canvas mutations) stages content to a sibling temp file then renames onto the target, so a crash or kill mid-write never leaves a truncated file. Combined with per-path locks for the full read-modify-write cycle, concurrent callers can't lose each other's updates. The `install` subcommand uses the same pattern and keeps a backup of the previous config.
 - **Rate limiting + CORS allowlist** — optional `--rate-limit` caps per-IP request volume; `--allow-origin` restricts browser-facing CORS and refuses `*` unless bearer auth is enabled. `/health` and `/version` stay reachable under load for monitoring.
 - **Request timeout** — HTTP POST requests are capped at 2 minutes of wall-clock time. Long-lived SSE GET streams are exempt so idle clients aren't reaped.
@@ -413,7 +413,7 @@ Tag extraction is similarly case-tolerant: `tags`, `Tags`, `TAGS`, `tag`, and `T
 | `prepend_to_note` | Prepend content after frontmatter | `path`, `content` |
 | `update_frontmatter` | Update frontmatter properties on a note | `path`, `properties` |
 | `create_daily_note` | Create today's daily note from template | `date`, `content`, `templatePath` |
-| `move_note` | Move or rename a note; rewrites references across the vault | `oldPath`, `newPath`, `updateLinks` |
+| `move_note` | Move or rename a note; rewrites references across the vault | `oldPath`, `newPath`, `updateLinks`, `confirmPath` |
 | `delete_note` | Delete a note (trash by default); optional elicitation on permanent | `path`, `permanent`, `removeReferences` |
 
 ### Section-level edits
@@ -432,7 +432,7 @@ Tag extraction is similarly case-tolerant: `tags`, `Tags`, `TAGS`, `tag`, and `T
 |------|-------------|----------------|
 | `get_tags` | Get all tags and their usage counts | `sortBy` |
 | `search_by_tag` | Find all notes with a specific tag | `tag`, `includeContent` |
-| `rename_tag` | Rewrite inline + frontmatter occurrences vault-wide; hierarchical | `oldName`, `newName`, `hierarchical`, `dryRun` |
+| `rename_tag` | Rewrite inline + frontmatter occurrences vault-wide; hierarchical | `oldName`, `newName`, `hierarchical`, `dryRun`, `confirmTag` |
 
 ### Links & graph
 
@@ -702,7 +702,7 @@ npm run lint:fix   # auto-fix
 - **Quick wins.** `get_recent_notes`, `get_vault_stats`, `resolve_alias`.
 - **MCP prompts.** `daily-review`, `weekly-rollup`, `find-stale-notes`, `extract-action-items`, `build-moc`.
 - **Progress notifications** on `rename_tag`, `find_unused_attachments`, `index_vault`.
-- **Elicitation** on `delete_note(permanent: true)`, `move_note` reference rewrites, and `rename_tag` bulk writes for clients that support it.
+- **Bulk-write confirmation latches** on `delete_note(permanent: true)`, `move_note` reference rewrites, and non-dry-run `rename_tag`, plus elicitation prompts for clients that support them.
 - **eslint** wired up with typescript-eslint flat config; `npm run lint` and `lint:fix`.
 
 **v1.7.0** — `delete_note` reference handling:

--- a/src/__tests__/handlers/tags.test.ts
+++ b/src/__tests__/handlers/tags.test.ts
@@ -197,10 +197,25 @@ describe("tag handlers — search_by_tag", () => {
 });
 
 describe("tag handlers — rename_tag", () => {
-  it("rewrites both inline #tag and frontmatter tags vault-wide", async () => {
+  it("requires confirmTag for non-dry-run vault-wide rewrites", async () => {
     const result = await env.client.callTool({
       name: "rename_tag",
       arguments: { oldName: "review", newName: "audit" },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toContain('confirmTag="audit"');
+    const search = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "review" },
+    });
+    expect(textContent(search)).toContain("note-a.md");
+  });
+
+  it("rewrites both inline #tag and frontmatter tags vault-wide", async () => {
+    const result = await env.client.callTool({
+      name: "rename_tag",
+      arguments: { oldName: "review", newName: "audit", confirmTag: "audit" },
     });
     expect(isError(result)).toBe(false);
     const text = textContent(result);
@@ -274,7 +289,7 @@ describe("tag handlers — rename_tag", () => {
 
     const result = await env.client.callTool({
       name: "rename_tag",
-      arguments: { oldName: "draft", newName: "wip" },
+      arguments: { oldName: "draft", newName: "wip", confirmTag: "wip" },
     });
 
     expect(isError(result)).toBe(true);
@@ -301,7 +316,7 @@ describe("tag handlers — rename_tag", () => {
 
     const result = await env.client.callTool({
       name: "rename_tag",
-      arguments: { oldName: "draft", newName: "wip" },
+      arguments: { oldName: "draft", newName: "wip", confirmTag: "wip" },
     });
 
     expect(isError(result)).toBe(false);
@@ -333,11 +348,15 @@ describe("tag handlers — rename_tag", () => {
     const [moveResult, renameResult] = await Promise.all([
       env.client.callTool({
         name: "move_note",
-        arguments: { oldPath: "note-c.md", newPath: "archive/note-c.md" },
+        arguments: {
+          oldPath: "note-c.md",
+          newPath: "archive/note-c.md",
+          confirmPath: "archive/note-c.md",
+        },
       }),
       env.client.callTool({
         name: "rename_tag",
-        arguments: { oldName: "review", newName: "audit" },
+        arguments: { oldName: "review", newName: "audit", confirmTag: "audit" },
       }),
     ]);
     expect(isError(moveResult)).toBe(false);

--- a/src/__tests__/handlers/write.test.ts
+++ b/src/__tests__/handlers/write.test.ts
@@ -351,10 +351,26 @@ describe("write handlers — create_daily_note", () => {
 });
 
 describe("write handlers — move_note", () => {
-  it("moves a note and creates missing parent folders", async () => {
+  it("requires confirmPath for default reference rewrites", async () => {
     const result = await env.client.callTool({
       name: "move_note",
       arguments: { oldPath: "note-c.md", newPath: "archive/2026/note-c.md" },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toContain('confirmPath="archive/2026/note-c.md"');
+    await expect(fs.access(path.join(env.vaultDir, "note-c.md"))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(env.vaultDir, "archive/2026/note-c.md"))).rejects.toThrow();
+  });
+
+  it("moves a note and creates missing parent folders", async () => {
+    const result = await env.client.callTool({
+      name: "move_note",
+      arguments: {
+        oldPath: "note-c.md",
+        newPath: "archive/2026/note-c.md",
+        confirmPath: "archive/2026/note-c.md",
+      },
     });
     expect(isError(result)).toBe(false);
 
@@ -371,7 +387,11 @@ describe("write handlers — move_note", () => {
 
     const result = await env.client.callTool({
       name: "move_note",
-      arguments: { oldPath: "note-c.md", newPath: "archive/note-c.md" },
+      arguments: {
+        oldPath: "note-c.md",
+        newPath: "archive/note-c.md",
+        confirmPath: "archive/note-c.md",
+      },
     });
 
     expect(isError(result)).toBe(false);
@@ -395,7 +415,11 @@ describe("write handlers — move_note", () => {
 
     const result = await env.client.callTool({
       name: "move_note",
-      arguments: { oldPath: "note-c.md", newPath: "archive/note-c.md" },
+      arguments: {
+        oldPath: "note-c.md",
+        newPath: "archive/note-c.md",
+        confirmPath: "archive/note-c.md",
+      },
     });
 
     expect(isError(result)).toBe(false);
@@ -406,7 +430,7 @@ describe("write handlers — move_note", () => {
   it("refuses to overwrite an existing destination", async () => {
     const result = await env.client.callTool({
       name: "move_note",
-      arguments: { oldPath: "note-a.md", newPath: "note-b.md" },
+      arguments: { oldPath: "note-a.md", newPath: "note-b.md", confirmPath: "note-b.md" },
     });
     expect(isError(result)).toBe(true);
     expect(textContent(result)).toMatch(/already exists/i);
@@ -417,7 +441,11 @@ describe("write handlers — move_note", () => {
     // structured path reference and must follow the move.
     const result = await env.client.callTool({
       name: "move_note",
-      arguments: { oldPath: "note-a.md", newPath: "archive/2026/note-a.md" },
+      arguments: {
+        oldPath: "note-a.md",
+        newPath: "archive/2026/note-a.md",
+        confirmPath: "archive/2026/note-a.md",
+      },
     });
     expect(isError(result)).toBe(false);
     expect(textContent(result)).toMatch(/Updated references in \d+ file\(s\)/);
@@ -488,7 +516,11 @@ describe("write handlers — move_note", () => {
       try {
         return await env.client.callTool({
           name: "move_note",
-          arguments: { oldPath: "note-a.md", newPath: "archive/renamed-a.md" },
+          arguments: {
+            oldPath: "note-a.md",
+            newPath: "archive/renamed-a.md",
+            confirmPath: "archive/renamed-a.md",
+          },
         });
       } finally {
         linkSpy.mockRestore();

--- a/src/__tests__/regression-tools-tags.test.ts
+++ b/src/__tests__/regression-tools-tags.test.ts
@@ -125,7 +125,7 @@ describe("regression M9: rename_tag hierarchical rebases nested children", () =>
   it("with hierarchical=true (default), renaming 'project' also rewrites 'project/alpha'", async () => {
     const result = await env.client.callTool({
       name: "rename_tag",
-      arguments: { oldName: "project", newName: "client" },
+      arguments: { oldName: "project", newName: "client", confirmTag: "client" },
     });
     expect(isError(result)).toBe(false);
     expect(textContent(result)).toMatch(/Rewrote #project → #client/);
@@ -158,6 +158,7 @@ describe("regression M9: rename_tag hierarchical rebases nested children", () =>
       arguments: {
         oldName: "project",
         newName: "client",
+        confirmTag: "client",
         hierarchical: false,
       },
     });

--- a/src/tools/tags.ts
+++ b/src/tools/tags.ts
@@ -298,7 +298,7 @@ export function registerTagTools(server: McpServer, vaultPath: string): void {
     {
       title: "Rename Tag",
       description:
-        "Rename a tag everywhere it appears across the vault, in both inline #tags and frontmatter `tags:` fields. With `hierarchical: true` (default), nested tags also rebase: renaming `project` to `client` also renames `project/alpha` → `client/alpha`. With `dryRun: true`, returns the planned counts without writing. Strip the leading `#` from oldName/newName — they're tag names, not tag tokens.",
+        "Rename a tag everywhere it appears across the vault, in both inline #tags and frontmatter `tags:` fields. Non-dry-run rewrites require `confirmTag` to match the new tag name. With `hierarchical: true` (default), nested tags also rebase: renaming `project` to `client` also renames `project/alpha` → `client/alpha`. With `dryRun: true`, returns the planned counts without writing. Strip the leading `#` from oldName/newName — they're tag names, not tag tokens.",
       annotations: {
         readOnlyHint: false,
         destructiveHint: true,
@@ -328,12 +328,23 @@ export function registerTagTools(server: McpServer, vaultPath: string): void {
           .optional()
           .default(false)
           .describe("If true, count matches without modifying any notes."),
+        confirmTag: z
+          .string()
+          .max(200)
+          .optional()
+          .describe("Required when dryRun is false: re-type the new tag name to confirm vault-wide tag rewriting."),
       },
     },
-    async ({ oldName, newName, hierarchical, dryRun }, extra) => {
+    async ({ oldName, newName, hierarchical, dryRun, confirmTag }, extra) => {
       try {
         if (oldName === newName) return errorResult("oldName and newName must differ");
         if (!dryRun) {
+          if (confirmTag?.trim() !== newName) {
+            return errorResult(
+              `Vault-wide tag rewriting to #${displayTagValue(newName)} requires confirmTag="${displayTagValue(newName)}". ` +
+              "Set dryRun=true to preview without writing.",
+            );
+          }
           const confirmation = await elicitTextConfirmation(server, {
             tool: "rename_tag",
             message:

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -358,7 +358,7 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
     {
       title: "Move/Rename Note",
       description:
-        "Move or rename a note within the vault, preserving its full content. Parent folders at the destination are created as needed. By default, wikilinks and file references are updated, matching Obsidian's \"Automatically update internal links\" behavior. Pass `updateLinks: false` to skip the rewrite scan (faster on large vaults; pair with `find_broken_links` if you need to audit afterward). A .md extension is added automatically if omitted from either path.",
+        "Move or rename a note within the vault, preserving its full content. Parent folders at the destination are created as needed. By default, wikilinks and file references are updated, matching Obsidian's \"Automatically update internal links\" behavior; this rewrite requires `confirmPath` to match the destination path after .md normalization. Pass `updateLinks: false` to skip the rewrite scan (faster on large vaults; pair with `find_broken_links` if you need to audit afterward). A .md extension is added automatically if omitted from either path.",
       annotations: {
         readOnlyHint: false,
         destructiveHint: true,
@@ -381,13 +381,24 @@ export function registerWriteTools(server: McpServer, vaultPath: string): void {
           .optional()
           .default(true)
           .describe("If true (default), update every wikilink, markdown link, and canvas node reference across the vault to point at the new path. Set false to skip the rewrite pass."),
+        confirmPath: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Required when updateLinks is true: re-type the destination path after .md normalization to confirm vault-wide reference rewriting."),
       },
     },
-    async ({ oldPath, newPath, updateLinks }) => {
+    async ({ oldPath, newPath, updateLinks, confirmPath }) => {
       try {
         const resolvedOld = ensureMdExtension(oldPath);
         const resolvedNew = ensureMdExtension(newPath);
         if (updateLinks !== false) {
+          if (confirmPath?.trim() !== resolvedNew) {
+            return errorResult(
+              `Reference rewriting for "${displayWriteValue(resolvedOld)}" requires confirmPath="${displayWriteValue(resolvedNew)}". ` +
+              "Set updateLinks=false to move without rewriting references.",
+            );
+          }
           const confirmation = await elicitTextConfirmation(server, {
             tool: "move_note",
             message:


### PR DESCRIPTION
`move_note` now requires `confirmPath` to match the normalized destination before default reference rewrites, and non-dry-run `rename_tag` requires `confirmTag` to match the new tag before vault-wide tag rewrites. Elicitation remains as a second prompt for capable clients, while clients without elicitation no longer skip the confirmation boundary.

Score: 5 severity x 4 reach / 1 effort = 20. These paths can rewrite many vault files, and the fix is a narrow schema/handler latch with focused regressions.

Risk: scripts and clients that rely on default reference/tag rewrites must pass `confirmPath` or `confirmTag`; `updateLinks=false` and `dryRun=true` stay unchanged. This rides the unreleased 4.0.0 migration surface.

Tested: `npm test -- src/__tests__/handlers/write.test.ts src/__tests__/handlers/tags.test.ts src/__tests__/regression-tools-tags.test.ts`; `npm run verify`.

Greptile skipped because the review quota is exhausted.