### PR TITLE
fix: require http bearer auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_note`, `get_daily_note`, `search_notes`, `search_by_frontmatter`, `list_notes`, `get_recent_notes`, `get_vault_stats`, `resolve_alias`, `list_tags`, `search_by_tag` result paths and previews, `rename_tag` skipped note rows, `index_vault` failed note rows, `search_semantic` result paths and snippets, semantic heading paths, `find_similar_notes` result paths, `move_note`/`delete_note` failed referrers, `get_backlinks`, `get_outlinks`, `find_orphans`, `find_broken_links`, `get_graph_neighbors`, `list_attachments` paths and extension summaries, `find_unused_attachments`, `list_bases`, `list_canvases`, `read_canvas` paths, node identities, node colors, edge endpoints, node previews, and edge labels, `read_base`, `query_base`, SVG attachment text, section-heading output, backlink context output, and note/daily resource bodies now wrap vault-authored text or path summaries in `[BEGIN UNTRUSTED VAULT CONTENT: ...]` / `[END UNTRUSTED VAULT CONTENT: ...]` markers. Clients that parsed raw note fragments, path rows, attachment extension summaries, failed-referrer rows, skipped-note rows, failed-note rows, search result headings, tag values, headings, link targets, canvas labels, canvas identifiers, resource bodies, or snippets should extract the text between those markers.
 - `index_vault` now requires `confirm: "send-vault-text-to-embedding-provider"` on each call before it reads notes and sends chunks to the configured embedding provider.
 - `move_note` now requires `confirmPath` to match the destination path when `updateLinks` is true, and `rename_tag` now requires `confirmTag` to match the new tag when `dryRun` is false.
+- HTTP transport now requires `--token=<secret>` or `MCP_HTTP_TOKEN`, even for loopback-only local servers.
 
 ### Added
 
@@ -59,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Semantic search now verifies persisted embedding chunk text against the live note chunks before accepting cached snippets or skipping an unchanged note.
 - `index_vault` now has a hard confirmation latch before any readable note chunks are sent to the active embedding provider.
 - `move_note` and `rename_tag` now have hard confirmation latches before vault-wide rewrites, so clients without MCP elicitation cannot silently skip the confirmation boundary.
+- HTTP transport now refuses to start without bearer auth, removing the previous warning-only tokenless loopback mode.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ claude mcp add obsidian-mcp-pro -- npx -y obsidian-mcp-pro
 ### HTTP Transport (Remote Clients, Cursor, ChatGPT, Web)
 
 ```bash
-npx -y obsidian-mcp-pro --transport=http --port=3333
+MCP_HTTP_TOKEN=your-secret npx -y obsidian-mcp-pro --transport=http --port=3333
 ```
 
-Endpoint: `http://127.0.0.1:3333/mcp` (Streamable HTTP). Protect with a bearer token:
+Endpoint: `http://127.0.0.1:3333/mcp` (Streamable HTTP). HTTP transport requires a bearer token:
 
 ```bash
 npx -y obsidian-mcp-pro --transport=http --token=your-secret
@@ -191,11 +191,10 @@ npx -y obsidian-mcp-pro --transport=http --token=your-secret
 ```
 
 The HTTP server binds to `127.0.0.1` by default with DNS rebinding protection enabled.
-If `--host` is set to a non-loopback address or `--allow-origin=*` is configured,
-startup requires `--token=<secret>` or `MCP_HTTP_TOKEN`.
+Startup always requires `--token=<secret>` or `MCP_HTTP_TOKEN`, including loopback-only local servers.
 
 > [!WARNING]
-> **Never bind `--host=0.0.0.0` directly to the public internet.** Doing so exposes your entire Obsidian vault to anyone who can reach the port. The server refuses non-loopback binds without a bearer token, but if you need remote access:
+> **Never bind `--host=0.0.0.0` directly to the public internet.** Doing so exposes your entire Obsidian vault to anyone who can reach the port. The server refuses HTTP startup without a bearer token, but if you need remote access:
 > - Put the server behind a reverse proxy (nginx, Caddy, Cloudflare Tunnel) that terminates TLS, **and**
 > - Require `--token=<secret>` (or `MCP_HTTP_TOKEN`), **and**
 > - Restrict `--allow-origin` to the specific origins you trust, **and**
@@ -207,6 +206,7 @@ Additional hardening flags:
 
 | Flag | Purpose |
 |------|---------|
+| `--token=<secret>` | Required bearer token for `/mcp` requests. Prefer `MCP_HTTP_TOKEN` so the secret is not passed on the command line. |
 | `--allow-origin=<csv>` | Restrict CORS to an allowlist (e.g. `https://claude.ai,https://chat.openai.com`). Default is localhost-only; `*` requires bearer auth. |
 | `--rate-limit=<n>` | Cap requests per minute per client IP. `/health` and `/version` are exempt. Default is unlimited. |
 
@@ -214,7 +214,7 @@ Operational endpoints (no auth required):
 
 | Endpoint | Returns |
 |----------|---------|
-| `GET /health` | `{ status: "ok", sessions: <n>, version: <string> }` — liveness + session count. |
+| `GET /health` | `{ status: "ok", version: <string> }` — liveness for monitoring. |
 | `GET /version` | `{ version: <string> }` — package version, for rollout auditing. |
 
 Structured logging is controlled by `LOG_LEVEL` (`debug`/`info`/`warn`/`error`/`silent`, default `info`) and `LOG_FORMAT` (`text`/`json`, default `text`). All logs go to stderr so the stdio transport on stdout is never polluted.
@@ -359,7 +359,7 @@ The server also declares the MCP [`logging` capability](https://modelcontextprot
 - **Note/file boundary** — note read and edit surfaces only target `.md` files; attachments, Canvas files, and Bases stay on their dedicated tools with their own caps and parsers.
 - **Full-note cap** — full `.md` note reads and read-modify-write helpers refuse notes over 5 MiB before materializing them; `get_note` line fragments still stream from large notes for targeted inspection.
 - **Excluded directories** — `.obsidian`, `.git`, and `.trash` are pruned at traversal time and at resolution time, so nested occurrences never leak back to clients.
-- **HTTP transport** — binds to `127.0.0.1` by default with DNS rebinding protection (host-header allowlist). Optional `--token=<secret>` requires `Authorization: Bearer <secret>` on every `/mcp` request; compared in constant time. Non-loopback binds and wildcard CORS require bearer auth. Malformed request URL or Host data is rejected before routing.
+- **HTTP transport** — requires a bearer token at startup and binds to `127.0.0.1` by default with DNS rebinding protection (host-header allowlist). `/mcp` requests must send `Authorization: Bearer <secret>`, compared in constant time. Malformed request URL or Host data is rejected before routing.
 - **Attachment safety** — executable extensions are blocked, SVGs are returned as `text/plain`, and active text formats such as HTML/XML/CSS are served with `text/plain` resource metadata.
 - **Canvas link safety** — Canvas link nodes added through the server accept only absolute `http://` and `https://` URLs, preventing local file and application-protocol links from being persisted by tool calls.
 - **Regex edit safety** — `replace_in_note` caps regex pattern/input size and rejects backtracking-prone repeated groups before matching.
@@ -654,8 +654,8 @@ npm run lint:fix   # auto-fix
   block (and don't expose subsequent content to wikilink rewriting).
 - **`/health` no longer leaks the live session count when a Bearer
   token is configured.** Status + version stay public for monitoring;
-  `sessions` is dropped in authenticated deployments. Local-only
-  setups still see it.
+  `sessions` is dropped in authenticated deployments. In 4.0.0 and
+  later, HTTP always starts with bearer auth, so the field stays hidden.
 - **`constantTimeEqual` is now fully length-safe** (pads both inputs
   to a fixed width before comparing), and the regex / parser hardening
   list also closed: `resolveWikilink` proximity tie-break for

--- a/src/__tests__/http-server.test.ts
+++ b/src/__tests__/http-server.test.ts
@@ -4,6 +4,9 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { startHttpServer, type HttpServerHandle } from "../http-server.js";
 
+const TEST_TOKEN = "test-http-token";
+const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
+
 function buildNoopServer(): McpServer {
   return new McpServer({ name: "test", version: "0.0.0" });
 }
@@ -27,6 +30,7 @@ async function startOnEphemeral(
       buildMcpServer: buildNoopServer,
       installSignalHandlers: false,
       ...overrides,
+      bearerToken: overrides.bearerToken ?? TEST_TOKEN,
     });
     if (!FETCH_FORBIDDEN_PORTS.has(handle.port)) return handle;
     await handle.stop();
@@ -51,6 +55,17 @@ afterEach(async () => {
     await handle.stop();
     handle = null;
   }
+});
+
+describe("HTTP server — required Bearer auth", () => {
+  it("refuses to start without a bearer token, even on loopback", async () => {
+    await expect(startHttpServer({
+      host: "127.0.0.1",
+      port: 0,
+      buildMcpServer: buildNoopServer,
+      installSignalHandlers: false,
+    } as Parameters<typeof startHttpServer>[0])).rejects.toThrow(/bearer token is required/i);
+  });
 });
 
 describe("HTTP server — Bearer auth (regression guard for timing-safe compare / 401 behavior)", () => {
@@ -103,7 +118,7 @@ describe("HTTP server — oversize body (regression guard for 413 / drain)", () 
     const huge = "x".repeat(5 * 1024 * 1024); // 5 MB
     const res = await fetch(`${handle.url}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "noop", params: { huge } }),
     });
     expect(res.status).toBe(413);
@@ -194,7 +209,7 @@ describe("HTTP server — rate limiting", () => {
     const hit = async (): Promise<number> => {
       const res = await fetch(url, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
         body,
       });
       // Drain the body so the socket can be reused / freed cleanly.
@@ -215,7 +230,11 @@ describe("HTTP server — rate limiting", () => {
     const port = pickPort();
     handle = await startOnEphemeral({ port, rateLimitPerMinute: 1 });
     // Burn the one allowed /mcp request.
-    await fetch(`${handle.url}`, { method: "POST", body: "{}", headers: { "Content-Type": "application/json" } });
+    await fetch(`${handle.url}`, {
+      method: "POST",
+      body: "{}",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+    });
     // Health and version still respond 200 even though the window is exhausted.
     for (let i = 0; i < 5; i++) {
       const h = await fetch(`http://127.0.0.1:${handle.port}/health`);
@@ -236,14 +255,18 @@ describe("HTTP server: multi-session lifecycle (regression for #8)", () => {
     handle = await startOnEphemeral();
 
     const clientA = new Client({ name: "session-a", version: "0.0.0" });
-    const transportA = new StreamableHTTPClientTransport(new URL(handle.url));
+    const transportA = new StreamableHTTPClientTransport(new URL(handle.url), {
+      requestInit: { headers: AUTH_HEADERS },
+    });
     await clientA.connect(transportA);
     expect(transportA.sessionId).toBeTruthy();
     await clientA.close();
 
     // Pre-fix: second initialize → 500 "Already connected to a transport".
     const clientB = new Client({ name: "session-b", version: "0.0.0" });
-    const transportB = new StreamableHTTPClientTransport(new URL(handle.url));
+    const transportB = new StreamableHTTPClientTransport(new URL(handle.url), {
+      requestInit: { headers: AUTH_HEADERS },
+    });
     await clientB.connect(transportB);
     expect(transportB.sessionId).toBeTruthy();
     expect(transportB.sessionId).not.toBe(transportA.sessionId);
@@ -254,9 +277,13 @@ describe("HTTP server: multi-session lifecycle (regression for #8)", () => {
     handle = await startOnEphemeral();
 
     const clientA = new Client({ name: "session-a", version: "0.0.0" });
-    const transportA = new StreamableHTTPClientTransport(new URL(handle.url));
+    const transportA = new StreamableHTTPClientTransport(new URL(handle.url), {
+      requestInit: { headers: AUTH_HEADERS },
+    });
     const clientB = new Client({ name: "session-b", version: "0.0.0" });
-    const transportB = new StreamableHTTPClientTransport(new URL(handle.url));
+    const transportB = new StreamableHTTPClientTransport(new URL(handle.url), {
+      requestInit: { headers: AUTH_HEADERS },
+    });
 
     // Connect both before either closes. This exercises the
     // singleton-Protocol failure mode, where the second `connect()` happens
@@ -289,9 +316,7 @@ describe("HTTP server — /version", () => {
     const body = (await res.json()) as { status: string; version: string; sessions?: number };
     expect(body.status).toBe("ok");
     expect(body.version).toBe("1.2.3");
-    // Without a bearer token configured, the live session count is part
-    // of the /health response so local-only operators can see usage.
-    expect(typeof body.sessions).toBe("number");
+    expect(body.sessions).toBeUndefined();
   });
 
   // Regression for the v1.8.1-audit finding: when a Bearer token is

--- a/src/__tests__/regression-cli-install.test.ts
+++ b/src/__tests__/regression-cli-install.test.ts
@@ -73,6 +73,22 @@ describe("parseArgs token redaction (C7)", () => {
       delete process.env.MCP_HTTP_TOKEN;
     }
   });
+
+  it("should reject HTTP transport without a bearer token", () => {
+    process.argv = ["node", "script", "--transport", "http"];
+    expect(() => parseArgs(process.argv.slice(2))).toThrow(/bearer token is required/i);
+  });
+
+  it("should accept HTTP transport when MCP_HTTP_TOKEN is set", () => {
+    process.env.MCP_HTTP_TOKEN = "env-token";
+    try {
+      process.argv = ["node", "script", "--transport", "http"];
+      const opts = parseArgs(process.argv.slice(2));
+      expect(opts.bearerToken).toBe("env-token");
+    } finally {
+      delete process.env.MCP_HTTP_TOKEN;
+    }
+  });
 });
 
 describe("runInstall serverName sanitization (H2)", () => {

--- a/src/__tests__/regression-http-fixes.test.ts
+++ b/src/__tests__/regression-http-fixes.test.ts
@@ -3,6 +3,9 @@ import * as http from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { startHttpServer, type HttpServerHandle } from "../http-server.js";
 
+const TEST_TOKEN = "test-http-token";
+const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
+
 // Regression coverage for the v1.8.x HTTP audit:
 //   C1 — DNS-rebinding allowedHosts ref was captured empty, silently disabling
 //        Host validation (now mutated in place after listen()).
@@ -28,6 +31,7 @@ async function startOnEphemeral(
     buildMcpServer: buildNoopServer,
     installSignalHandlers: false,
     ...overrides,
+    bearerToken: overrides.bearerToken ?? TEST_TOKEN,
   });
 }
 
@@ -256,6 +260,7 @@ describe("regression: DSS-R04-C035 — HTTP body caps fail fast", () => {
       path: "/mcp",
       headers: {
         "Content-Type": "application/json",
+        ...AUTH_HEADERS,
         "Content-Length": String(4 * 1024 * 1024 + 1),
       },
     });
@@ -273,6 +278,7 @@ describe("regression: DSS-R04-C035 — HTTP body caps fail fast", () => {
       path: "/mcp",
       headers: {
         "Content-Type": "application/json",
+        ...AUTH_HEADERS,
         "Transfer-Encoding": "chunked",
       },
       initialBody: Buffer.alloc(4 * 1024 * 1024 + 1, 0x78),
@@ -290,7 +296,7 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
 
     const res = await fetch(handle.url, {
       method: "POST",
-      headers: { "Content-Type": "text/plain" },
+      headers: { "Content-Type": "text/plain", ...AUTH_HEADERS },
       body: "not json at all",
     });
     expect(res.status).toBe(415);
@@ -307,6 +313,7 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
     const res = await rawRequest(handle.port, {
       method: "POST",
       path: "/mcp",
+      headers: AUTH_HEADERS,
       body: "{}",
     });
     expect(res.status).toBe(415);
@@ -317,7 +324,7 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
     handles.push(handle);
     const res = await fetch(handle.url, {
       method: "POST",
-      headers: { "Content-Type": "application/json; charset=utf-8" },
+      headers: { "Content-Type": "application/json; charset=utf-8", ...AUTH_HEADERS },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
     });
     // Whatever the MCP layer does next, it must NOT be a Content-Type 415.
@@ -339,18 +346,14 @@ describe("regression: M2 — /version gates non-GET methods when bearerToken is 
     expect(res.headers.get("www-authenticate")).toMatch(/Bearer/);
   });
 
-  it("POST /version succeeds (200) when no bearerToken is configured", async () => {
-    const handle = await startOnEphemeral({ version: "9.9.9" });
-    handles.push(handle);
-
-    const res = await fetch(`http://127.0.0.1:${handle.port}/version`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: "{}",
-    });
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { version: string };
-    expect(body.version).toBe("9.9.9");
+  it("refuses to start without bearer auth instead of exposing tokenless /version writes", async () => {
+    await expect(startHttpServer({
+      host: "127.0.0.1",
+      port: 0,
+      version: "9.9.9",
+      buildMcpServer: buildNoopServer,
+      installSignalHandlers: false,
+    } as Parameters<typeof startHttpServer>[0])).rejects.toThrow(/bearer token is required/i);
   });
 
   it("POST /version with the correct bearer token returns 200", async () => {
@@ -387,6 +390,7 @@ describe("regression: M5 — repeated startHttpServer does not leak signal liste
     const h1 = await startHttpServer({
       host: "127.0.0.1",
       port: 0,
+      bearerToken: "secret",
       buildMcpServer: buildNoopServer,
       installSignalHandlers: true,
     });
@@ -395,6 +399,7 @@ describe("regression: M5 — repeated startHttpServer does not leak signal liste
     const h2 = await startHttpServer({
       host: "127.0.0.1",
       port: 0,
+      bearerToken: "secret",
       buildMcpServer: buildNoopServer,
       installSignalHandlers: true,
     });
@@ -490,9 +495,13 @@ describe("regression: HTTP bearer token must not be empty", () => {
   });
 
   it("rejects wildcard CORS without bearer auth", async () => {
-    await expect(startOnEphemeral({ allowedOrigins: ["*"] })).rejects.toThrow(
-      /bearer token.*CORS.*all origins/i,
-    );
+    await expect(startHttpServer({
+      host: "127.0.0.1",
+      port: 0,
+      allowedOrigins: ["*"],
+      buildMcpServer: buildNoopServer,
+      installSignalHandlers: false,
+    } as Parameters<typeof startHttpServer>[0])).rejects.toThrow(/bearer token is required/i);
   });
 
   it("allows wildcard CORS when bearer auth is configured", async () => {
@@ -522,7 +531,7 @@ describe("regression: HTTP bearer token must not be empty", () => {
         port: 0,
         buildMcpServer: buildNoopServer,
         installSignalHandlers: false,
-      });
+      } as Parameters<typeof startHttpServer>[0]);
     } catch (caught) {
       err = caught;
     } finally {
@@ -530,7 +539,7 @@ describe("regression: HTTP bearer token must not be empty", () => {
     }
 
     expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message).toMatch(/bearer token.*non-loopback/i);
+    expect((err as Error).message).toMatch(/bearer token is required/i);
   });
 
   it("allows non-loopback binds when bearer auth is configured", async () => {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -8,7 +8,8 @@ import { log } from "./lib/logger.js";
 export interface HttpServerOptions {
   host: string;
   port: number;
-  bearerToken?: string;
+  /** Required for HTTP transport. Use MCP_HTTP_TOKEN in the CLI path. */
+  bearerToken: string;
   buildMcpServer: () => McpServer;
   /** Install SIGINT/SIGTERM handlers + exit the process on shutdown. Default
    *  `true` for CLI use. Set `false` when embedding (e.g. inside an Obsidian
@@ -243,41 +244,17 @@ function clientIp(req: IncomingMessage): string {
   return addr.startsWith("::ffff:") ? addr.slice(7) : addr;
 }
 
-function normalizedBindHost(host: string): string {
-  const trimmed = host.trim().toLowerCase();
-  return trimmed.startsWith("[") && trimmed.endsWith("]")
-    ? trimmed.slice(1, -1)
-    : trimmed;
-}
-
-function isLoopbackBindHost(host: string): boolean {
-  const normalized = normalizedBindHost(host);
-  return (
-    normalized === "localhost" ||
-    normalized === "::1" ||
-    normalized.startsWith("127.") ||
-    normalized.startsWith("::ffff:127.")
-  );
-}
-
 export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServerHandle> {
   const bearerToken = opts.bearerToken?.trim();
   if (opts.bearerToken !== undefined && !bearerToken) {
     throw new Error("HTTP bearer token cannot be empty");
   }
+  if (!bearerToken) {
+    throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN or pass --token.");
+  }
   const allowedOrigins = opts.allowedOrigins && opts.allowedOrigins.length > 0
     ? opts.allowedOrigins
     : ["http://localhost:*", "http://127.0.0.1:*", "http://[::1]:*"];
-  if (!bearerToken && allowedOrigins.includes("*")) {
-    throw new Error(
-      "HTTP bearer token is required when CORS allows all origins. Set MCP_HTTP_TOKEN or pass --token, or restrict --allow-origin.",
-    );
-  }
-  if (!bearerToken && !isLoopbackBindHost(opts.host)) {
-    throw new Error(
-      "HTTP bearer token is required when binding to a non-loopback host. Set MCP_HTTP_TOKEN or pass --token, or bind to 127.0.0.1.",
-    );
-  }
   const transports = new Map<string, StreamableHTTPServerTransport>();
   const lastActivity = new Map<string, number>();
   const touch = (sid: string): void => { lastActivity.set(sid, Date.now()); };
@@ -392,7 +369,6 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
           status: "ok",
           version: opts.version ?? "",
         };
-        if (!bearerToken) body.sessions = transports.size;
         sendJson(res, 200, body);
         return;
       }
@@ -567,10 +543,6 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
     allowedOrigins: allowedOrigins.join(","),
     rateLimitPerMinute: opts.rateLimitPerMinute ?? 0,
   });
-  if (!bearerToken) {
-    log.warn("WARNING: HTTP server starting without authentication. Set MCP_HTTP_TOKEN to enable bearer token auth.");
-  }
-
   const installSignals = opts.installSignalHandlers ?? true;
   const onSignal = (): void => {
     void stop().finally(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,9 @@ export function parseArgs(argv: string[]): CliOptions {
       throw new Error("--token / MCP_HTTP_TOKEN cannot be empty");
     }
   }
+  if (opts.transport === "http" && opts.bearerToken === undefined) {
+    throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN or pass --token.");
+  }
   if (!Number.isFinite(opts.port) || opts.port < 1 || opts.port > 65535) {
     throw new Error(`Invalid port: ${opts.port}`);
   }
@@ -157,7 +160,7 @@ Serve options:
   --transport=<stdio|http>                  Transport to use (default: stdio)
   --host=<addr>                             HTTP bind host (default: 127.0.0.1)
   --port=<n>                                HTTP port (default: 3333)
-  --token=<secret>                          Require Bearer <secret> (prefer env MCP_HTTP_TOKEN to avoid leaking via ps/cmdline)
+  --token=<secret>                          Bearer token for HTTP transport (prefer env MCP_HTTP_TOKEN to avoid leaking via ps/cmdline)
   --allow-origin=<origins>                  Comma-separated CORS/Origin allowlist (default: localhost-only)
   --rate-limit=<n>                          Max requests per minute per IP (default: unlimited)
 
@@ -387,6 +390,10 @@ async function main(): Promise<void> {
   const vaultPath = resolveVaultPathOrWarn();
 
   if (opts.transport === "http") {
+    const bearerToken = opts.bearerToken;
+    if (!bearerToken) {
+      throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN or pass --token.");
+    }
     // Single McpServer instance shared across sessions — the canonical SDK
     // pattern (one server, one transport per session, transports share the
     // server's tool/resource registry). Tools here are stateless, so nothing
@@ -394,7 +401,7 @@ async function main(): Promise<void> {
     await startHttpServer({
       host: opts.host,
       port: opts.port,
-      bearerToken: opts.bearerToken,
+      bearerToken,
       allowedOrigins: opts.allowedOrigins,
       rateLimitPerMinute: opts.rateLimitPerMinute,
       buildMcpServer: () => buildMcpServer(vaultPath),


### PR DESCRIPTION
HTTP transport now refuses to start unless a bearer token is configured, including loopback-only local binds. The CLI fails early without `--token` or `MCP_HTTP_TOKEN`, `/mcp` tests use authenticated requests, and `/health` stays public without exposing session counts.

Score: 5 severity x 4 reach / 1 effort = 20. Loopback browser and local-process exposure can reach every HTTP tool, and the fix is a narrow startup gate on the unreleased 4.0.0 migration surface.

Risk: HTTP users must configure `MCP_HTTP_TOKEN` or pass `--token`; stdio users are unaffected. `/health` and GET `/version` remain unauthenticated for monitoring, but `/mcp` always requires `Authorization: Bearer <token>`.

Tested: `npm test -- src/__tests__/http-server.test.ts src/__tests__/regression-http-fixes.test.ts src/__tests__/regression-cli-install.test.ts`; `npm run verify`.

Greptile skipped because the review quota is exhausted.