### PR TITLE
fix: redact local log diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `move_note` now rejects relative symlink moves whose copied destination link would resolve to a different target.
 - Direct note reads, note read-modify-write helpers, and direct attachment reads now require regular files before reading content.
 - Direct vault reads now use revalidated open file handles, so a symlink retargeted after containment validation is rejected before note, section, Base, Canvas, cache, attachment, or rewrite content is returned.
+- Local stderr logs now redact absolute paths, vault-relative path fields, secret-bearing URLs, and control characters before writing text or JSON diagnostics.
 - `read_base` and `query_base` now require `.base` file paths instead of accepting arbitrary readable vault files.
 - Daily-note config-derived paths in `get_daily_note`, `create_daily_note`, and `obsidian://daily` output now use explicit untrusted-content markers, and note/daily resource metadata labels are generic.
 - Note and daily resources now wrap returned markdown bodies in visible untrusted-content markers instead of relying only on `_meta` trust metadata.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Operational endpoints (no auth required):
 | `GET /health` | `{ status: "ok", version: <string> }` — liveness for monitoring. |
 | `GET /version` | `{ version: <string> }` — package version, for rollout auditing. |
 
-Structured logging is controlled by `LOG_LEVEL` (`debug`/`info`/`warn`/`error`/`silent`, default `info`) and `LOG_FORMAT` (`text`/`json`, default `text`). All logs go to stderr so the stdio transport on stdout is never polluted.
+Structured logging is controlled by `LOG_LEVEL` (`debug`/`info`/`warn`/`error`/`silent`, default `info`) and `LOG_FORMAT` (`text`/`json`, default `text`). All logs go to stderr so the stdio transport on stdout is never polluted, with absolute paths, vault-relative path fields, secret-bearing URLs, and control characters redacted before write.
 
 ---
 
@@ -345,7 +345,7 @@ This latch is per call so scripted index refreshes have to keep the privacy deci
 
 ### Observability
 
-Logs stream to stderr as either plain text (default) or single-line JSON, controlled by `LOG_LEVEL` (`debug`/`info`/`warn`/`error`/`silent`) and `LOG_FORMAT` (`text`/`json`).
+Logs stream to stderr as either plain text (default) or single-line JSON, controlled by `LOG_LEVEL` (`debug`/`info`/`warn`/`error`/`silent`) and `LOG_FORMAT` (`text`/`json`). Local stderr and MCP-forwarded log payloads both redact absolute paths, vault-relative path fields, secret-bearing URLs, and control characters.
 
 The server also declares the MCP [`logging` capability](https://modelcontextprotocol.io/specification), so every log line is forwarded to the connected client as a `notifications/message` frame alongside tool responses. Clients that honor `logging/setLevel` can filter server-side logs at runtime without restarting. Claude Desktop surfaces these in its MCP DevTools pane; most other clients currently ignore them, so this is useful primarily for self-hosters and tooling authors.
 
@@ -361,7 +361,7 @@ The server also declares the MCP [`logging` capability](https://modelcontextprot
 - **Attachment safety** — executable extensions are blocked, SVGs are returned as `text/plain`, and active text formats such as HTML/XML/CSS are served with `text/plain` resource metadata.
 - **Canvas link safety** — Canvas link nodes added through the server accept only absolute `http://` and `https://` URLs, preventing local file and application-protocol links from being persisted by tool calls.
 - **Regex edit safety** — `replace_in_note` caps regex pattern/input size and rejects backtracking-prone repeated groups before matching.
-- **Error and log sanitization** — filesystem error messages are stripped of absolute host paths before being returned to MCP clients, ASCII control bytes and Unicode bidi controls are escaped in displayed values, and note-derived duplicate-alias text is not copied into graph warnings. Uncaught HTTP errors respond with a generic `Internal server error` body; full detail stays in the server log.
+- **Error and log sanitization** — filesystem error messages are stripped of absolute host paths before being returned to MCP clients, local stderr and MCP-forwarded logs redact paths and secret-bearing URLs, ASCII control bytes and Unicode bidi controls are escaped in displayed values, and note-derived duplicate-alias text is not copied into graph warnings. Uncaught HTTP errors respond with a generic `Internal server error` body while server logs keep sanitized diagnostics.
 - **Untrusted vault text boundaries** — tool outputs that include note bodies, read, search result, semantic result, semantic index failure, write rewrite-warning, link-graph, attachment, Base, and Canvas path summaries, attachment extension summaries, search snippets, semantic snippets and heading paths, tag lists, tag search result paths and previews, tag rename skipped-note rows, frontmatter values, Base data, wikilink targets in link-analysis output, SVG attachment text, section headings, Canvas node identities, colors, previews, edge endpoints, and edge labels, or backlink context wrap those vault-authored portions in `[BEGIN UNTRUSTED VAULT CONTENT: ...]` / `[END UNTRUSTED VAULT CONTENT: ...]` markers before they enter an MCP client's model context. Note and daily resources use the same visible boundaries for markdown bodies and carry `_meta["obsidian-mcp-pro/contentTrust"] = "untrusted-vault-content"`.
 - **YAML parser boundaries** — Obsidian properties are parsed only from `---` YAML delimiter lines; non-YAML gray-matter language blocks stay as body text, oversized frontmatter is skipped on reads and refused for metadata updates, and note/Base YAML containing anchors or aliases is not parsed.
 - **Semantic index freshness** — `search_semantic` and `find_similar_notes` re-check current note content hashes before returning stored snippets or source-note embeddings, pruning stale cache entries instead of surfacing old note text.

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -94,19 +94,18 @@ describe("logger", () => {
     expect(sendLoggingMessage).not.toHaveBeenCalled();
   });
 
-  it("strips absolute paths from forwarded MCP payload but keeps them in stderr", () => {
+  it("strips absolute paths from stderr and forwarded MCP payloads", () => {
     const sendLoggingMessage = vi.fn().mockResolvedValue(undefined);
     const fakeServer = { server: { sendLoggingMessage } } as unknown as McpServer;
     configureLogger({ level: "info", format: "text", mcpServer: fakeServer });
 
     log.info("vault configured", { vault: "/Users/alice/Documents/MyVault", configPath: "C:\\Users\\bob\\.obsidian" });
 
-    // Local stderr keeps the full path for operator diagnostics.
     const stderrOut = captured.join("");
-    expect(stderrOut).toContain("/Users/alice/Documents/MyVault");
-    expect(stderrOut).toContain("C:\\Users\\bob");
+    expect(stderrOut).not.toContain("/Users/alice/Documents/MyVault");
+    expect(stderrOut).not.toContain("C:\\Users\\bob");
+    expect(stderrOut).toContain("<path>");
 
-    // MCP-forwarded payload MUST NOT contain the absolute host paths.
     expect(sendLoggingMessage).toHaveBeenCalledTimes(1);
     const [params] = sendLoggingMessage.mock.calls[0];
     const dataStr = JSON.stringify(params.data);
@@ -128,10 +127,11 @@ describe("logger", () => {
     });
 
     const stderrOut = captured.join("");
-    expect(stderrOut).toContain("private/therapy.md");
-    expect(stderrOut).toContain("finance/taxes-2026.md");
-    expect(stderrOut).toContain("daily.md");
-    expect(stderrOut).toContain("projects/acquisition.md");
+    expect(stderrOut).not.toContain("private/therapy.md");
+    expect(stderrOut).not.toContain("finance/taxes-2026.md");
+    expect(stderrOut).not.toContain("daily.md");
+    expect(stderrOut).not.toContain("projects/acquisition.md");
+    expect(stderrOut).toContain("<vault path>");
 
     expect(sendLoggingMessage).toHaveBeenCalledTimes(1);
     const [params] = sendLoggingMessage.mock.calls[0];
@@ -193,11 +193,68 @@ describe("logger", () => {
 
     const err = new Error("ENOENT: no such file '/Users/alice/vault/secret.md'");
     log.error("tool failed", { err });
+    log.error("tool failed", { err: new Error("Note not found: private/therapy.md") });
+
+    const dataStr = JSON.stringify(sendLoggingMessage.mock.calls.map(([params]) => params.data));
+    expect(dataStr).not.toContain("alice");
+    expect(dataStr).not.toContain("secret.md");
+    expect(dataStr).not.toContain("therapy");
+    expect(dataStr).toContain("<vault path>");
+
+    const stderrOut = captured.join("");
+    expect(stderrOut).not.toContain("alice");
+    expect(stderrOut).not.toContain("secret.md");
+    expect(stderrOut).not.toContain("therapy");
+    expect(stderrOut).toContain("<vault path>");
+  });
+
+  it("redacts local JSON logs before writing to stderr", () => {
+    configureLogger({ level: "info", format: "json" });
+
+    log.error("provider rejected https://alice:pa55@example.internal/v1?token=abc\nnext", {
+      vault: "/Users/alice/Documents/MyVault",
+      note: "private/therapy.md",
+      err: new Error("Note not found: private/therapy.md"),
+    });
+
+    const parsed = JSON.parse(captured.join("").trim()) as {
+      msg: string;
+      vault: string;
+      note: string;
+      err: { message: string; stack?: string };
+    };
+    const serialized = JSON.stringify(parsed);
+    expect(parsed.msg).toBe("provider rejected https://<redacted-url>\\nnext");
+    expect(parsed.vault).toBe("<path>");
+    expect(parsed.note).toBe("<vault path>");
+    expect(parsed.err.message).toContain("<vault path>");
+    expect(serialized).not.toContain("alice");
+    expect(serialized).not.toContain("therapy");
+    expect(serialized).not.toContain("pa55");
+    expect(serialized).not.toContain("\nnext");
+  });
+
+  it("keeps non-path slashes in serialized error diagnostics", () => {
+    const sendLoggingMessage = vi.fn().mockResolvedValue(undefined);
+    const fakeServer = { server: { sendLoggingMessage } } as unknown as McpServer;
+    configureLogger({ level: "info", format: "json", mcpServer: fakeServer });
+
+    log.error("provider failed", {
+      err: new Error(
+        "OBSIDIAN_EMBEDDING_URL scheme/host not allowed. Only https:// URLs and http:// to localhost/127.0.0.1 are permitted.",
+      ),
+    });
+
+    const stderrOut = captured.join("");
+    expect(stderrOut).toContain("scheme/host");
+    expect(stderrOut).toContain("https:// URLs");
+    expect(stderrOut).toContain("localhost/127.0.0.1");
 
     const [params] = sendLoggingMessage.mock.calls[0];
     const dataStr = JSON.stringify(params.data);
-    expect(dataStr).not.toContain("alice");
-    expect(dataStr).not.toContain("secret.md");
+    expect(dataStr).toContain("scheme/host");
+    expect(dataStr).toContain("https:// URLs");
+    expect(dataStr).toContain("localhost/127.0.0.1");
   });
 
   it("escapes controls recursively in forwarded MCP payloads", () => {
@@ -231,6 +288,15 @@ describe("logger", () => {
       nested: { callback: "https://callback.example.test/path?sig=hidden" },
       err: new Error("bad https://bob:pw@host.test/path#frag"),
     });
+
+    const stderrOut = captured.join("");
+    expect(stderrOut).not.toContain("alice");
+    expect(stderrOut).not.toContain("pa55");
+    expect(stderrOut).not.toContain("api_key");
+    expect(stderrOut).not.toContain("bob");
+    expect(stderrOut).not.toContain("host.test");
+    expect(stderrOut).not.toContain("sig=hidden");
+    expect(stderrOut).toContain("https://<redacted-url>");
 
     const [params] = sendLoggingMessage.mock.calls[0];
     const dataStr = JSON.stringify(params.data);

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -24,6 +24,7 @@ import {
   getVaultRootRealPath,
 } from "../lib/vault.js";
 import { setPermissions } from "../lib/permissions.js";
+import { configureLogger } from "../lib/logger.js";
 
 let vaultDir: string;
 const itWin32 = process.platform === "win32" ? it : it.skip;
@@ -38,6 +39,7 @@ afterEach(async () => {
   setMaxNoteFileBytesForTests(null);
   setMaxNoteLineRangeBytesForTests(null);
   setPermissions({ readPaths: null, writePaths: null });
+  configureLogger({ level: "info", format: "text", mcpServer: null });
   await fs.rm(vaultDir, { recursive: true, force: true });
 });
 
@@ -53,6 +55,28 @@ describe("resolveVaultPath", () => {
   it("should allow the vault root itself", () => {
     const result = resolveVaultPath(vaultDir, ".");
     expect(result).toBe(path.resolve(vaultDir));
+  });
+
+  it("redacts missing vault root paths in the fallback log", async () => {
+    const missingRoot = path.join(vaultDir, "missing-root");
+    const captured: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      captured.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    });
+
+    try {
+      configureLogger({ level: "warn", format: "text", mcpServer: null });
+      await expect(getVaultRootRealPath(missingRoot)).resolves.toBe(path.resolve(missingRoot));
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    const out = captured.join("");
+    expect(out).toContain("Vault path does not exist");
+    expect(out).toContain("vaultPath=<path>");
+    expect(out).not.toContain(missingRoot);
   });
 
   it("should block ../ traversal", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,9 +93,8 @@ function resolveVaultFromEnv(): string | null {
 
   const resolved = path.resolve(envPath);
   if (!isValidVaultPath(resolved)) {
-    // Log the configured path (not sanitized) because this is an operator-
-    // facing diagnostic — they already know the path, and hiding it would
-    // make the error useless. This never goes into a tool response.
+    // The logger redacts the path before writing to stderr or forwarding to
+    // MCP clients, so this stays useful without leaking host layout.
     log.warn("OBSIDIAN_VAULT_PATH is not a valid vault (missing .obsidian dir)", {
       vaultPath: resolved,
     });

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -6,6 +6,9 @@
 // Level + mode are resolved once from env at module load (`LOG_LEVEL`,
 // `LOG_FORMAT`). Tests can override via `configureLogger`.
 //
+// Local stderr is redacted before write, so paths, secret-bearing URLs, and
+// control characters do not leak into shared terminal/session logs.
+//
 // When an `McpServer` is wired in via `configureLogger({ mcpServer })` the
 // logger ALSO forwards each message to the connected MCP client(s) via
 // `notifications/message`. The MCP Server declares a `logging` capability
@@ -19,6 +22,7 @@ import { stripPaths, escapeControlChars, redactUrlSecrets } from "./errors.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "silent";
 export type LogFormat = "text" | "json";
+type VaultPathRedactionMode = "field" | "message";
 
 const LEVEL_RANK: Record<LogLevel, number> = {
   debug: 10,
@@ -130,8 +134,8 @@ function emit(level: LogLevel, msg: string, fields?: Record<string, unknown>): v
     const payload: Record<string, unknown> = {
       ts: new Date().toISOString(),
       level,
-      msg,
-      ...serialized,
+      msg: sanitizeLogString(msg),
+      ...sanitizeLogData(serialized),
     };
     process.stderr.write(JSON.stringify(payload) + "\n");
   } else {
@@ -139,7 +143,7 @@ function emit(level: LogLevel, msg: string, fields?: Record<string, unknown>): v
     const suffix = fields && Object.keys(fields).length > 0
       ? " " + formatFieldsText(fields)
       : "";
-    process.stderr.write(`${prefix} ${level} ${msg}${suffix}\n`);
+    process.stderr.write(`${prefix} ${level} ${sanitizeLogString(msg)}${suffix}\n`);
   }
 
   // Forward to the MCP client too when a server is wired in. Fire-and-forget:
@@ -148,13 +152,12 @@ function emit(level: LogLevel, msg: string, fields?: Record<string, unknown>): v
   // messages below the session's `logging/setLevel` on its own.
   //
   // The MCP `data` payload goes verbatim to the client in `notifications/
-  // message` — no SDK sanitization. Scrub absolute paths out of string values
-  // so remote clients (or clients running on a different host than the server)
-  // never see the operator's host filesystem layout. Stderr still gets full
-  // detail because the operator is reading it on their own machine.
+  // message` — no SDK sanitization. Scrub paths and secret-bearing URLs out of
+  // string values so remote clients never see the operator's host filesystem
+  // layout or vault note names from structured path fields.
   if (mcpServer && level !== "silent") {
     const mcpLevel = MCP_LEVEL[level];
-    const data: Record<string, unknown> = { msg: sanitizeForwardedString(msg) };
+    const data: Record<string, unknown> = { msg: sanitizeLogString(msg) };
     if (fields && Object.keys(fields).length > 0) {
       Object.assign(data, sanitizeLogData(serialized));
     }
@@ -176,8 +179,14 @@ function sanitizeLogData(input: Record<string, unknown>): Record<string, unknown
   return out;
 }
 
-function sanitizeForwardedString(value: string): string {
-  return escapeControlChars(stripPaths(redactUrlSecrets(value)));
+function sanitizeLogString(
+  value: string,
+  redactVaultPaths?: VaultPathRedactionMode,
+): string {
+  const stripped = stripPaths(redactUrlSecrets(value));
+  return escapeControlChars(
+    redactVaultPaths ? redactVaultPathText(stripped, redactVaultPaths) : stripped,
+  );
 }
 
 function isVaultPathField(key: string): boolean {
@@ -200,28 +209,66 @@ function looksLikeVaultPath(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;
   if (trimmed.includes("/") || trimmed.includes("\\")) return true;
-  const dot = trimmed.lastIndexOf(".");
-  if (dot <= 0) return false;
-  return VAULT_PATH_EXTENSIONS.has(trimmed.slice(dot).toLowerCase());
+  return containsVaultPathExtension(trimmed);
 }
 
-function sanitizeValue(key: string, v: unknown, redactVaultPath = false): unknown {
-  const shouldRedactVaultPath = redactVaultPath || isVaultPathField(key);
+function containsVaultPathExtension(value: string): boolean {
+  const lower = value.toLowerCase();
+  return [...VAULT_PATH_EXTENSIONS].some((ext) =>
+    lower.endsWith(ext) ||
+    lower.includes(`${ext}:`) ||
+    lower.includes(`${ext}/`) ||
+    lower.includes(`${ext}\\`),
+  );
+}
+
+function looksLikeVaultPathMessageToken(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (trimmed.includes("<path>") || trimmed.includes("<redacted-url>")) return false;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/?$/.test(trimmed)) return false;
+  return containsVaultPathExtension(trimmed);
+}
+
+function redactVaultPathText(value: string, mode: VaultPathRedactionMode): string {
+  return value.replace(/[^\s"'`<>(){}[\],;]+/g, (token) => {
+    const trailing = token.match(/[.:!?]+$/)?.[0] ?? "";
+    const core = trailing ? token.slice(0, -trailing.length) : token;
+    const shouldRedact = mode === "field"
+      ? looksLikeVaultPath(core)
+      : looksLikeVaultPathMessageToken(core);
+    return shouldRedact ? `<vault path>${trailing}` : token;
+  });
+}
+
+function isSerializedErrorObject(obj: Record<string, unknown>): boolean {
+  return typeof obj.message === "string" &&
+    (typeof obj.name === "string" || typeof obj.stack === "string");
+}
+
+function sanitizeValue(
+  key: string,
+  v: unknown,
+  redactVaultPath?: VaultPathRedactionMode,
+): unknown {
+  const redactionMode = redactVaultPath ?? (isVaultPathField(key) ? "field" : undefined);
   if (typeof v === "string") {
     const stripped = stripPaths(redactUrlSecrets(v));
-    if (stripped !== v) return escapeControlChars(stripped);
-    return shouldRedactVaultPath && looksLikeVaultPath(stripped)
-      ? "<vault path>"
-      : escapeControlChars(stripped);
+    const redacted = redactionMode
+      ? redactVaultPathText(stripped, redactionMode)
+      : stripped;
+    return escapeControlChars(redacted);
   }
   if (Array.isArray(v)) {
-    return v.map((inner) => sanitizeValue(key, inner, shouldRedactVaultPath));
+    return v.map((inner) => sanitizeValue(key, inner, redactionMode));
   }
   if (v && typeof v === "object") {
     const obj = v as Record<string, unknown>;
+    const childRedactVaultPath = redactionMode ??
+      (isSerializedErrorObject(obj) ? "message" : undefined);
     const out: Record<string, unknown> = {};
     for (const [k, inner] of Object.entries(obj)) {
-      out[k] = sanitizeValue(k, inner, shouldRedactVaultPath);
+      out[k] = sanitizeValue(k, inner, childRedactVaultPath);
     }
     return out;
   }
@@ -243,11 +290,13 @@ function formatFieldsText(fields: Record<string, unknown>): string {
   const parts: string[] = [];
   for (const [k, v] of Object.entries(fields)) {
     if (v instanceof Error) {
-      parts.push(`${k}=${escapeControlChars(v.message)}`);
+      parts.push(`${k}=${sanitizeLogString(v.message, "message")}`);
     } else if (typeof v === "string") {
-      parts.push(`${k}=${escapeControlChars(v)}`);
+      const sanitized = sanitizeValue(k, v);
+      parts.push(`${k}=${typeof sanitized === "string" ? sanitized : String(sanitized)}`);
     } else {
-      parts.push(`${k}=${escapeControlChars(JSON.stringify(v))}`);
+      const sanitized = sanitizeValue(k, v);
+      parts.push(`${k}=${escapeControlChars(JSON.stringify(sanitized) ?? String(sanitized))}`);
     }
   }
   return parts.join(" ");

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -8,6 +8,7 @@ import { mapConcurrent } from "./concurrency.js";
 import { assertAllowed, type AccessKind } from "./permissions.js";
 import { renameWithRetry, unlinkWithRetry } from "./fs-ops.js";
 import { MAX_BASE_FILE_BYTES } from "./bases.js";
+import { log } from "./logger.js";
 import type { SearchResult, SearchMatch, CanvasData } from "../types.js";
 
 // Bounded fan-out for vault-wide scans. Higher values saturate the event loop
@@ -397,7 +398,7 @@ async function getRealVaultRoot(vaultPath: string): Promise<string> {
     // ENOENT: vault root doesn't exist (yet). Fall back to the resolved path
     // so callers can proceed with creation workflows. Log so the misconfiguration
     // is visible in server logs.
-    console.warn(`getRealVaultRoot: vault path does not exist, falling back to resolved path: ${key}`);
+    log.warn("Vault path does not exist, falling back to resolved path", { vaultPath: key });
     return key;
   }
 }


### PR DESCRIPTION
﻿Local stderr now uses the same redaction path as MCP-forwarded logs before text or JSON diagnostics are written. Absolute host paths, vault-relative path fields, file-like tokens in serialized errors, secret-bearing URLs, and control characters are redacted, and the missing-vault-root fallback now goes through the logger instead of `console.warn`.

Score: 3 severity x 3 reach / 1 effort = 9. The exposure is local-process logging rather than a remote tool response, but stderr is commonly captured by clients, terminals, test logs, and support bundles, so paths and URL secrets should not be raw there.

Risk: local logs no longer show exact vault paths or note filenames for diagnostics. Error reasons, tool names, counts, status codes, and non-path URL/prose diagnostics stay readable.

Tested: `npm test -- src/__tests__/logger.test.ts src/__tests__/vault.test.ts src/__tests__/config.test.ts src/__tests__/errors.test.ts`; `npm run lint`; `npm run typecheck`; `npm run verify`.

Greptile skipped because the review quota is exhausted.
