### PR TITLE
fix: hide permission allowlists in errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `search_by_frontmatter` now matches frontmatter property names case-insensitively, so a query for `status` also finds `Status` and `STATUS` keys while preserving value matching, folder filtering, result shape, and displayed frontmatter.
 - Canvas write tools now reject non-object `.canvas` JSON before mutation, matching `read_canvas` and leaving invalid files untouched instead of replacing them with a new object.
 - Canvas reference rewrites now report a failed referrer when a planned `.canvas` file becomes non-object JSON before apply, instead of silently skipping the stale reference.
+- Permission-denial errors no longer echo configured `OBSIDIAN_READ_PATHS` or `OBSIDIAN_WRITE_PATHS` folder lists back to clients.
 - `read_base` and `query_base` now require `.base` file paths instead of accepting arbitrary readable vault files.
 - Daily-note config-derived paths in `get_daily_note`, `create_daily_note`, and `obsidian://daily` output now use explicit untrusted-content markers, and note/daily resource metadata labels are generic.
 - Note and daily resources now wrap returned markdown bodies in visible untrusted-content markers instead of relying only on `_meta` trust metadata.

--- a/src/__tests__/permissions.test.ts
+++ b/src/__tests__/permissions.test.ts
@@ -45,6 +45,18 @@ describe("permissions", () => {
     expect(() => assertAllowed("projects/sub/a.md", "read")).not.toThrow();
   });
 
+  it("does not echo configured allowlist folders in denial errors", () => {
+    setPermissions({ readPaths: ["sensitive/clients", "public/notes"], writePaths: null });
+    expect(() => assertAllowed("other/note.md", "read")).toThrow(/OBSIDIAN_READ_PATHS/);
+    try {
+      assertAllowed("other/note.md", "read");
+    } catch (err) {
+      const message = (err as Error).message;
+      expect(message).not.toContain("sensitive/clients");
+      expect(message).not.toContain("public/notes");
+    }
+  });
+
   it("loads allowlists from env vars", () => {
     process.env.OBSIDIAN_READ_PATHS = "a,b:c";
     process.env.OBSIDIAN_WRITE_PATHS = "drafts";

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -134,18 +134,17 @@ export function assertAllowed(relativePath: string, kind: AccessKind): void {
   const list = kind === "read" ? active.readPaths : active.writePaths;
   if (!list || list.length === 0) return;
   const envName = kind === "read" ? "OBSIDIAN_READ_PATHS" : "OBSIDIAN_WRITE_PATHS";
-  const list_ = list.map((f) => f || "<vault root>").join(", ");
   const rel = normalizeRel(relativePath);
   if (rel === null) {
     throw new Error(
-      `Access denied: "${relativePath}" escapes the configured ${envName} allowlist (${list_})`,
+      `Access denied: "${relativePath}" escapes the configured ${envName} allowlist`,
     );
   }
   for (const folder of list) {
     if (isUnder(rel, folder)) return;
   }
   throw new Error(
-    `Access denied: "${relativePath}" is outside the configured ${envName} allowlist (${list_})`,
+    `Access denied: "${relativePath}" is outside the configured ${envName} allowlist`,
   );
 }
 


### PR DESCRIPTION
Permission-denial errors still name the blocking `OBSIDIAN_READ_PATHS` or `OBSIDIAN_WRITE_PATHS` setting, but no longer echo the configured folder list back to clients. The requested path still flows through the existing client-facing sanitizer at tool boundaries.

Score: 3 severity x 3 reach / 1 effort = 9. Folder allowlists can reveal private vault organization across every permission-denied tool path, and dropping them keeps the actionable env-var hint without exposing the configured entries.

Risk: clients that parse the literal folder list from error strings will no longer receive it; `describePermissions()` remains unchanged for explicit local diagnostics.

Tested: `npm test -- src/__tests__/permissions.test.ts src/__tests__/regression-permissions.test.ts src/__tests__/security.test.ts src/__tests__/regression-tools-sections.test.ts`; `npm run lint`; `npm run typecheck`; `npm run verify`.