### PR TITLE
fix: report invalid canvas rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Local stderr logs now redact absolute paths, vault-relative path fields, secret-bearing URLs, and control characters before writing text or JSON diagnostics.
 - `search_by_frontmatter` now matches frontmatter property names case-insensitively, so a query for `status` also finds `Status` and `STATUS` keys while preserving value matching, folder filtering, result shape, and displayed frontmatter.
 - Canvas write tools now reject non-object `.canvas` JSON before mutation, matching `read_canvas` and leaving invalid files untouched instead of replacing them with a new object.
+- Canvas reference rewrites now report a failed referrer when a planned `.canvas` file becomes non-object JSON before apply, instead of silently skipping the stale reference.
 - `read_base` and `query_base` now require `.base` file paths instead of accepting arbitrary readable vault files.
 - Daily-note config-derived paths in `get_daily_note`, `create_daily_note`, and `obsidian://daily` output now use explicit untrusted-content markers, and note/daily resource metadata labels are generic.
 - Note and daily resources now wrap returned markdown bodies in visible untrusted-content markers instead of relying only on `_meta` trust metadata.

--- a/src/__tests__/link-rewriter.test.ts
+++ b/src/__tests__/link-rewriter.test.ts
@@ -455,6 +455,38 @@ describe("applyRewrites — TOCTOU safety", () => {
       oversizedCanvas,
     );
   });
+
+  it("fails when a planned canvas referrer becomes non-object JSON before apply", async () => {
+    await seed("inbox/idea.md", "# Idea");
+    await seed(
+      "board.canvas",
+      JSON.stringify({
+        nodes: [{ id: "n1", type: "file", file: "inbox/idea.md" }],
+        edges: [],
+      }),
+    );
+
+    const preMoveNotes = await listNotes(vaultDir);
+    const plan = await planMoveRewrites(
+      vaultDir,
+      "inbox/idea.md",
+      "archive/idea.md",
+      preMoveNotes,
+    );
+
+    const racedCanvas = "[]";
+    await fs.writeFile(path.join(vaultDir, "board.canvas"), racedCanvas, "utf-8");
+
+    const result = await applyRewrites(vaultDir, plan);
+
+    expect(result.updated).toEqual([]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].path).toBe("board.canvas");
+    expect(result.failed[0].error).toContain("Invalid canvas file (expected JSON object)");
+    expect(await fs.readFile(path.join(vaultDir, "board.canvas"), "utf-8")).toBe(
+      racedCanvas,
+    );
+  });
 });
 
 describe("moveNote — concurrent serialization", () => {

--- a/src/lib/link-rewriter.ts
+++ b/src/lib/link-rewriter.ts
@@ -31,6 +31,13 @@ function assertCanvasApplyFileSize(relativePath: string, size: number): void {
   }
 }
 
+function assertCanvasJsonObject(parsed: unknown, relativePath: string): Record<string, unknown> {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Invalid canvas file (expected JSON object): ${relativePath}`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
 /** A single in-place edit on a referrer file, expressed as a byte-offset slice
  *  to replace. Edits within a file are listed in increasing-offset order.
  *
@@ -413,7 +420,7 @@ export async function applyRewrites(
         } catch {
           throw new Error(`Invalid canvas file (malformed JSON): ${cp}`);
         }
-        const obj = (parsed && typeof parsed === "object" ? parsed : {}) as Record<string, unknown>;
+        const obj = assertCanvasJsonObject(parsed, cp);
         const nodes = Array.isArray(obj.nodes) ? (obj.nodes as Array<Record<string, unknown>>) : [];
         let mutated = false;
         const oldLower = plan.oldPath.toLowerCase();


### PR DESCRIPTION
Canvas reference rewrites now fail closed when a planned `.canvas` referrer becomes non-object JSON before apply. The file stays unchanged and the rewrite result reports the Canvas as a failed referrer instead of silently skipping a stale reference.

Score: 3 severity x 2 reach / 1 effort = 6. This is a narrow race/repair path, but it matters because `move_note` can otherwise report a cleaner rewrite result than actually happened.

Risk: malformed-object handling is unchanged; only primitive, array, or null Canvas JSON now moves from silent skip to a failed-referrer error.

Tested: `npm test -- src/__tests__/link-rewriter.test.ts`; `npm run lint`; `npm run typecheck`; `npm run verify`.