### PR TITLE
fix: ignore whitespace frontmatter tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- R&D experiment for tag whitespace quality, with a synthetic frontmatter tag fixture in `scripts/bench-tag-whitespace-quality.mjs` and ship/kill metric in `docs/rnd/tag-whitespace-quality.md`.
 - R&D experiment for tag validity quality, with a synthetic frontmatter/inline tag fixture in `scripts/bench-tag-validity-quality.mjs` and ship/kill metric in `docs/rnd/tag-validity-quality.md`.
 - R&D experiment for frontmatter key quality, with a synthetic `search_by_frontmatter` fixture in `scripts/bench-frontmatter-key-quality.mjs` and ship/kill metric in `docs/rnd/frontmatter-key-quality.md`.
 - R&D experiment for lexical search ranking quality, with a synthetic `searchInContents` fixture in `scripts/bench-search-ranking-quality.mjs` and ship/kill metric in `docs/rnd/search-ranking-quality.md`.
@@ -46,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Frontmatter tag extraction now ignores tag values containing whitespace, matching Obsidian's tag format while preserving hyphenated, underscored, nested, and inline tags.
 - Frontmatter tag extraction now drops leading hashes and ignores numeric-only tag values, matching Obsidian's tag format while preserving valid mixed, nested, and inline tags.
 - `get_note` line fragments now reject unsafe line numbers and cap line-range scan/output bytes, while still allowing small targeted fragments from notes over the full-read cap.
 - `list_sections` now rejects non-markdown files and notes over the configured note-size cap before parsing headings.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,6 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
+| [Tag Whitespace Quality](tag-whitespace-quality.md) | retrieval quality | shipped | Whitespace-bearing frontmatter tag leakage in `list_tags` and `search_by_tag` fell from 1 to 0 while valid tag list and search recall stayed at 1.000. |
 | [Tag Validity Quality](tag-validity-quality.md) | retrieval quality | shipped | Numeric-only frontmatter tag leakage in `list_tags` and `search_by_tag` fell from 1 to 0 while valid tag list and search recall stayed at 1.000. |
 | [Frontmatter Key Quality](frontmatter-key-quality.md) | retrieval quality | shipped | `search_by_frontmatter` recall across `status` / `Status` / `STATUS` key variants rose from 0.333 to 1.000, with zero wrong-key matches and zero duplicate paths. |
 | [Search Snippet Length](search-snippet-length.md) | retrieval quality | shipped | Max snippet chars fell from 2152 to 237, total snippet chars fell from 2285 to 370, oversized snippet rows fell to zero, and every snippet still contains the query. |

--- a/docs/rnd/tag-whitespace-quality.md
+++ b/docs/rnd/tag-whitespace-quality.md
@@ -1,0 +1,78 @@
+# Tag Whitespace Quality
+
+_Status: shipped_
+_Started: 2026-06-07 - Decided: 2026-06-07_
+
+## Hypothesis
+
+Obsidian tags cannot contain blank spaces, but `extractTags` accepted whitespace
+inside YAML frontmatter tag values. Filtering whitespace-bearing frontmatter
+tags should remove false positives from `list_tags` and `search_by_tag` without
+reducing valid hyphen, underscore, nested, or inline tag recall.
+
+Official sources:
+
+- https://help.obsidian.md/tags
+- https://help.obsidian.md/properties
+
+## Fixture
+
+Bench command:
+
+```powershell
+npm run build
+node scripts\bench-tag-whitespace-quality.mjs --json
+```
+
+The fixture creates a temporary five-note vault and calls `list_tags` and
+`search_by_tag` through a real stdio MCP client.
+
+Relevant notes:
+
+- `space-frontmatter.md` has frontmatter `tags: ["project alpha"]`
+- `hyphen-frontmatter.md` has frontmatter `tags: [project-alpha]`
+- `underscore-frontmatter.md` has frontmatter `tags: [project_alpha]`
+- `nested.md` has frontmatter `tags: [project/alpha]`
+- `inline-valid.md` contains inline `#meeting-notes`
+
+## Metric
+
+Primary metric: whitespace-bearing frontmatter tag leakage across tag listing
+and tag search.
+
+Ship bar: zero whitespace-bearing frontmatter tags listed, zero whitespace
+frontmatter search matches, `validTagListRecall` at 1.000, and
+`validSearchRecall` at 1.000.
+
+| | before | after |
+|---|---:|---:|
+| invalid whitespace tags listed | 1 | 0 |
+| invalid whitespace search matches | 1 | 0 |
+| valid tag list recall | 1.000 | 1.000 |
+| valid search recall | 1.000 | 1.000 |
+
+## Safety review
+
+Data accessed: synthetic markdown notes generated in a temporary vault by
+`scripts/bench-tag-whitespace-quality.mjs`. No real vault content, secrets,
+network calls, or embedding providers are used.
+
+Writes performed: temporary fixture vault creation and deletion only.
+
+Logs emitted: normal stdio server startup logging with the temporary vault path
+redacted by the shared logger sanitizer.
+
+Rollback path: restore the previous frontmatter tag normalization helper and
+keep the benchmark as a stopped experiment.
+
+## Kill criterion
+
+Stop if filtering whitespace-bearing frontmatter values removes valid hyphen,
+underscore, nested, inline, numeric-mixed, or leading-hash-normalized tags, or if
+tag-index cache invalidation changes.
+
+## Decision
+
+Shipped. Frontmatter tags containing whitespace are now ignored before insertion.
+The benchmark removed both invalid whitespace listing and search matches while
+valid tag list and search recall stayed at 1.000.

--- a/scripts/bench-tag-whitespace-quality.mjs
+++ b/scripts/bench-tag-whitespace-quality.mjs
@@ -1,0 +1,164 @@
+// Tag whitespace quality benchmark: exercise frontmatter tag values containing
+// spaces through a real stdio MCP client.
+//
+// Direct use: node scripts/bench-tag-whitespace-quality.mjs [--json]
+// Run after `npm run build`.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const entry = join(root, "build", "index.js");
+
+function writeNote(vault, name, lines) {
+  writeFileSync(join(vault, name), `${lines.join("\n")}\n`);
+}
+
+function makeVault() {
+  const dir = mkdtempSync(join(tmpdir(), "ompro-tag-whitespace-"));
+  mkdirSync(join(dir, ".obsidian"));
+  writeNote(dir, "space-frontmatter.md", [
+    "---",
+    "tags:",
+    "  - \"project alpha\"",
+    "---",
+    "Frontmatter contains a space-separated tag value.",
+  ]);
+  writeNote(dir, "hyphen-frontmatter.md", [
+    "---",
+    "tags:",
+    "  - project-alpha",
+    "---",
+    "Hyphenated tags remain valid.",
+  ]);
+  writeNote(dir, "underscore-frontmatter.md", [
+    "---",
+    "tags:",
+    "  - project_alpha",
+    "---",
+    "Underscore tags remain valid.",
+  ]);
+  writeNote(dir, "nested.md", [
+    "---",
+    "tags:",
+    "  - project/alpha",
+    "---",
+    "Nested frontmatter tags remain valid.",
+  ]);
+  writeNote(dir, "inline-valid.md", [
+    "Inline valid #meeting-notes tag should remain searchable.",
+  ]);
+  return dir;
+}
+
+function textOf(result) {
+  return result.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
+}
+
+function containsPath(text, notePath) {
+  return text.includes(notePath);
+}
+
+function containsTag(text, tag) {
+  return new RegExp(`(^|\\n)#${tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s+\\(`).test(text);
+}
+
+async function callText(client, name, args) {
+  return textOf(await client.callTool({ name, arguments: args }));
+}
+
+async function measure(vault) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [entry],
+    cwd: root,
+    env: { ...process.env, OBSIDIAN_VAULT_PATH: vault },
+  });
+  const client = new Client({ name: "tag-whitespace-bench", version: "1.0.0" });
+  await client.connect(transport);
+  try {
+    const listTags = await callText(client, "list_tags", { sortBy: "name" });
+    const searchWhitespace = await callText(client, "search_by_tag", {
+      tag: "project alpha",
+      includeContent: false,
+      maxResults: 10,
+    });
+    const searchHyphen = await callText(client, "search_by_tag", {
+      tag: "project-alpha",
+      includeContent: false,
+      maxResults: 10,
+    });
+    const searchUnderscore = await callText(client, "search_by_tag", {
+      tag: "project_alpha",
+      includeContent: false,
+      maxResults: 10,
+    });
+    const searchNested = await callText(client, "search_by_tag", {
+      tag: "project",
+      includeContent: false,
+      maxResults: 10,
+    });
+    const searchInline = await callText(client, "search_by_tag", {
+      tag: "meeting-notes",
+      includeContent: false,
+      maxResults: 10,
+    });
+
+    const validSearches = [
+      containsPath(searchHyphen, "hyphen-frontmatter.md"),
+      containsPath(searchUnderscore, "underscore-frontmatter.md"),
+      containsPath(searchNested, "nested.md"),
+      containsPath(searchInline, "inline-valid.md"),
+    ];
+    const validListedTags = [
+      "project-alpha",
+      "project_alpha",
+      "project/alpha",
+      "meeting-notes",
+    ].filter((tag) => containsTag(listTags, tag)).length;
+
+    return {
+      invalidWhitespaceTagsListed: containsTag(listTags, "project alpha") ? 1 : 0,
+      invalidWhitespaceSearchMatches: containsPath(searchWhitespace, "space-frontmatter.md") ? 1 : 0,
+      validTagListRecall: validListedTags / 4,
+      validSearchRecall: validSearches.filter(Boolean).length / validSearches.length,
+    };
+  } finally {
+    await client.close();
+  }
+}
+
+export async function runTagWhitespaceQualityBench() {
+  const vault = makeVault();
+  try {
+    return await measure(vault);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+}
+
+const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (invokedDirectly) {
+  if (!existsSync(entry)) {
+    console.error("build/index.js missing - run `npm run build` first.");
+    process.exit(1);
+  }
+  const asJson = process.argv.slice(2).includes("--json");
+  const metrics = await runTagWhitespaceQualityBench();
+  if (asJson) {
+    console.log(JSON.stringify(metrics));
+  } else {
+    console.log("| metric | value |");
+    console.log("|---|---:|");
+    for (const [name, value] of Object.entries(metrics)) {
+      console.log(`| ${name} | ${value} |`);
+    }
+  }
+}

--- a/src/__tests__/handlers/tags.test.ts
+++ b/src/__tests__/handlers/tags.test.ts
@@ -87,6 +87,38 @@ describe("tag handlers — list_tags", () => {
     expect(textContent(validSearch)).toContain("numeric-frontmatter-tag.md");
   });
 
+  it("ignores whitespace frontmatter tags in list and search", async () => {
+    await env.client.callTool({
+      name: "create_note",
+      arguments: {
+        path: "whitespace-frontmatter-tag.md",
+        content: "Body.",
+        frontmatter: JSON.stringify({ tags: ["project alpha", "project-alpha"] }),
+      },
+    });
+
+    const list = await env.client.callTool({
+      name: "list_tags",
+      arguments: { sortBy: "name" },
+    });
+    const listText = textContent(list);
+    expect(isError(list)).toBe(false);
+    expect(listText).not.toMatch(/#project alpha\s+\(/);
+    expect(listText).toContain("#project-alpha (1 note)");
+
+    const invalidSearch = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "project alpha" },
+    });
+    expect(textContent(invalidSearch)).toMatch(/No notes found/i);
+
+    const validSearch = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "project-alpha" },
+    });
+    expect(textContent(validSearch)).toContain("whitespace-frontmatter-tag.md");
+  });
+
   it("sorts by count desc by default (review appears in 2 notes)", async () => {
     const result = await env.client.callTool({ name: "list_tags", arguments: {} });
     const text = textContent(result);

--- a/src/__tests__/markdown.test.ts
+++ b/src/__tests__/markdown.test.ts
@@ -364,6 +364,22 @@ Body.`;
     expect(tags).toContain("project/1984");
   });
 
+  it("should ignore frontmatter tags containing whitespace", () => {
+    const content = `---
+tags:
+  - "project alpha"
+  - "project\tbeta"
+  - project-alpha
+  - project_alpha
+---
+Body.`;
+    const tags = extractTags(content);
+    expect(tags).not.toContain("project alpha");
+    expect(tags).not.toContain("project\tbeta");
+    expect(tags).toContain("project-alpha");
+    expect(tags).toContain("project_alpha");
+  });
+
   it("should strip leading hashes from frontmatter tags", () => {
     const content = `---
 tags:

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -621,6 +621,7 @@ export function formatWikilinkTarget(
 function normalizeFrontmatterTag(value: unknown): string | null {
   const tag = String(value).trim().replace(/^#+/, "");
   if (!tag) return null;
+  if (/\s/u.test(tag)) return null;
   if (!/[^\d/]/u.test(tag)) return null;
   return tag;
 }


### PR DESCRIPTION
Frontmatter tag extraction now ignores tag values containing whitespace before they enter `list_tags` and `search_by_tag`. This follows Obsidian's tag format docs while preserving hyphenated, underscored, nested, and inline tags.

Docs: https://help.obsidian.md/tags and https://help.obsidian.md/properties

Risk: low; this is limited to tag extraction and does not change tool schemas or output shapes. Existing vaults that used whitespace-bearing frontmatter values as tags will stop seeing those invalid tags in tag results.

Score: 8 = correctness 4 x reach 4 / effort 2.

Tested: `npm test -- src/__tests__/markdown.test.ts src/__tests__/handlers/tags.test.ts`; `npm run build`; `node scripts/bench-tag-whitespace-quality.mjs --json`; `npm run verify`.