### PR TITLE
fix: ignore numeric-only frontmatter tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- R&D experiment for tag validity quality, with a synthetic frontmatter/inline tag fixture in `scripts/bench-tag-validity-quality.mjs` and ship/kill metric in `docs/rnd/tag-validity-quality.md`.
 - R&D experiment for frontmatter key quality, with a synthetic `search_by_frontmatter` fixture in `scripts/bench-frontmatter-key-quality.mjs` and ship/kill metric in `docs/rnd/frontmatter-key-quality.md`.
 - R&D experiment for lexical search ranking quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-ranking-quality.mjs` and ship/kill metric in `docs/rnd/search-ranking-quality.md`.
 - R&D experiment for lexical search snippet quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-snippet-quality.mjs` and ship/kill metric in `docs/rnd/search-snippet-quality.md`.
@@ -45,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Frontmatter tag extraction now drops leading hashes and ignores numeric-only tag values, matching Obsidian's tag format while preserving valid mixed, nested, and inline tags.
 - `get_note` line fragments now reject unsafe line numbers and cap line-range scan/output bytes, while still allowing small targeted fragments from notes over the full-read cap.
 - `list_sections` now rejects non-markdown files and notes over the configured note-size cap before parsing headings.
 - Attachment inventory and direct attachment reads now skip files inside hidden dot-directories, matching the existing hidden-dotfile boundary.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,6 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
+| [Tag Validity Quality](tag-validity-quality.md) | retrieval quality | shipped | Numeric-only frontmatter tag leakage in `list_tags` and `search_by_tag` fell from 1 to 0 while valid tag list and search recall stayed at 1.000. |
 | [Frontmatter Key Quality](frontmatter-key-quality.md) | retrieval quality | shipped | `search_by_frontmatter` recall across `status` / `Status` / `STATUS` key variants rose from 0.333 to 1.000, with zero wrong-key matches and zero duplicate paths. |
 | [Search Snippet Length](search-snippet-length.md) | retrieval quality | shipped | Max snippet chars fell from 2152 to 237, total snippet chars fell from 2285 to 370, oversized snippet rows fell to zero, and every snippet still contains the query. |
 | [Search Snippet Quality](search-snippet-quality.md) | retrieval quality | shipped | Duplicate snippet rows fell from 6 to 0, unique-line coverage rose from 0.667 to 1.000, and each matching note still keeps at least one visible snippet line. |

--- a/docs/rnd/tag-validity-quality.md
+++ b/docs/rnd/tag-validity-quality.md
@@ -1,0 +1,79 @@
+# Tag Validity Quality
+
+_Status: shipped_
+_Started: 2026-06-07 - Decided: 2026-06-07_
+
+## Hypothesis
+
+Obsidian rejects numeric-only tags such as `#1984`, but `extractTags` accepted
+numeric-only values from YAML frontmatter. Filtering numeric-only frontmatter
+tags should remove false positives from `list_tags` and `search_by_tag` without
+reducing valid mixed, nested, or inline tag recall.
+
+Official sources:
+
+- https://help.obsidian.md/tags
+- https://help.obsidian.md/properties
+
+## Fixture
+
+Bench command:
+
+```powershell
+npm run build
+node scripts\bench-tag-validity-quality.mjs --json
+```
+
+The fixture creates a temporary five-note vault and calls `list_tags` and
+`search_by_tag` through a real stdio MCP client.
+
+Relevant notes:
+
+- `numeric-frontmatter.md` has frontmatter `tags: [1984]`
+- `mixed-year.md` has frontmatter `tags: [y1984]`
+- `nested.md` has frontmatter `tags: [project/alpha]`
+- `inline-invalid.md` contains inline `#1984`
+- `inline-valid.md` contains inline `#meeting`
+
+## Metric
+
+Primary metric: invalid numeric-only tag leakage across tag listing and tag
+search.
+
+Ship bar: zero numeric-only frontmatter tags listed, zero numeric-only
+frontmatter search matches, `validTagListRecall` at 1.000, and
+`validSearchRecall` at 1.000.
+
+| | before | after |
+|---|---:|---:|
+| invalid numeric tags listed | 1 | 0 |
+| invalid numeric search matches | 1 | 0 |
+| valid tag list recall | 1.000 | 1.000 |
+| valid search recall | 1.000 | 1.000 |
+
+## Safety review
+
+Data accessed: synthetic markdown notes generated in a temporary vault by
+`scripts/bench-tag-validity-quality.mjs`. No real vault content, secrets,
+network calls, or embedding providers are used.
+
+Writes performed: temporary fixture vault creation and deletion only.
+
+Logs emitted: normal stdio server startup logging with the temporary vault path
+redacted by the shared logger sanitizer.
+
+Rollback path: restore the old frontmatter tag insertion path and keep the
+benchmark as a stopped experiment.
+
+## Kill criterion
+
+Stop if filtering numeric-only frontmatter values removes valid mixed tags,
+nested tags, inline tags, control-character escaping behavior, nested-parent
+matching, or tag-index cache invalidation.
+
+## Decision
+
+Shipped. Frontmatter tags are now normalized by trimming and dropping leading
+hashes before insertion, then numeric-only values are ignored. The benchmark
+removed both invalid numeric-only listing and search matches while valid tag
+list and search recall stayed at 1.000.

--- a/scripts/bench-tag-validity-quality.mjs
+++ b/scripts/bench-tag-validity-quality.mjs
@@ -1,0 +1,151 @@
+// Tag validity quality benchmark: exercise frontmatter and inline tag parsing
+// through a real stdio MCP client.
+//
+// Direct use: node scripts/bench-tag-validity-quality.mjs [--json]
+// Run after `npm run build`.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const entry = join(root, "build", "index.js");
+
+function writeNote(vault, name, lines) {
+  writeFileSync(join(vault, name), `${lines.join("\n")}\n`);
+}
+
+function makeVault() {
+  const dir = mkdtempSync(join(tmpdir(), "ompro-tag-validity-"));
+  mkdirSync(join(dir, ".obsidian"));
+  writeNote(dir, "numeric-frontmatter.md", [
+    "---",
+    "tags:",
+    "  - 1984",
+    "---",
+    "Frontmatter contains a numeric-only tag value.",
+  ]);
+  writeNote(dir, "mixed-year.md", [
+    "---",
+    "tags:",
+    "  - y1984",
+    "---",
+    "Mixed tags remain valid.",
+  ]);
+  writeNote(dir, "nested.md", [
+    "---",
+    "tags:",
+    "  - project/alpha",
+    "---",
+    "Nested frontmatter tags remain valid.",
+  ]);
+  writeNote(dir, "inline-invalid.md", [
+    "Inline numeric-only #1984 should not become a tag.",
+  ]);
+  writeNote(dir, "inline-valid.md", [
+    "Inline valid #meeting tag should remain searchable.",
+  ]);
+  return dir;
+}
+
+function textOf(result) {
+  return result.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
+}
+
+function containsPath(text, notePath) {
+  return text.includes(notePath);
+}
+
+function containsTag(text, tag) {
+  return text.includes(`#${tag}`);
+}
+
+async function callText(client, name, args) {
+  return textOf(await client.callTool({ name, arguments: args }));
+}
+
+async function measure(vault) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [entry],
+    cwd: root,
+    env: { ...process.env, OBSIDIAN_VAULT_PATH: vault },
+  });
+  const client = new Client({ name: "tag-validity-bench", version: "1.0.0" });
+  await client.connect(transport);
+  try {
+    const listTags = await callText(client, "list_tags", { sortBy: "name" });
+    const searchNumeric = await callText(client, "search_by_tag", {
+      tag: "1984",
+      includeContent: false,
+      maxResults: 10,
+    });
+    const searchMixed = await callText(client, "search_by_tag", {
+      tag: "y1984",
+      includeContent: false,
+      maxResults: 10,
+    });
+    const searchNested = await callText(client, "search_by_tag", {
+      tag: "project",
+      includeContent: false,
+      maxResults: 10,
+    });
+    const searchInline = await callText(client, "search_by_tag", {
+      tag: "meeting",
+      includeContent: false,
+      maxResults: 10,
+    });
+
+    const validSearches = [
+      containsPath(searchMixed, "mixed-year.md"),
+      containsPath(searchNested, "nested.md"),
+      containsPath(searchInline, "inline-valid.md"),
+    ];
+    const validListedTags = ["y1984", "project/alpha", "meeting"].filter((tag) =>
+      containsTag(listTags, tag),
+    ).length;
+
+    return {
+      invalidNumericTagsListed: containsTag(listTags, "1984") ? 1 : 0,
+      invalidNumericSearchMatches: containsPath(searchNumeric, "numeric-frontmatter.md") ? 1 : 0,
+      validTagListRecall: validListedTags / 3,
+      validSearchRecall: validSearches.filter(Boolean).length / validSearches.length,
+    };
+  } finally {
+    await client.close();
+  }
+}
+
+export async function runTagValidityQualityBench() {
+  const vault = makeVault();
+  try {
+    return await measure(vault);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+}
+
+const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (invokedDirectly) {
+  if (!existsSync(entry)) {
+    console.error("build/index.js missing - run `npm run build` first.");
+    process.exit(1);
+  }
+  const asJson = process.argv.slice(2).includes("--json");
+  const metrics = await runTagValidityQualityBench();
+  if (asJson) {
+    console.log(JSON.stringify(metrics));
+  } else {
+    console.log("| metric | value |");
+    console.log("|---|---:|");
+    for (const [name, value] of Object.entries(metrics)) {
+      console.log(`| ${name} | ${value} |`);
+    }
+  }
+}

--- a/src/__tests__/handlers/tags.test.ts
+++ b/src/__tests__/handlers/tags.test.ts
@@ -55,6 +55,38 @@ describe("tag handlers — list_tags", () => {
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
   });
 
+  it("ignores numeric-only frontmatter tags in list and search", async () => {
+    await env.client.callTool({
+      name: "create_note",
+      arguments: {
+        path: "numeric-frontmatter-tag.md",
+        content: "Body.",
+        frontmatter: JSON.stringify({ tags: [1984, "y1984"] }),
+      },
+    });
+
+    const list = await env.client.callTool({
+      name: "list_tags",
+      arguments: { sortBy: "name" },
+    });
+    const listText = textContent(list);
+    expect(isError(list)).toBe(false);
+    expect(listText).not.toMatch(/#1984\s+\(/);
+    expect(listText).toContain("#y1984 (1 note)");
+
+    const invalidSearch = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "1984" },
+    });
+    expect(textContent(invalidSearch)).toMatch(/No notes found/i);
+
+    const validSearch = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "y1984" },
+    });
+    expect(textContent(validSearch)).toContain("numeric-frontmatter-tag.md");
+  });
+
   it("sorts by count desc by default (review appears in 2 notes)", async () => {
     const result = await env.client.callTool({ name: "list_tags", arguments: {} });
     const text = textContent(result);

--- a/src/__tests__/markdown.test.ts
+++ b/src/__tests__/markdown.test.ts
@@ -348,6 +348,36 @@ Body.`;
     expect(tags).toContain("solo");
   });
 
+  it("should ignore numeric-only frontmatter tags", () => {
+    const content = `---
+tags:
+  - 1984
+  - 1984/2020
+  - y1984
+  - project/1984
+---
+Body.`;
+    const tags = extractTags(content);
+    expect(tags).not.toContain("1984");
+    expect(tags).not.toContain("1984/2020");
+    expect(tags).toContain("y1984");
+    expect(tags).toContain("project/1984");
+  });
+
+  it("should strip leading hashes from frontmatter tags", () => {
+    const content = `---
+tags:
+  - "#idea"
+  - "##review"
+---
+Body.`;
+    const tags = extractTags(content);
+    expect(tags).toContain("idea");
+    expect(tags).toContain("review");
+    expect(tags).not.toContain("#idea");
+    expect(tags).not.toContain("##review");
+  });
+
   it("should ignore tags inside code blocks", () => {
     const content = "```\n#hidden\n```\n#visible";
     const tags = extractTags(content);

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -618,6 +618,13 @@ export function formatWikilinkTarget(
  * Returns deduplicated tags without the `#` prefix.
  * Ignores tags inside code blocks and inline code.
  */
+function normalizeFrontmatterTag(value: unknown): string | null {
+  const tag = String(value).trim().replace(/^#+/, "");
+  if (!tag) return null;
+  if (!/[^\d/]/u.test(tag)) return null;
+  return tag;
+}
+
 export function extractTags(content: string): string[] {
   const tagSet = new Set<string>();
 
@@ -630,12 +637,12 @@ export function extractTags(content: string): string[] {
   if (tagFieldValue) {
     if (Array.isArray(tagFieldValue)) {
       for (const tag of tagFieldValue) {
-        const t = String(tag).trim();
+        const t = normalizeFrontmatterTag(tag);
         if (t) tagSet.add(t);
       }
     } else if (typeof tagFieldValue === "string") {
       for (const tag of tagFieldValue.split(",")) {
-        const t = tag.trim();
+        const t = normalizeFrontmatterTag(tag);
         if (t) tagSet.add(t);
       }
     }


### PR DESCRIPTION
Frontmatter tag extraction now drops leading hashes and ignores numeric-only tag values before they enter `list_tags` and `search_by_tag`. This matches Obsidian's tag format docs while preserving mixed, nested, and inline tags.

Docs: https://help.obsidian.md/tags and https://help.obsidian.md/properties

Risk: low; this is limited to tag extraction and does not change tool schemas or output shapes. Existing vaults that used numeric-only frontmatter values as tags will stop seeing those invalid tags in tag results.

Score: 8 = correctness 4 x reach 4 / effort 2.

Tested: `npm test -- src/__tests__/markdown.test.ts src/__tests__/handlers/tags.test.ts`; `npm run build`; `node scripts/bench-tag-validity-quality.mjs --json`; `npm run verify`.