### PR TITLE
fix: revalidate vault read handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bulk reference rewrite apply now re-checks markdown note and Canvas file size caps before re-reading planned referrers.
 - `move_note` now rejects relative symlink moves whose copied destination link would resolve to a different target.
 - Direct note reads, note read-modify-write helpers, and direct attachment reads now require regular files before reading content.
+- Direct vault reads now use revalidated open file handles, so a symlink retargeted after containment validation is rejected before note, section, Base, Canvas, cache, attachment, or rewrite content is returned.
 - `read_base` and `query_base` now require `.base` file paths instead of accepting arbitrary readable vault files.
 - Daily-note config-derived paths in `get_daily_note`, `create_daily_note`, and `obsidian://daily` output now use explicit untrusted-content markers, and note/daily resource metadata labels are generic.
 - Note and daily resources now wrap returned markdown bodies in visible untrusted-content markers instead of relying only on `_meta` trust metadata.

--- a/src/__tests__/attachments-display.test.ts
+++ b/src/__tests__/attachments-display.test.ts
@@ -34,6 +34,17 @@ async function createAttachmentClient(mocks: AttachmentMocks): Promise<{
       }
       return mocks.resolvedPath;
     }),
+    openVaultFileForRead: vi.fn(async () => {
+      if (!mocks.resolvedPath) {
+        throw new Error("openVaultFileForRead mock missing resolvedPath");
+      }
+      const handle = await fs.open(mocks.resolvedPath, "r");
+      return {
+        fullPath: mocks.resolvedPath,
+        handle,
+        stats: await handle.stat(),
+      };
+    }),
   }));
   vi.doMock("../lib/index-cache.js", () => ({
     readAllCached: vi.fn(async () => ({ contents: new Map<string, string>() })),

--- a/src/__tests__/regression-tools-links.test.ts
+++ b/src/__tests__/regression-tools-links.test.ts
@@ -58,9 +58,9 @@ describe("H5: find_broken_links uses bounded parallelism, not a serial loop", ()
     let activeReads = 0;
     let maxActiveReads = 0;
     let noteReads = 0;
-    const originalReadFile = fs.readFile.bind(fs);
-    const readSpy = vi.spyOn(fs, "readFile").mockImplementation(
-      async (...args: Parameters<typeof fs.readFile>) => {
+    const originalOpen = fs.open.bind(fs);
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(
+      async (...args: Parameters<typeof fs.open>) => {
         const fileArg = args[0];
         const filePath = typeof fileArg === "string" ? fileArg : undefined;
         const isVaultNote = filePath !== undefined
@@ -68,7 +68,7 @@ describe("H5: find_broken_links uses bounded parallelism, not a serial loop", ()
           && filePath.endsWith(".md");
 
         if (!isVaultNote) {
-          return originalReadFile(...args);
+          return originalOpen(...args);
         }
 
         activeReads++;
@@ -76,7 +76,7 @@ describe("H5: find_broken_links uses bounded parallelism, not a serial loop", ()
         noteReads++;
         try {
           await new Promise((resolve) => setTimeout(resolve, 20));
-          return await originalReadFile(...args);
+          return await originalOpen(...args);
         } finally {
           activeReads--;
         }
@@ -94,7 +94,7 @@ describe("H5: find_broken_links uses bounded parallelism, not a serial loop", ()
       expect(noteReads).toBe(50);
       expect(maxActiveReads).toBeGreaterThan(1);
     } finally {
-      readSpy.mockRestore();
+      openSpy.mockRestore();
     }
   });
 });

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -263,6 +263,35 @@ describe("readNote", () => {
       /Note line fragment exceeds size cap \(13 > 12 bytes\): many-lines\.md/,
     );
   });
+
+  it.skipIf(!SYMLINKS_SUPPORTED)("rejects a symlink retargeted between validation and open", async () => {
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-race-outside-"));
+    try {
+      const insideTarget = path.join(vaultDir, "inside.md");
+      const outsideTarget = path.join(outsideDir, "secret.md");
+      const linkPath = path.join(vaultDir, "race.md");
+      await fs.writeFile(insideTarget, "inside\n", "utf-8");
+      await fs.writeFile(outsideTarget, "outside\n", "utf-8");
+      await fs.symlink(insideTarget, linkPath);
+
+      const realOpen = fs.open.bind(fs);
+      let swapped = false;
+      vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+        const [file] = args;
+        if (!swapped && path.resolve(String(file)) === linkPath) {
+          swapped = true;
+          await fs.unlink(linkPath);
+          await fs.symlink(outsideTarget, linkPath);
+        }
+        return realOpen(...args);
+      });
+
+      await expect(readNoteLineRange(vaultDir, "race.md", 1, 1)).rejects.toThrow(/symlink|changed/i);
+      await expect(fs.readFile(outsideTarget, "utf-8")).resolves.toBe("outside\n");
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,9 @@
 import * as fs from "fs";
-import * as fsp from "fs/promises";
 import * as path from "path";
 import * as os from "os";
 import type { VaultConfig, DailyNoteConfig } from "./types.js";
 import { log } from "./lib/logger.js";
-import { resolveVaultInternalPathSafe } from "./lib/vault.js";
+import { openVaultInternalFileForRead } from "./lib/vault.js";
 
 const DAILY_NOTES_CONFIG_REL_PATH = ".obsidian/daily-notes.json";
 const MAX_DAILY_NOTES_CONFIG_BYTES = 64 * 1024;
@@ -217,29 +216,28 @@ export async function getDailyNoteConfig(vaultPath?: string): Promise<DailyNoteC
   };
 
   const resolvedVaultPath = vaultPath ?? getVaultConfig().vaultPath;
-  let dailyNotesConfigPath: string;
+  let dailyNotesConfigPath = "";
+  let raw: string;
   try {
-    dailyNotesConfigPath = await resolveVaultInternalPathSafe(
+    const opened = await openVaultInternalFileForRead(
       resolvedVaultPath,
       DAILY_NOTES_CONFIG_REL_PATH,
     );
-  } catch (err) {
-    log.warn("Failed to resolve daily notes config path", { err: err as Error });
-    return defaults;
-  }
-
-  let raw: string;
-  try {
-    const stats = await fsp.stat(dailyNotesConfigPath);
-    if (!stats.isFile()) return defaults;
+    dailyNotesConfigPath = opened.fullPath;
+    const stats = opened.stats;
     if (stats.size > MAX_DAILY_NOTES_CONFIG_BYTES) {
+      await opened.handle.close();
       log.warn("Daily notes config exceeds size cap; using defaults", {
         bytes: stats.size,
         max: MAX_DAILY_NOTES_CONFIG_BYTES,
       });
       return defaults;
     }
-    raw = await fsp.readFile(dailyNotesConfigPath, "utf-8");
+    try {
+      raw = await opened.handle.readFile("utf-8");
+    } finally {
+      await opened.handle.close();
+    }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return defaults;
     log.warn("Failed to read daily notes config", {

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { createHash, randomBytes } from "crypto";
 import { log } from "./logger.js";
 import { isPersistenceEnabled } from "./index-cache.js";
-import { resolveVaultInternalPathSafe } from "./vault.js";
+import { openVaultInternalFileForRead, resolveVaultInternalPathSafe } from "./vault.js";
 import { renameWithRetry } from "./fs-ops.js";
 
 /**
@@ -164,9 +164,10 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
     }
     let raw: string;
     try {
-      const file = await storePath(vaultPath);
-      const stat = await fs.stat(file);
+      const opened = await openVaultInternalFileForRead(vaultPath, STORE_REL_PATH);
+      const stat = opened.stats;
       if (stat.size > maxEmbeddingBytes) {
+        await opened.handle.close();
         log.warn("embedding-store: snapshot exceeds MAX_EMBEDDING_BYTES; ignoring", {
           bytes: stat.size,
           max: maxEmbeddingBytes,
@@ -175,7 +176,11 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
         state.loadingPromise = null;
         return state;
       }
-      raw = await fs.readFile(file, "utf-8");
+      try {
+        raw = await opened.handle.readFile("utf-8");
+      } finally {
+        await opened.handle.close();
+      }
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
         log.warn("embedding-store: failed to read snapshot", { err: err as Error });

--- a/src/lib/index-cache.ts
+++ b/src/lib/index-cache.ts
@@ -3,8 +3,8 @@ import path from "path";
 import {
   assertNoteFileSize,
   getVaultRootRealPath,
+  openVaultFileForRead,
   resolveVaultInternalPathSafe,
-  resolveVaultPathSafe,
 } from "./vault.js";
 import { mapConcurrent } from "./concurrency.js";
 import { log } from "./logger.js";
@@ -157,15 +157,19 @@ export async function readAllCached(
   await mapConcurrent(relPaths, READ_CONCURRENCY, async (relPath) => {
     seen.add(relPath);
     let fullPath: string;
+    let opened: Awaited<ReturnType<typeof openVaultFileForRead>> | undefined;
     try {
-      fullPath = await resolveVaultPathSafe(vaultPath, relPath, "read", { realVaultRoot });
+      opened = await openVaultFileForRead(vaultPath, relPath, "read", { realVaultRoot });
+      fullPath = opened.fullPath;
     } catch (err) {
       onError?.(relPath, err as Error);
       return undefined;
     }
+    if (!opened) return undefined;
+    const openedFile = opened;
     let mtimeMs: number;
     try {
-      const stat = await fs.stat(fullPath);
+      const stat = openedFile.stats;
       assertNoteFileSize(relPath, stat.size);
       mtimeMs = stat.mtimeMs;
       mtimes.set(relPath, stat.mtime.getTime());
@@ -175,6 +179,7 @@ export async function readAllCached(
         mtime: stat.mtimeMs,
       });
     } catch (err) {
+      await openedFile.handle.close();
       // ENOENT during stat means the file disappeared between listing and
       // reading — drop the cache entry and skip.
       if (cache.delete(relPath)) state.dirty = true;
@@ -185,15 +190,18 @@ export async function readAllCached(
     if (cached && cached.mtimeMs === mtimeMs && cached.fullPath === fullPath) {
       contents.set(relPath, cached.content);
       cacheHits++;
+      await openedFile.handle.close();
       return undefined;
     }
     let content: string;
     try {
-      content = await fs.readFile(fullPath, "utf-8");
+      content = await openedFile.handle.readFile("utf-8");
     } catch (err) {
       onError?.(relPath, err as Error);
       if (cache.delete(relPath)) state.dirty = true;
       return undefined;
+    } finally {
+      await openedFile.handle.close();
     }
     cache.set(relPath, { fullPath, relPath, content, mtimeMs });
     state.dirty = true;

--- a/src/lib/link-rewriter.ts
+++ b/src/lib/link-rewriter.ts
@@ -1,10 +1,10 @@
-import fs from "fs/promises";
 import path from "path";
 import {
   listCanvasFiles,
   readNote,
   readCanvasFile,
   resolveVaultPathSafe,
+  readVaultTextFile,
   withFileLock,
   atomicWriteFile,
   assertNoteFileSize,
@@ -361,9 +361,9 @@ export async function applyRewrites(
           // applyEditsBackToFront verifies each edit's `expected` slice
           // matches before splicing — a parallel `write_note` that landed
           // between plan and apply will fail the comparison.
-          const stats = await fs.stat(fullPath);
-          assertNoteFileSize(notePath, stats.size);
-          const current = await fs.readFile(fullPath, "utf-8");
+          const read = await readVaultTextFile(vaultPath, notePath, "write");
+          assertNoteFileSize(notePath, read.stats.size);
+          const current = read.content;
           let next = applyEditsBackToFront(current, edits);
           if (next === null) {
             // Single bounded retry: the offsets drifted because content
@@ -404,9 +404,9 @@ export async function applyRewrites(
       const fullPath = await resolveVaultPathSafe(vaultPath, cp, "write");
       let didWrite = false;
       await withFileLock(fullPath, async () => {
-        const stats = await fs.stat(fullPath);
-        assertCanvasApplyFileSize(cp, stats.size);
-        const raw = await fs.readFile(fullPath, "utf-8");
+        const read = await readVaultTextFile(vaultPath, cp, "write");
+        assertCanvasApplyFileSize(cp, read.stats.size);
+        const raw = read.content;
         let parsed: unknown;
         try {
           parsed = JSON.parse(raw);

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises";
 import { constants as fsConstants, type Stats } from "fs";
+import type { FileHandle } from "fs/promises";
 import path from "path";
 import { randomBytes } from "crypto";
 import { StringDecoder } from "string_decoder";
@@ -70,12 +71,8 @@ async function assertResolvedRegularFile(
   return stats;
 }
 
-async function assertResolvedNoteFileSize(
-  fullPath: string,
-  relativePath: string,
-): Promise<void> {
-  const stats = await assertResolvedRegularFile(fullPath, relativePath);
-  assertNoteFileSize(relativePath, stats.size);
+function sameFileIdentity(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
 }
 
 function assertNoteContentSize(relativePath: string, content: string): void {
@@ -489,6 +486,82 @@ export async function resolveVaultPathSafe(
   return resolved;
 }
 
+export interface ValidatedVaultFile {
+  fullPath: string;
+  handle: FileHandle;
+  stats: Stats;
+}
+
+async function openResolvedVaultFileForRead(
+  vaultPath: string,
+  relativePath: string,
+  fullPath: string,
+  access: AccessKind | null,
+  options?: { realVaultRoot?: string },
+): Promise<ValidatedVaultFile> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let handle: FileHandle | undefined;
+    try {
+      handle = await fs.open(fullPath, "r");
+      const openedStats = await handle.stat();
+      assertRegularFile(relativePath, openedStats);
+
+      const canonical = await assertRealPathWithinVault(
+        fullPath,
+        vaultPath,
+        options?.realVaultRoot,
+      );
+      if (access !== null) {
+        assertAllowed(vaultRelativeFromRealPath(canonical.realVault, canonical.realPath), access);
+      }
+
+      const currentStats = await assertResolvedRegularFile(fullPath, relativePath);
+      if (sameFileIdentity(openedStats, currentStats)) {
+        return { fullPath, handle, stats: openedStats };
+      }
+
+      await handle.close();
+      handle = undefined;
+      if (attempt === 0) continue;
+      throw new Error(`Path changed during validation: ${relativePath}`);
+    } catch (err) {
+      await handle?.close();
+      throw err;
+    }
+  }
+
+  throw new Error(`Path changed during validation: ${relativePath}`);
+}
+
+export async function openVaultFileForRead(
+  vaultPath: string,
+  relativePath: string,
+  access: AccessKind = "read",
+  options?: { realVaultRoot?: string },
+): Promise<ValidatedVaultFile> {
+  const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, access, options);
+  return openResolvedVaultFileForRead(vaultPath, relativePath, fullPath, access, options);
+}
+
+export async function readVaultTextFile(
+  vaultPath: string,
+  relativePath: string,
+  access: AccessKind = "read",
+  options?: { realVaultRoot?: string },
+): Promise<{ fullPath: string; stats: Stats; content: string }> {
+  const { fullPath, handle, stats } = await openVaultFileForRead(
+    vaultPath,
+    relativePath,
+    access,
+    options,
+  );
+  try {
+    return { fullPath, stats, content: await handle.readFile("utf-8") };
+  } finally {
+    await handle.close();
+  }
+}
+
 export async function resolveVaultInternalPathSafe(
   vaultPath: string,
   relativePath: string,
@@ -516,6 +589,26 @@ export async function resolveVaultInternalPathSafe(
   }
   await assertRealPathWithinVault(resolved, vaultPath);
   return resolved;
+}
+
+export async function openVaultInternalFileForRead(
+  vaultPath: string,
+  relativePath: string,
+): Promise<ValidatedVaultFile> {
+  const fullPath = await resolveVaultInternalPathSafe(vaultPath, relativePath);
+  return openResolvedVaultFileForRead(vaultPath, relativePath, fullPath, null);
+}
+
+export async function readVaultInternalTextFile(
+  vaultPath: string,
+  relativePath: string,
+): Promise<{ fullPath: string; stats: Stats; content: string }> {
+  const { fullPath, handle, stats } = await openVaultInternalFileForRead(vaultPath, relativePath);
+  try {
+    return { fullPath, stats, content: await handle.readFile("utf-8") };
+  } finally {
+    await handle.close();
+  }
 }
 
 export async function listNotes(
@@ -548,15 +641,21 @@ export async function readNote(
   relativePath: string,
 ): Promise<string> {
   assertMarkdownNotePath(relativePath);
-  const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
+  let handle: FileHandle | undefined;
   try {
-    await assertResolvedNoteFileSize(fullPath, relativePath);
-    return await fs.readFile(fullPath, "utf-8");
+    const opened = await openVaultFileForRead(vaultPath, relativePath);
+    handle = opened.handle;
+    assertNoteFileSize(relativePath, opened.stats.size);
+    const content = await handle.readFile("utf-8");
+    assertNoteContentSize(relativePath, content);
+    return content;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       throw new Error(`Note not found: ${relativePath}`, { cause: err });
     }
     throw err;
+  } finally {
+    await handle?.close();
   }
 }
 
@@ -583,11 +682,10 @@ export async function readNoteLineRange(
   ) {
     throw new Error(`Invalid line range for note: ${relativePath}`);
   }
-  const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
-  let handle: fs.FileHandle | undefined;
+  let handle: FileHandle | undefined;
   try {
-    await assertResolvedRegularFile(fullPath, relativePath);
-    handle = await fs.open(fullPath, "r");
+    const opened = await openVaultFileForRead(vaultPath, relativePath);
+    handle = opened.handle;
     const decoder = new StringDecoder("utf8");
     const buffer = Buffer.allocUnsafe(64 * 1024);
     const collected: string[] = [];
@@ -735,8 +833,14 @@ export async function updateNote(
   assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
-    await assertResolvedNoteFileSize(fullPath, relativePath);
-    const existing = await fs.readFile(fullPath, "utf-8");
+    const opened = await openResolvedVaultFileForRead(vaultPath, relativePath, fullPath, "write");
+    let existing: string;
+    try {
+      assertNoteFileSize(relativePath, opened.stats.size);
+      existing = await opened.handle.readFile("utf-8");
+    } finally {
+      await opened.handle.close();
+    }
     const next = await transform(existing);
     if (next === existing) return;
     assertNoteContentSize(relativePath, next);
@@ -752,8 +856,14 @@ export async function appendToNote(
   assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
-    await assertResolvedNoteFileSize(fullPath, relativePath);
-    const existing = await fs.readFile(fullPath, "utf-8");
+    const opened = await openResolvedVaultFileForRead(vaultPath, relativePath, fullPath, "write");
+    let existing: string;
+    try {
+      assertNoteFileSize(relativePath, opened.stats.size);
+      existing = await opened.handle.readFile("utf-8");
+    } finally {
+      await opened.handle.close();
+    }
     const separator = existing.endsWith("\n") ? "" : "\n";
     const next = existing + separator + content;
     assertNoteContentSize(relativePath, next);
@@ -800,8 +910,14 @@ export async function prependToNote(
   assertMarkdownNotePath(relativePath);
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
-    await assertResolvedNoteFileSize(fullPath, relativePath);
-    const existing = await fs.readFile(fullPath, "utf-8");
+    const opened = await openResolvedVaultFileForRead(vaultPath, relativePath, fullPath, "write");
+    let existing: string;
+    try {
+      assertNoteFileSize(relativePath, opened.stats.size);
+      existing = await opened.handle.readFile("utf-8");
+    } finally {
+      await opened.handle.close();
+    }
 
     // Detect frontmatter by scanning only the first N lines instead of
     // running a lazy-match regex across the full file. A malformed note with
@@ -1279,14 +1395,16 @@ export async function getNoteStats(
   relativePath: string,
   options?: { realVaultRoot?: string },
 ): Promise<{ size: number; created: Date | null; modified: Date | null }> {
-  const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "read", options);
-  const stats = await fs.stat(fullPath);
-
-  return {
-    size: stats.size,
-    created: stats.birthtime ?? null,
-    modified: stats.mtime ?? null,
-  };
+  const { handle, stats } = await openVaultFileForRead(vaultPath, relativePath, "read", options);
+  try {
+    return {
+      size: stats.size,
+      created: stats.birthtime ?? null,
+      modified: stats.mtime ?? null,
+    };
+  } finally {
+    await handle.close();
+  }
 }
 
 export async function listCanvasFiles(
@@ -1328,9 +1446,12 @@ export async function getAttachmentStats(
   vaultPath: string,
   relativePath: string,
 ): Promise<{ size: number; modified: Date | null }> {
-  const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
-  const stats = await fs.stat(fullPath);
-  return { size: stats.size, modified: stats.mtime ?? null };
+  const { handle, stats } = await openVaultFileForRead(vaultPath, relativePath);
+  try {
+    return { size: stats.size, modified: stats.mtime ?? null };
+  } finally {
+    await handle.close();
+  }
 }
 
 export async function readBaseFile(
@@ -1340,15 +1461,18 @@ export async function readBaseFile(
   if (!relativePath.toLowerCase().endsWith(".base")) {
     throw new Error(`Not a Base file: ${relativePath}`);
   }
-  const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
-  const stats = await fs.stat(fullPath);
-  assertRegularFile(relativePath, stats);
+  const { handle, stats } = await openVaultFileForRead(vaultPath, relativePath);
   if (stats.size > MAX_BASE_FILE_BYTES) {
+    await handle.close();
     throw new Error(
       `Base file exceeds size cap (${stats.size} > ${MAX_BASE_FILE_BYTES} bytes)`,
     );
   }
-  return fs.readFile(fullPath, "utf-8");
+  try {
+    return await handle.readFile("utf-8");
+  } finally {
+    await handle.close();
+  }
 }
 
 function assertCanvasFileSize(size: number, relativePath: string): void {
@@ -1394,10 +1518,14 @@ export async function readCanvasFile(
   vaultPath: string,
   relativePath: string,
 ): Promise<CanvasData> {
-  const fullPath = await resolveVaultPathSafe(vaultPath, relativePath);
-  const stats = await fs.stat(fullPath);
-  assertCanvasFileSize(stats.size, relativePath);
-  const content = await fs.readFile(fullPath, "utf-8");
+  const { handle, stats } = await openVaultFileForRead(vaultPath, relativePath);
+  let content: string;
+  try {
+    assertCanvasFileSize(stats.size, relativePath);
+    content = await handle.readFile("utf-8");
+  } finally {
+    await handle.close();
+  }
   let parsed: unknown;
   try {
     parsed = JSON.parse(content);
@@ -1448,9 +1576,14 @@ export async function updateCanvasFile(
 ): Promise<void> {
   const fullPath = await resolveVaultPathSafe(vaultPath, relativePath, "write");
   await withFileLock(fullPath, async () => {
-    const stats = await fs.stat(fullPath);
-    assertCanvasFileSize(stats.size, relativePath);
-    const raw = await fs.readFile(fullPath, "utf-8");
+    const opened = await openResolvedVaultFileForRead(vaultPath, relativePath, fullPath, "write");
+    let raw: string;
+    try {
+      assertCanvasFileSize(opened.stats.size, relativePath);
+      raw = await opened.handle.readFile("utf-8");
+    } finally {
+      await opened.handle.close();
+    }
     let parsed: unknown;
     try {
       parsed = JSON.parse(raw);

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -8,7 +8,7 @@ import {
   getAttachmentStats,
   getNoteStats,
   getVaultRootRealPath,
-  resolveVaultPathSafe,
+  openVaultFileForRead,
 } from "../lib/vault.js";
 import { readAllCached } from "../lib/index-cache.js";
 import { makeProgressReporter } from "../lib/progress.js";
@@ -526,17 +526,21 @@ export function registerAttachmentTools(server: McpServer, vaultPath: string): v
         }
 
         const limit = maxBytes ?? DEFAULT_GET_ATTACHMENT_LIMIT;
-        const fullPath = await resolveVaultPathSafe(vaultPath, relPath);
-        await assertNoSymlinkAttachmentPath(vaultPath, fullPath, relPath);
-        const preOpenStat = await fs.stat(fullPath);
-        if (!preOpenStat.isFile()) {
-          return errorResult(
-            `Attachment "${displayAttachmentValue(relPath)}" is not a regular file.`,
-          );
+        let opened: Awaited<ReturnType<typeof openVaultFileForRead>>;
+        try {
+          opened = await openVaultFileForRead(vaultPath, relPath);
+        } catch (err) {
+          if ((err as Error).message === `Not a regular file: ${relPath}`) {
+            return errorResult(
+              `Attachment "${displayAttachmentValue(relPath)}" is not a regular file.`,
+            );
+          }
+          throw err;
         }
-        const handle = await fs.open(fullPath, "r");
+        const handle = opened.handle;
         let bytes: Buffer;
         try {
+          await assertNoSymlinkAttachmentPath(vaultPath, opened.fullPath, relPath);
           const stat = await handle.stat();
           if (!stat.isFile()) {
             return errorResult(

--- a/src/tools/canvas.ts
+++ b/src/tools/canvas.ts
@@ -1,9 +1,14 @@
 import { randomUUID } from "crypto";
-import fs from "fs/promises";
 import path from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { listCanvasFiles, readCanvasFile, updateCanvasFile, resolveVaultPathSafe } from "../lib/vault.js";
+import {
+  listCanvasFiles,
+  openVaultFileForRead,
+  readCanvasFile,
+  updateCanvasFile,
+  resolveVaultPathSafe,
+} from "../lib/vault.js";
 import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import {
   formatUntrustedVaultContent,
@@ -82,10 +87,10 @@ async function getCanvasReadSignature(
   vaultPath: string,
   canvasPath: string,
 ): Promise<{ fullPath: string; size: number; mtimeMs: number }> {
-  const fullPath = await resolveVaultPathSafe(vaultPath, canvasPath);
+  let opened: Awaited<ReturnType<typeof openVaultFileForRead>> | undefined;
   try {
-    const stats = await fs.stat(fullPath);
-    return { fullPath, size: stats.size, mtimeMs: stats.mtimeMs };
+    opened = await openVaultFileForRead(vaultPath, canvasPath);
+    return { fullPath: opened.fullPath, size: opened.stats.size, mtimeMs: opened.stats.mtimeMs };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       // Preserve the existing read_canvas missing-file error shape, which
@@ -93,6 +98,8 @@ async function getCanvasReadSignature(
       await readCanvasFile(vaultPath, canvasPath);
     }
     throw err;
+  } finally {
+    await opened?.handle.close();
   }
 }
 

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -1,13 +1,12 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import fs from "fs/promises";
 import path from "path";
 import {
   searchInContents,
   readNote,
   readNoteLineRange,
   listNotes,
-  resolveVaultPathSafe,
+  getNoteStats,
   getVaultRootRealPath,
 } from "../lib/vault.js";
 import { readAllCached } from "../lib/index-cache.js";
@@ -587,8 +586,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
         }
         const notes = await listNotes(vaultPath, folder);
 
-        // Stat each note for mtime. fs.stat is one syscall and bypasses the
-        // content cache deliberately — we don't need bodies, only timestamps.
+        // Stat each note for mtime without reading bodies.
         type Row = { path: string; mtimeMs: number };
         const realVaultRoot = await getVaultRootRealPath(vaultPath);
         const stats = await mapConcurrent<string, Row | undefined>(
@@ -596,9 +594,8 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
           MAX_CONCURRENT_OPS,
           async (notePath) => {
             try {
-              const fullPath = await resolveVaultPathSafe(vaultPath, notePath, "read", { realVaultRoot });
-              const st = await fs.stat(fullPath);
-              return { path: notePath, mtimeMs: st.mtimeMs };
+              const st = await getNoteStats(vaultPath, notePath, { realVaultRoot });
+              return { path: notePath, mtimeMs: st.modified?.getTime() ?? 0 };
             } catch {
               return undefined;
             }

--- a/src/tools/sections.ts
+++ b/src/tools/sections.ts
@@ -1,8 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import fs from "fs/promises";
 import path from "path";
-import { assertNoteFileSize, readNote, resolveVaultPathSafe, updateNote } from "../lib/vault.js";
+import {
+  assertNoteFileSize,
+  openVaultFileForRead,
+  readNote,
+  readVaultTextFile,
+  resolveVaultPathSafe,
+  updateNote,
+} from "../lib/vault.js";
 import {
   findSection,
   findBlockById,
@@ -353,16 +359,18 @@ async function getSectionListSignature(
   notePath: string,
 ): Promise<{ fullPath: string; size: number; mtimeMs: number }> {
   assertMarkdownSectionListPath(notePath);
-  const fullPath = await resolveVaultPathSafe(vaultPath, notePath);
+  let opened: Awaited<ReturnType<typeof openVaultFileForRead>> | undefined;
   try {
-    const stats = await fs.stat(fullPath);
-    assertNoteFileSize(notePath, stats.size);
-    return { fullPath, size: stats.size, mtimeMs: stats.mtimeMs };
+    opened = await openVaultFileForRead(vaultPath, notePath);
+    assertNoteFileSize(notePath, opened.stats.size);
+    return { fullPath: opened.fullPath, size: opened.stats.size, mtimeMs: opened.stats.mtimeMs };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       await readNote(vaultPath, notePath);
     }
     throw err;
+  } finally {
+    await opened?.handle.close();
   }
 }
 
@@ -391,17 +399,24 @@ async function readSectionListCached(vaultPath: string, notePath: string): Promi
     return cached.text;
   }
 
-  let content: string;
+  let read: Awaited<ReturnType<typeof readVaultTextFile>> | undefined;
   try {
-    content = await fs.readFile(signature.fullPath, "utf-8");
+    read = await readVaultTextFile(vaultPath, notePath);
+    assertNoteFileSize(notePath, read.stats.size);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       throw new Error(`Note not found: ${notePath}`, { cause: err });
     }
     throw err;
   }
-  const text = renderSectionList(notePath, content);
-  sectionListCache.set(key, { ...signature, text });
+  if (!read) throw new Error(`Note not found: ${notePath}`);
+  const text = renderSectionList(notePath, read.content);
+  sectionListCache.set(key, {
+    fullPath: read.fullPath,
+    size: read.stats.size,
+    mtimeMs: read.stats.mtimeMs,
+    text,
+  });
   while (sectionListCache.size > SECTION_LIST_CACHE_LIMIT) {
     const oldestKey = sectionListCache.keys().next().value;
     if (oldestKey === undefined) break;


### PR DESCRIPTION
﻿Direct vault reads now open the target, re-run canonical containment, and compare the opened handle with the current path before content or metadata is returned. Note, section, Base, Canvas, attachment, cache, daily config, embedding snapshot, and rewrite reads use the shared helper so a symlink retargeted after validation is rejected instead of followed.

Score: 4 severity x 4 reach / 2 effort = 8. The race needs local write access to the vault and tight timing, but it crosses the vault boundary on high-reach read paths, and the fix centralizes the validation instead of patching one sink.

Risk: read paths now retry once if the file identity changes between open and validation; a file being atomically replaced twice in that tiny window may return a validation error instead of stale content.

Reference: Node's fs docs define `fs.stat()` as following symlinks, `fs.lstat()` as statting the link itself, and `FileHandle.stat()` as reading metadata from an opened handle: https://nodejs.org/api/fs.html

Tested: `$env:CI_SYMLINKS='1'; npm test -- src/__tests__/vault.test.ts -t "rejects a symlink retargeted"`; `npm test -- src/__tests__/vault.test.ts src/__tests__/security.test.ts src/__tests__/handlers/attachments.test.ts src/__tests__/handlers/read.test.ts src/__tests__/handlers/canvas.test.ts src/__tests__/handlers/bases.test.ts src/__tests__/index-cache.test.ts src/__tests__/embedding-store.test.ts src/__tests__/link-rewriter.test.ts`; `npm test -- src/__tests__/attachments-display.test.ts src/__tests__/regression-tools-links.test.ts`; `npm run verify`.

Greptile skipped because the review quota is exhausted.
