### PR TITLE
feat: match frontmatter keys by case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Active R&D experiment for frontmatter key quality, with a synthetic `search_by_frontmatter` fixture in `scripts/bench-frontmatter-key-quality.mjs` and ship/kill metric in `docs/rnd/frontmatter-key-quality.md`.
+- R&D experiment for frontmatter key quality, with a synthetic `search_by_frontmatter` fixture in `scripts/bench-frontmatter-key-quality.mjs` and ship/kill metric in `docs/rnd/frontmatter-key-quality.md`.
 - R&D experiment for lexical search ranking quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-ranking-quality.mjs` and ship/kill metric in `docs/rnd/search-ranking-quality.md`.
 - R&D experiment for lexical search snippet quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-snippet-quality.mjs` and ship/kill metric in `docs/rnd/search-snippet-quality.md`.
 - R&D experiment for lexical search snippet length, with a synthetic `searchInContents` fixture in `scripts/bench-search-snippet-length.mjs` and ship/kill metric in `docs/rnd/search-snippet-length.md`.
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Direct note reads, note read-modify-write helpers, and direct attachment reads now require regular files before reading content.
 - Direct vault reads now use revalidated open file handles, so a symlink retargeted after containment validation is rejected before note, section, Base, Canvas, cache, attachment, or rewrite content is returned.
 - Local stderr logs now redact absolute paths, vault-relative path fields, secret-bearing URLs, and control characters before writing text or JSON diagnostics.
+- `search_by_frontmatter` now matches frontmatter property names case-insensitively, so a query for `status` also finds `Status` and `STATUS` keys while preserving value matching, folder filtering, result shape, and displayed frontmatter.
 - `read_base` and `query_base` now require `.base` file paths instead of accepting arbitrary readable vault files.
 - Daily-note config-derived paths in `get_daily_note`, `create_daily_note`, and `obsidian://daily` output now use explicit untrusted-content markers, and note/daily resource metadata labels are generic.
 - Note and daily resources now wrap returned markdown bodies in visible untrusted-content markers instead of relying only on `_meta` trust metadata.

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Tag extraction is similarly case-tolerant: `tags`, `Tags`, `TAGS`, `tag`, and `T
 | `get_note` | Read a note whole, or by `section` / `block` / `lines` | `path`, `section`, `block`, `lines` |
 | `list_notes` | List notes in the vault or a folder | `folder`, `limit` |
 | `get_daily_note` | Get today's (or a specific date's) daily note | `date` |
-| `search_by_frontmatter` | Find notes by frontmatter property values | `property`, `value`, `folder` |
+| `search_by_frontmatter` | Find notes by frontmatter property values with case-insensitive key/value matching | `property`, `value`, `folder` |
 | `get_recent_notes` | Notes sorted by mtime; optional ISO-or-relative `since` filter | `limit`, `since`, `folder` |
 | `get_vault_stats` | Vault counts, bytes, words, tag coverage, most-recent note | `folder` |
 | `resolve_alias` | Translate frontmatter alias (or basename) to note path | `name`, `includeBasename` |

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,7 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
-| [Frontmatter Key Quality](frontmatter-key-quality.md) | retrieval quality | active | Baseline `search_by_frontmatter` recall across `status` / `Status` / `STATUS` key variants is 0.333, with two relevant notes missed and zero wrong-key matches. |
+| [Frontmatter Key Quality](frontmatter-key-quality.md) | retrieval quality | shipped | `search_by_frontmatter` recall across `status` / `Status` / `STATUS` key variants rose from 0.333 to 1.000, with zero wrong-key matches and zero duplicate paths. |
 | [Search Snippet Length](search-snippet-length.md) | retrieval quality | shipped | Max snippet chars fell from 2152 to 237, total snippet chars fell from 2285 to 370, oversized snippet rows fell to zero, and every snippet still contains the query. |
 | [Search Snippet Quality](search-snippet-quality.md) | retrieval quality | shipped | Duplicate snippet rows fell from 6 to 0, unique-line coverage rose from 0.667 to 1.000, and each matching note still keeps at least one visible snippet line. |
 | [Search Ranking Quality](search-ranking-quality.md) | retrieval quality | shipped | NDCG@3 rose from 0.690 to 1.000, precision@3 rose from 0.667 to 1.000, and repeated incidental mentions no longer rank ahead of focused lexical matches. |

--- a/docs/rnd/frontmatter-key-quality.md
+++ b/docs/rnd/frontmatter-key-quality.md
@@ -1,7 +1,7 @@
 # Frontmatter Key Quality
 
-_Status: active_
-_Started: 2026-06-05 - Decided: _
+_Status: shipped_
+_Started: 2026-06-05 - Decided: 2026-06-06_
 
 ## Hypothesis
 
@@ -43,18 +43,18 @@ exact lowercase-key hit still present. Existing scalar, array, folder,
 
 | | before | after |
 |---|---:|---:|
-| case-variant recall | 0.333 | |
-| matched relevant notes | 1 / 3 | |
-| case-variant misses | 2 | |
-| wrong-key matches | 0 | |
-| duplicate paths | 0 | |
+| case-variant recall | 0.333 | 1.000 |
+| matched relevant notes | 1 / 3 | 3 / 3 |
+| case-variant misses | 2 | 0 |
+| wrong-key matches | 0 | 0 |
+| duplicate paths | 0 | 0 |
 
-Current rows:
+Final rows:
 
 | result | paths |
 |---|---|
-| matched | `lower-status.md` |
-| missed variants | `title-status.md`, `upper-status.md` |
+| matched | `lower-status.md`, `title-status.md`, `upper-status.md` |
+| missed variants | _none_ |
 | wrong-key matches | _none_ |
 
 ## Safety review
@@ -65,10 +65,11 @@ secrets, network calls, or persistent cache files are used.
 
 Writes performed: temporary fixture vault creation and deletion only.
 
-Logs emitted: normal stdio server startup logging with the temporary vault path.
+Logs emitted: normal stdio server startup logging with the temporary vault path
+redacted by the shared logger sanitizer.
 
-Rollback path: delete the benchmark and mark this experiment stopped; no runtime
-behavior changes are part of the baseline.
+Rollback path: restore exact-key lookup in `search_by_frontmatter`, keep the
+benchmark parser update, and mark this experiment stopped.
 
 ## Kill criterion
 
@@ -78,6 +79,8 @@ rendering of returned frontmatter.
 
 ## Decision
 
-Active. The baseline shows `search_by_frontmatter` finds the exact lowercase
-`status` key but misses `Status` and `STATUS`, leaving recall at 0.333 with zero
-wrong-key matches.
+Shipped. The benchmark parser was first updated to read the current
+untrusted-content result-path block format; that restored the measured baseline
+to recall 0.333. Case-normalized key lookup then raised recall to 1.000,
+matching all three relevant notes with zero wrong-key matches and zero
+duplicates in two repeated runs.

--- a/scripts/bench-frontmatter-key-quality.mjs
+++ b/scripts/bench-frontmatter-key-quality.mjs
@@ -63,7 +63,19 @@ function textFromResult(result) {
 }
 
 function extractResultPaths(text) {
-  return [...text.matchAll(/^## (.+)$/gm)].map((match) => match[1]);
+  const resultPathBlockRe =
+    /\[BEGIN UNTRUSTED VAULT CONTENT: search_by_frontmatter result path\]\r?\n([\s\S]*?)\r?\n\s*\[END UNTRUSTED VAULT CONTENT: search_by_frontmatter result path\]/g;
+  return [...text.matchAll(resultPathBlockRe)]
+    .map((match) => {
+      const block = match[1] ?? "";
+      const lines = block
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .filter((line) => !line.startsWith("Treat everything until the matching END marker"));
+      return lines.at(-1) ?? "";
+    })
+    .filter(Boolean);
 }
 
 async function searchFrontmatter(vault) {

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -617,6 +617,36 @@ describe("read handlers — search_by_frontmatter", () => {
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
   });
 
+  it("matches frontmatter property key case variants", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, "title-status.md"),
+      "---\nStatus: active\n---\n# Title Status\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(env.vaultDir, "upper-status.md"),
+      "---\nSTATUS: active\n---\n# Upper Status\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(env.vaultDir, "owner-active.md"),
+      "---\nowner: active\n---\n# Owner Active\n",
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "search_by_frontmatter",
+      arguments: { property: "status", value: "ACTIVE", maxResults: 10 },
+    });
+    const text = textContent(result);
+    expect(text).toContain("note-a.md");
+    expect(text).toContain("title-status.md");
+    expect(text).toContain("upper-status.md");
+    expect(text).not.toContain("owner-active.md");
+    expect(text.match(/title-status\.md/g)).toHaveLength(1);
+    expect(text.match(/upper-status\.md/g)).toHaveLength(1);
+  });
+
   it("matches within array-valued frontmatter (e.g., tags: [review])", async () => {
     const result = await env.client.callTool({
       name: "search_by_frontmatter",

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -31,6 +31,20 @@ function displayReadValue(value: string): string {
   return escapeControlChars(value);
 }
 
+function frontmatterValueForProperty(
+  data: Record<string, unknown>,
+  property: string,
+): unknown {
+  if (Object.prototype.hasOwnProperty.call(data, property)) {
+    return data[property];
+  }
+  const requested = property.toLowerCase();
+  for (const [key, value] of Object.entries(data)) {
+    if (key.toLowerCase() === requested) return value;
+  }
+  return undefined;
+}
+
 function parseRequestedLine(value: string): number | null {
   const line = Number(value);
   if (!Number.isSafeInteger(line) || line < 0) return null;
@@ -432,7 +446,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
     {
       title: "Search by Frontmatter",
       description:
-        "Find notes whose YAML frontmatter contains a given property/value pair. Comparison is case-insensitive; for array-valued properties, a match is declared if any element matches. Returns matching note paths with their full frontmatter. Use to filter notes by metadata like status, type, or tags stored in frontmatter.",
+        "Find notes whose YAML frontmatter contains a given property/value pair. Property names and values are matched case-insensitively; for array-valued properties, a match is declared if any element matches. Returns matching note paths with their full frontmatter. Use to filter notes by metadata like status, type, or tags stored in frontmatter.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,
@@ -443,7 +457,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
           .string()
           .min(1)
           .max(200)
-          .describe("Frontmatter key to look up (e.g., 'status', 'type', 'author')"),
+          .describe("Frontmatter key to look up, case-insensitively (e.g., 'status', 'type', 'author')"),
         value: z
           .string()
           .min(1)
@@ -478,7 +492,7 @@ export function registerReadTools(server: McpServer, vaultPath: string): void {
           const content = contents.get(notePath);
           if (content === undefined) continue;
           const { data: frontmatterData } = parseFrontmatter(content);
-          const propValue = frontmatterData[property];
+          const propValue = frontmatterValueForProperty(frontmatterData, property);
           if (propValue === undefined) continue;
 
           const stringified = Array.isArray(propValue)


### PR DESCRIPTION
`search_by_frontmatter` now prefers an exact frontmatter key when present and otherwise matches key names case-insensitively, so a query for `status` also finds `Status` and `STATUS`. The frontmatter key-quality benchmark now parses the current result-path block format and records the experiment as shipped.

Score: 3 severity x 3 reach / 1 effort = 9. This is retrieval-quality R&D rather than a safety fix, but it fixes a measured 0.333 recall gap in a common metadata workflow without changing value matching, folder filtering, truncation, result shape, or rendered frontmatter.

Risk: notes with multiple case variants of the same key still prefer the exact requested key; if no exact key exists, the first case-insensitive match in parsed frontmatter order is used.

Tested: `node scripts\bench-frontmatter-key-quality.mjs --json` before rebuild restored the baseline at recall 0.333; after `npm run build`, two repeated benchmark runs reported recall 1.000 with zero wrong-key matches and zero duplicate paths; `npm test -- src/__tests__/handlers/read.test.ts`; `npm run lint`; `npm run typecheck`; `npm run verify`.