### PR TITLE
fix: reject invalid canvas updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Direct vault reads now use revalidated open file handles, so a symlink retargeted after containment validation is rejected before note, section, Base, Canvas, cache, attachment, or rewrite content is returned.
 - Local stderr logs now redact absolute paths, vault-relative path fields, secret-bearing URLs, and control characters before writing text or JSON diagnostics.
 - `search_by_frontmatter` now matches frontmatter property names case-insensitively, so a query for `status` also finds `Status` and `STATUS` keys while preserving value matching, folder filtering, result shape, and displayed frontmatter.
+- Canvas write tools now reject non-object `.canvas` JSON before mutation, matching `read_canvas` and leaving invalid files untouched instead of replacing them with a new object.
 - `read_base` and `query_base` now require `.base` file paths instead of accepting arbitrary readable vault files.
 - Daily-note config-derived paths in `get_daily_note`, `create_daily_note`, and `obsidian://daily` output now use explicit untrusted-content markers, and note/daily resource metadata labels are generic.
 - Note and daily resources now wrap returned markdown bodies in visible untrusted-content markers instead of relying only on `_meta` trust metadata.

--- a/src/__tests__/handlers/canvas.test.ts
+++ b/src/__tests__/handlers/canvas.test.ts
@@ -314,6 +314,25 @@ describe("canvas handlers — add_canvas_node", () => {
     await expect(fs.readFile(fullPath, "utf-8")).resolves.toBe(before);
   });
 
+  it("rejects non-object canvas JSON before mutation", async () => {
+    const fullPath = path.join(env.vaultDir, "array.canvas");
+    const before = "[]";
+    await fs.writeFile(fullPath, before, "utf-8");
+
+    const result = await env.client.callTool({
+      name: "add_canvas_node",
+      arguments: {
+        canvasPath: "array.canvas",
+        type: "text",
+        content: "should not write",
+      },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toMatch(/expected JSON object/i);
+    await expect(fs.readFile(fullPath, "utf-8")).resolves.toBe(before);
+  });
+
   it("validates file-type references stay inside the vault", async () => {
     const result = await env.client.callTool({
       name: "add_canvas_node",

--- a/src/__tests__/semantics.test.ts
+++ b/src/__tests__/semantics.test.ts
@@ -4,7 +4,7 @@ import path from "path";
 import os from "os";
 import { resolveWikilink, extractTags, extractAliases } from "../lib/markdown.js";
 import { formatMomentDate } from "../lib/dates.js";
-import { writeCanvasFile, updateCanvasFile, readCanvasFile, MAX_CANVAS_FILE_BYTES } from "../lib/vault.js";
+import { writeCanvasFile, updateCanvasFile, MAX_CANVAS_FILE_BYTES } from "../lib/vault.js";
 import type { CanvasData } from "../types.js";
 
 // ---------------------------------------------------------------------------
@@ -169,11 +169,18 @@ describe("updateCanvasFile — round-trip fidelity", () => {
     expect(roundTripped.nodes).toHaveLength(1);
   });
 
-  it("falls back gracefully when file is a bare array (invalid canvas)", async () => {
+  it("rejects bare array JSON before updating a canvas", async () => {
     const canvasPath = "broken.canvas";
-    // Not an object — writeCanvasFile then read via updateCanvasFile.
-    await writeCanvasFile(vaultDir, canvasPath, { nodes: [], edges: [] });
-    await expect(readCanvasFile(vaultDir, canvasPath)).resolves.toBeDefined();
+    const before = "[]";
+    await fs.writeFile(path.join(vaultDir, canvasPath), before, "utf-8");
+
+    await expect(
+      updateCanvasFile(vaultDir, canvasPath, (data) => ({
+        nodes: data.nodes,
+        edges: data.edges,
+      })),
+    ).rejects.toThrow("Invalid canvas file (expected JSON object)");
+    await expect(fs.readFile(path.join(vaultDir, canvasPath), "utf-8")).resolves.toBe(before);
   });
 
   it("rejects oversized existing canvas files before update parsing", async () => {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1509,6 +1509,13 @@ function canvasDataFromObject(data: Record<string, unknown>, relativePath: strin
   return { nodes, edges };
 }
 
+function assertCanvasJsonObject(parsed: unknown, relativePath: string): Record<string, unknown> {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Invalid canvas file (expected JSON object): ${relativePath}`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
 function serializeCanvasFile(data: Record<string, unknown>, relativePath: string): string {
   const serialized = JSON.stringify(data, null, 2);
   assertCanvasFileSize(Buffer.byteLength(serialized, "utf-8"), relativePath);
@@ -1536,10 +1543,7 @@ export async function readCanvasFile(
   // BUG-14: runtime validation before casting. JSON.parse can return any JSON
   // primitive (string, number, boolean, null, array) - only a non-null object
   // is a valid canvas structure.
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(`Invalid canvas file (expected JSON object): ${relativePath}`);
-  }
-  const data = parsed as Record<string, unknown>;
+  const data = assertCanvasJsonObject(parsed, relativePath);
   if (!Array.isArray(data.nodes)) {
     return { nodes: [], edges: [] };
   }
@@ -1591,7 +1595,7 @@ export async function updateCanvasFile(
     } catch {
       throw new Error(`Invalid canvas file (malformed JSON): ${relativePath}`);
     }
-    const obj = (parsed && typeof parsed === "object" ? parsed : {}) as Record<string, unknown>;
+    const obj = assertCanvasJsonObject(parsed, relativePath);
     const current = canvasDataFromObject(obj, relativePath);
     const next = await transform(current);
     assertCanvasDataCounts(next.nodes, next.edges, relativePath);


### PR DESCRIPTION
Canvas mutations now reject `.canvas` files whose JSON root is not an object, matching `read_canvas` instead of treating primitives or arrays as an empty canvas. This prevents `add_canvas_node` and `add_canvas_edge` from replacing an invalid-but-existing Canvas file with a new object.

Score: 4 severity x 2 reach / 1 effort = 8. The reachable surface is narrower than note writes, but the old path could silently destroy a malformed Canvas file during a normal write workflow.

Risk: existing callers that relied on write tools repairing primitive or array JSON will now get the same expected-object error as `read_canvas`; valid Canvas objects, unknown top-level keys, size caps, and malformed-JSON handling are unchanged.

Tested: `npm test -- src/__tests__/semantics.test.ts src/__tests__/handlers/canvas.test.ts`; `npm run lint`; `npm run typecheck`; `npm run verify`.