### PR TITLE
fix: require env http token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_note`, `get_daily_note`, `search_notes`, `search_by_frontmatter`, `list_notes`, `get_recent_notes`, `get_vault_stats`, `resolve_alias`, `list_tags`, `search_by_tag` result paths and previews, `rename_tag` skipped note rows, `index_vault` failed note rows, `search_semantic` result paths and snippets, semantic heading paths, `find_similar_notes` result paths, `move_note`/`delete_note` failed referrers, `get_backlinks`, `get_outlinks`, `find_orphans`, `find_broken_links`, `get_graph_neighbors`, `list_attachments` paths and extension summaries, `find_unused_attachments`, `list_bases`, `list_canvases`, `read_canvas` paths, node identities, node colors, edge endpoints, node previews, and edge labels, `read_base`, `query_base`, SVG attachment text, section-heading output, backlink context output, and note/daily resource bodies now wrap vault-authored text or path summaries in `[BEGIN UNTRUSTED VAULT CONTENT: ...]` / `[END UNTRUSTED VAULT CONTENT: ...]` markers. Clients that parsed raw note fragments, path rows, attachment extension summaries, failed-referrer rows, skipped-note rows, failed-note rows, search result headings, tag values, headings, link targets, canvas labels, canvas identifiers, resource bodies, or snippets should extract the text between those markers.
 - `index_vault` now requires `confirm: "send-vault-text-to-embedding-provider"` on each call before it reads notes and sends chunks to the configured embedding provider.
 - `move_note` now requires `confirmPath` to match the destination path when `updateLinks` is true, and `rename_tag` now requires `confirmTag` to match the new tag when `dryRun` is false.
-- HTTP transport now requires `--token=<secret>` or `MCP_HTTP_TOKEN`, even for loopback-only local servers.
+- HTTP transport now requires `MCP_HTTP_TOKEN`, even for loopback-only local servers. The `--token` CLI flag was removed because command-line secrets can be exposed through OS process listings.
 
 ### Added
 
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `index_vault` now has a hard confirmation latch before any readable note chunks are sent to the active embedding provider.
 - `move_note` and `rename_tag` now have hard confirmation latches before vault-wide rewrites, so clients without MCP elicitation cannot silently skip the confirmation boundary.
 - HTTP transport now refuses to start without bearer auth, removing the previous warning-only tokenless loopback mode.
+- CLI HTTP bearer tokens now come only from `MCP_HTTP_TOKEN`; `--token <secret>` and `--token=<secret>` are rejected instead of trying to redact command-line secrets after process startup.
 - `replace_in_note` now rejects bounded repeated regex groups that contain quantified atoms before matching.
 - Tool outputs that include vault-authored bodies, snippets, previews, frontmatter values, Base data, SVG attachment text, section headings, Canvas node content, or backlink context now mark those portions with explicit untrusted-content boundaries before they enter an MCP client's model context.
 - `search_notes` result path and snippet marker labels are now generic; clients should read the path or snippet from inside the untrusted block body.

--- a/README.md
+++ b/README.md
@@ -186,17 +186,16 @@ MCP_HTTP_TOKEN=your-secret npx -y obsidian-mcp-pro --transport=http --port=3333
 Endpoint: `http://127.0.0.1:3333/mcp` (Streamable HTTP). HTTP transport requires a bearer token:
 
 ```bash
-npx -y obsidian-mcp-pro --transport=http --token=your-secret
-# or: MCP_HTTP_TOKEN=your-secret npx -y obsidian-mcp-pro --transport=http
+MCP_HTTP_TOKEN=your-secret npx -y obsidian-mcp-pro --transport=http
 ```
 
 The HTTP server binds to `127.0.0.1` by default with DNS rebinding protection enabled.
-Startup always requires `--token=<secret>` or `MCP_HTTP_TOKEN`, including loopback-only local servers.
+Startup always requires `MCP_HTTP_TOKEN`, including loopback-only local servers. The old `--token` flag was removed because command-line secrets can be exposed through OS process listings.
 
 > [!WARNING]
 > **Never bind `--host=0.0.0.0` directly to the public internet.** Doing so exposes your entire Obsidian vault to anyone who can reach the port. The server refuses HTTP startup without a bearer token, but if you need remote access:
 > - Put the server behind a reverse proxy (nginx, Caddy, Cloudflare Tunnel) that terminates TLS, **and**
-> - Require `--token=<secret>` (or `MCP_HTTP_TOKEN`), **and**
+> - Set `MCP_HTTP_TOKEN`, **and**
 > - Restrict `--allow-origin` to the specific origins you trust, **and**
 > - Set `--rate-limit` to cap request volume per IP.
 >
@@ -206,7 +205,6 @@ Additional hardening flags:
 
 | Flag | Purpose |
 |------|---------|
-| `--token=<secret>` | Required bearer token for `/mcp` requests. Prefer `MCP_HTTP_TOKEN` so the secret is not passed on the command line. |
 | `--allow-origin=<csv>` | Restrict CORS to an allowlist (e.g. `https://claude.ai,https://chat.openai.com`). Default is localhost-only; `*` requires bearer auth. |
 | `--rate-limit=<n>` | Cap requests per minute per client IP. `/health` and `/version` are exempt. Default is unlimited. |
 
@@ -513,7 +511,7 @@ All tool paths must be **vault-relative** (e.g. `notes/hello.md`), never absolut
 
 ### HTTP Transport Returns `401 Unauthorized`
 
-The server was started with `--token=<secret>` (or `MCP_HTTP_TOKEN` is set in the environment) but the client isn't sending a matching `Authorization: Bearer <secret>` header. Verify the token value and that the header is present — comparison is case-sensitive and constant-time.
+The server was started with `MCP_HTTP_TOKEN` but the client isn't sending a matching `Authorization: Bearer <secret>` header. Verify the token value and that the header is present — comparison is case-sensitive and constant-time.
 
 ### HTTP Transport Returns `429 Too Many Requests`
 

--- a/src/__tests__/regression-cli-install.test.ts
+++ b/src/__tests__/regression-cli-install.test.ts
@@ -3,8 +3,9 @@ import { parseArgs } from "../index.js";
 import { runInstall } from "../install.js";
 
 // Regression coverage for three audit findings:
-//   - C7: --token <secret> / --token=<secret> leaks via process.argv (ps,
-//         /proc/<pid>/cmdline).
+//   - C7: --token <secret> / --token=<secret> leaks via process command-line
+//         storage before runtime redaction can help, so HTTP auth uses
+//         MCP_HTTP_TOKEN instead.
 //   - H2: install.ts serverName accepts control characters that corrupt the
 //         JSON config or spoof terminal output via ANSI escapes.
 //
@@ -12,7 +13,7 @@ import { runInstall } from "../install.js";
 // the existing SDK error-response contract — these tests focus on the CLI
 // surface where direct argv/option mutation matters.
 
-describe("parseArgs token redaction (C7)", () => {
+describe("parseArgs HTTP token handling (C7)", () => {
   let originalArgv: string[];
 
   beforeEach(() => {
@@ -23,52 +24,25 @@ describe("parseArgs token redaction (C7)", () => {
     process.argv = originalArgv;
   });
 
-  it("should redact both argv slots when --token VALUE is passed as two arguments", () => {
-    // Simulate `node script ... --token supersecret`.
+  it("should reject --token VALUE because command-line secrets can leak", () => {
     process.argv = ["node", "script", "--transport", "http", "--token", "supersecret"];
-    const argv = process.argv.slice(2);
-
-    const opts = parseArgs(argv);
-
-    expect(opts.bearerToken).toBe("supersecret");
-    // The local slice the caller passes in is redacted.
-    expect(argv).not.toContain("supersecret");
-    // And process.argv itself, which is what `ps` and /proc/<pid>/cmdline
-    // expose, no longer contains the plaintext token.
-    expect(process.argv).not.toContain("supersecret");
-    expect(process.argv).toContain("***");
+    expect(() => parseArgs(process.argv.slice(2))).toThrow(/MCP_HTTP_TOKEN/i);
   });
 
-  it("should redact the argv entry when --token=VALUE is passed as one argument", () => {
+  it("should reject --token=VALUE because command-line secrets can leak", () => {
     process.argv = ["node", "script", "--token=secret"];
-    const argv = process.argv.slice(2);
-
-    const opts = parseArgs(argv);
-
-    expect(opts.bearerToken).toBe("secret");
-    expect(argv).not.toContain("--token=secret");
-    expect(argv).toContain("--token=***");
-    expect(process.argv).not.toContain("--token=secret");
-    expect(process.argv).toContain("--token=***");
+    expect(() => parseArgs(process.argv.slice(2))).toThrow(/MCP_HTTP_TOKEN/i);
   });
 
-  it("should still expose the captured token via the returned options", () => {
-    // Redaction must not break the legitimate use of the token by the HTTP
-    // server, only hide it from external observers.
-    process.argv = ["node", "script", "--token", "abc123"];
-    const opts = parseArgs(process.argv.slice(2));
-    expect(opts.bearerToken).toBe("abc123");
-  });
-
-  it("should reject an empty inline token instead of silently disabling auth", () => {
+  it("should reject an empty inline token flag with the removed-flag message", () => {
     process.argv = ["node", "script", "--token="];
-    expect(() => parseArgs(process.argv.slice(2))).toThrow(/token.*empty/i);
+    expect(() => parseArgs(process.argv.slice(2))).toThrow(/removed.*MCP_HTTP_TOKEN/i);
   });
 
   it("should reject a whitespace MCP_HTTP_TOKEN", () => {
     process.env.MCP_HTTP_TOKEN = "   ";
     try {
-      expect(() => parseArgs([])).toThrow(/token.*empty/i);
+      expect(() => parseArgs([])).toThrow(/MCP_HTTP_TOKEN cannot be empty/i);
     } finally {
       delete process.env.MCP_HTTP_TOKEN;
     }

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -250,7 +250,7 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
     throw new Error("HTTP bearer token cannot be empty");
   }
   if (!bearerToken) {
-    throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN or pass --token.");
+    throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN in the CLI or pass bearerToken when embedding.");
   }
   const allowedOrigins = opts.allowedOrigins && opts.allowedOrigins.length > 0
     ? opts.allowedOrigins

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,19 +77,8 @@ export function parseArgs(argv: string[]): CliOptions {
       opts.host = argv[++i]!;
     } else if (a.startsWith("--host=")) {
       opts.host = a.slice("--host=".length);
-    } else if (a === "--token" && argv[i + 1]) {
-      opts.bearerToken = argv[++i]!;
-      // Redact the secret from process.argv so it doesn't leak via `ps`,
-      // /proc/<pid>/cmdline, or crash dumps. Mutate both the local argv copy
-      // and process.argv (which a caller may pass a slice of).
-      argv[i] = "***";
-      const pIdx = process.argv.indexOf(opts.bearerToken);
-      if (pIdx !== -1) process.argv[pIdx] = "***";
-    } else if (a.startsWith("--token=")) {
-      opts.bearerToken = a.slice("--token=".length);
-      argv[i] = "--token=***";
-      const pIdx = process.argv.indexOf(a);
-      if (pIdx !== -1) process.argv[pIdx] = "--token=***";
+    } else if (a === "--token" || a.startsWith("--token=")) {
+      throw new Error("--token was removed because command-line secrets can leak. Set MCP_HTTP_TOKEN instead.");
     } else if (a === "--allow-origin" && argv[i + 1]) {
       opts.allowedOrigins = argv[++i]!.split(",").map((s) => s.trim()).filter(Boolean);
     } else if (a.startsWith("--allow-origin=")) {
@@ -129,11 +118,11 @@ export function parseArgs(argv: string[]): CliOptions {
   if (opts.bearerToken !== undefined) {
     opts.bearerToken = opts.bearerToken.trim();
     if (!opts.bearerToken) {
-      throw new Error("--token / MCP_HTTP_TOKEN cannot be empty");
+      throw new Error("MCP_HTTP_TOKEN cannot be empty");
     }
   }
   if (opts.transport === "http" && opts.bearerToken === undefined) {
-    throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN or pass --token.");
+    throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN.");
   }
   if (!Number.isFinite(opts.port) || opts.port < 1 || opts.port > 65535) {
     throw new Error(`Invalid port: ${opts.port}`);
@@ -160,7 +149,6 @@ Serve options:
   --transport=<stdio|http>                  Transport to use (default: stdio)
   --host=<addr>                             HTTP bind host (default: 127.0.0.1)
   --port=<n>                                HTTP port (default: 3333)
-  --token=<secret>                          Bearer token for HTTP transport (prefer env MCP_HTTP_TOKEN to avoid leaking via ps/cmdline)
   --allow-origin=<origins>                  Comma-separated CORS/Origin allowlist (default: localhost-only)
   --rate-limit=<n>                          Max requests per minute per IP (default: unlimited)
 
@@ -175,7 +163,7 @@ Env vars:
   OBSIDIAN_VAULT_NAME     Select a named vault when multiple exist
   OBSIDIAN_READ_PATHS     Comma/colon list of folders read tools may access
   OBSIDIAN_WRITE_PATHS    Comma/colon list of folders write tools may modify
-  MCP_HTTP_TOKEN          Default bearer token for --transport=http
+  MCP_HTTP_TOKEN          Required bearer token for --transport=http
   LOG_LEVEL               debug|info|warn|error|silent (default: info)
   LOG_FORMAT              text|json (default: text)
 `);
@@ -392,7 +380,7 @@ async function main(): Promise<void> {
   if (opts.transport === "http") {
     const bearerToken = opts.bearerToken;
     if (!bearerToken) {
-      throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN or pass --token.");
+      throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN.");
     }
     // Single McpServer instance shared across sessions — the canonical SDK
     // pattern (one server, one transport per session, transports share the


### PR DESCRIPTION
HTTP bearer tokens now come from `MCP_HTTP_TOKEN` only; `--token <secret>` and `--token=<secret>` are rejected before a CLI token is captured. The HTTP setup docs and migration note now point users to the env var path, which avoids putting the secret in process command-line storage.

Score: 4 severity x 3 reach / 1 effort = 12. Command-line secrets can be exposed by OS process listings before runtime redaction can help, and the fix is a narrow CLI contract change on the unreleased 4.0.0 surface.

Risk: HTTP users who passed `--token` must move the value to `MCP_HTTP_TOKEN`; stdio users and programmatic embedders passing `bearerToken` to `startHttpServer` are unaffected.

Tested: `npm test -- src/__tests__/regression-cli-install.test.ts src/__tests__/http-server.test.ts src/__tests__/regression-http-fixes.test.ts`; `npm run verify`.

Greptile skipped because the review quota is exhausted.