### PR TITLE
fix: accept numeric-leading tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- R&D experiment for numeric-leading tag quality, with a synthetic inline tag fixture in `scripts/bench-tag-leading-number-quality.mjs` and ship/kill metric in `docs/rnd/tag-leading-number-quality.md`.
 - R&D experiment for tag whitespace quality, with a synthetic frontmatter tag fixture in `scripts/bench-tag-whitespace-quality.mjs` and ship/kill metric in `docs/rnd/tag-whitespace-quality.md`.
 - R&D experiment for tag validity quality, with a synthetic frontmatter/inline tag fixture in `scripts/bench-tag-validity-quality.mjs` and ship/kill metric in `docs/rnd/tag-validity-quality.md`.
 - R&D experiment for frontmatter key quality, with a synthetic `search_by_frontmatter` fixture in `scripts/bench-frontmatter-key-quality.mjs` and ship/kill metric in `docs/rnd/frontmatter-key-quality.md`.
@@ -47,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Inline tag extraction and `rename_tag` validation now accept numeric-leading tags such as `#1a` and `#2026-goals` while still ignoring numeric-only tags.
 - Frontmatter tag extraction now ignores tag values containing whitespace, matching Obsidian's tag format while preserving hyphenated, underscored, nested, and inline tags.
 - Frontmatter tag extraction now drops leading hashes and ignores numeric-only tag values, matching Obsidian's tag format while preserving valid mixed, nested, and inline tags.
 - `get_note` line fragments now reject unsafe line numbers and cap line-range scan/output bytes, while still allowing small targeted fragments from notes over the full-read cap.

--- a/docs/rnd/README.md
+++ b/docs/rnd/README.md
@@ -19,6 +19,7 @@ delete stopped experiments; mark them `stopped` so the negative result stays on 
 
 | Experiment | Track | Status | Decision |
 |---|---|---|---|
+| [Tag Leading Number Quality](tag-leading-number-quality.md) | retrieval quality | shipped | Valid numeric-leading inline tag list/search recall rose from 0.000 to 1.000 while numeric-only tag leakage stayed at zero. |
 | [Tag Whitespace Quality](tag-whitespace-quality.md) | retrieval quality | shipped | Whitespace-bearing frontmatter tag leakage in `list_tags` and `search_by_tag` fell from 1 to 0 while valid tag list and search recall stayed at 1.000. |
 | [Tag Validity Quality](tag-validity-quality.md) | retrieval quality | shipped | Numeric-only frontmatter tag leakage in `list_tags` and `search_by_tag` fell from 1 to 0 while valid tag list and search recall stayed at 1.000. |
 | [Frontmatter Key Quality](frontmatter-key-quality.md) | retrieval quality | shipped | `search_by_frontmatter` recall across `status` / `Status` / `STATUS` key variants rose from 0.333 to 1.000, with zero wrong-key matches and zero duplicate paths. |

--- a/docs/rnd/tag-leading-number-quality.md
+++ b/docs/rnd/tag-leading-number-quality.md
@@ -1,0 +1,81 @@
+# Tag Leading Number Quality
+
+_Status: shipped_
+_Started: 2026-06-07 - Decided: 2026-06-07_
+
+## Hypothesis
+
+Obsidian tags can include numbers and only require at least one non-numerical
+character, but inline extraction and `rename_tag` validation rejected tag names
+that started with a digit. Allowing numeric-leading tags such as `#1a` and
+`#2026-goals` should improve inline tag recall and rename coverage without
+letting numeric-only tags such as `#1984` into tag results.
+
+Official sources:
+
+- https://obsidian.md/help/tags
+- https://obsidian.md/help/properties
+
+## Fixture
+
+Bench command:
+
+```powershell
+npm run build
+node scripts\bench-tag-leading-number-quality.mjs --json
+```
+
+The fixture creates a temporary five-note vault and calls `list_tags` and
+`search_by_tag` through a real stdio MCP client.
+
+Relevant notes:
+
+- `one-a.md` contains inline `#1a`
+- `year-goals.md` contains inline `#2026-goals`
+- `numeric-only.md` contains inline `#1984`
+- `numeric-nested-only.md` contains inline `#1984/2020`
+- `ordinary.md` contains inline `#a1`
+
+## Metric
+
+Primary metric: recall for valid numeric-leading inline tags.
+
+Ship bar: `numericLeadingTagListRecall` at 1.000,
+`numericLeadingSearchRecall` at 1.000, zero numeric-only listing/search leakage,
+and ordinary inline tag search recall still 1.000.
+
+| | before | after |
+|---|---:|---:|
+| numeric-leading tag list recall | 0.000 | 1.000 |
+| numeric-leading search recall | 0.000 | 1.000 |
+| invalid numeric-only tags listed | 0 | 0 |
+| invalid numeric-only search matches | 0 | 0 |
+| ordinary search recall | 1.000 | 1.000 |
+
+## Safety review
+
+Data accessed: synthetic markdown notes generated in a temporary vault by
+`scripts/bench-tag-leading-number-quality.mjs`. No real vault content, secrets,
+network calls, or embedding providers are used.
+
+Writes performed: temporary fixture vault creation and deletion only.
+
+Logs emitted: normal stdio server startup logging with the temporary vault path
+redacted by the shared logger sanitizer.
+
+Rollback path: restore the old inline tag head character class and old
+`rename_tag` validation, then keep the benchmark as a stopped experiment.
+
+## Kill criterion
+
+Stop if allowing numeric-leading tags admits numeric-only tags, changes ATX
+heading handling, changes inline-code/fenced-code exclusions, breaks nested
+matching, or weakens `rename_tag` validation for leading hash, leading slash, or
+whitespace-bearing names.
+
+## Decision
+
+Shipped. Inline tag parsing and `rename_tag` validation now accept
+numeric-leading tags when the name contains at least one non-numerical character.
+The benchmark raised numeric-leading list/search recall from 0.000 to 1.000
+while numeric-only leakage stayed at zero.

--- a/scripts/bench-tag-leading-number-quality.mjs
+++ b/scripts/bench-tag-leading-number-quality.mjs
@@ -1,0 +1,142 @@
+// Tag leading-number quality benchmark: exercise numeric-leading inline tags
+// through a real stdio MCP client.
+//
+// Direct use: node scripts/bench-tag-leading-number-quality.mjs [--json]
+// Run after `npm run build`.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const entry = join(root, "build", "index.js");
+
+function writeNote(vault, name, lines) {
+  writeFileSync(join(vault, name), `${lines.join("\n")}\n`);
+}
+
+function makeVault() {
+  const dir = mkdtempSync(join(tmpdir(), "ompro-tag-leading-number-"));
+  mkdirSync(join(dir, ".obsidian"));
+  writeNote(dir, "one-a.md", [
+    "Inline valid numeric-leading #1a tag.",
+  ]);
+  writeNote(dir, "year-goals.md", [
+    "Inline valid numeric-leading #2026-goals tag.",
+  ]);
+  writeNote(dir, "numeric-only.md", [
+    "Inline numeric-only #1984 should not become a tag.",
+  ]);
+  writeNote(dir, "numeric-nested-only.md", [
+    "Inline numeric-only nested #1984/2020 should not become a tag.",
+  ]);
+  writeNote(dir, "ordinary.md", [
+    "Ordinary inline #a1 tag should remain searchable.",
+  ]);
+  return dir;
+}
+
+function textOf(result) {
+  return result.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
+}
+
+function containsPath(text, notePath) {
+  return text.includes(notePath);
+}
+
+function containsTag(text, tag) {
+  return new RegExp(`(^|\\n)#${tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s+\\(`).test(text);
+}
+
+async function callText(client, name, args) {
+  return textOf(await client.callTool({ name, arguments: args }));
+}
+
+async function measure(vault) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [entry],
+    cwd: root,
+    env: { ...process.env, OBSIDIAN_VAULT_PATH: vault },
+  });
+  const client = new Client({ name: "tag-leading-number-bench", version: "1.0.0" });
+  await client.connect(transport);
+  try {
+    const listTags = await callText(client, "list_tags", { sortBy: "name" });
+    const searchOneA = await callText(client, "search_by_tag", {
+      tag: "1a",
+      includeContent: false,
+      maxResults: 10,
+    });
+    const searchYearGoals = await callText(client, "search_by_tag", {
+      tag: "2026-goals",
+      includeContent: false,
+      maxResults: 10,
+    });
+    const searchNumericOnly = await callText(client, "search_by_tag", {
+      tag: "1984",
+      includeContent: false,
+      maxResults: 10,
+    });
+    const searchOrdinary = await callText(client, "search_by_tag", {
+      tag: "a1",
+      includeContent: false,
+      maxResults: 10,
+    });
+
+    const numericLeadingListed = ["1a", "2026-goals"].filter((tag) =>
+      containsTag(listTags, tag),
+    ).length;
+    const numericLeadingSearches = [
+      containsPath(searchOneA, "one-a.md"),
+      containsPath(searchYearGoals, "year-goals.md"),
+    ];
+
+    return {
+      numericLeadingTagListRecall: numericLeadingListed / 2,
+      numericLeadingSearchRecall: numericLeadingSearches.filter(Boolean).length / numericLeadingSearches.length,
+      invalidNumericOnlyTagsListed: containsTag(listTags, "1984") || containsTag(listTags, "1984/2020") ? 1 : 0,
+      invalidNumericOnlySearchMatches: containsPath(searchNumericOnly, "numeric-only.md")
+        || containsPath(searchNumericOnly, "numeric-nested-only.md")
+        ? 1
+        : 0,
+      ordinarySearchRecall: containsPath(searchOrdinary, "ordinary.md") ? 1 : 0,
+    };
+  } finally {
+    await client.close();
+  }
+}
+
+export async function runTagLeadingNumberQualityBench() {
+  const vault = makeVault();
+  try {
+    return await measure(vault);
+  } finally {
+    rmSync(vault, { recursive: true, force: true });
+  }
+}
+
+const invokedDirectly = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (invokedDirectly) {
+  if (!existsSync(entry)) {
+    console.error("build/index.js missing - run `npm run build` first.");
+    process.exit(1);
+  }
+  const asJson = process.argv.slice(2).includes("--json");
+  const metrics = await runTagLeadingNumberQualityBench();
+  if (asJson) {
+    console.log(JSON.stringify(metrics));
+  } else {
+    console.log("| metric | value |");
+    console.log("|---|---:|");
+    for (const [name, value] of Object.entries(metrics)) {
+      console.log(`| ${name} | ${value} |`);
+    }
+  }
+}

--- a/src/__tests__/handlers/tags.test.ts
+++ b/src/__tests__/handlers/tags.test.ts
@@ -177,6 +177,33 @@ describe("tag handlers — search_by_tag", () => {
     expect(textContent(withoutHash)).toContain("note-a.md");
   });
 
+  it("finds numeric-leading inline tags with non-numeric characters", async () => {
+    await env.client.callTool({
+      name: "create_note",
+      arguments: {
+        path: "numeric-leading-inline.md",
+        content: "#1a #2026-goals #1984 #1984/2020",
+      },
+    });
+
+    const oneA = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "1a" },
+    });
+    const yearGoals = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "2026-goals" },
+    });
+    const numericOnly = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "1984" },
+    });
+
+    expect(textContent(oneA)).toContain("numeric-leading-inline.md");
+    expect(textContent(yearGoals)).toContain("numeric-leading-inline.md");
+    expect(textContent(numericOnly)).toMatch(/No notes found/i);
+  });
+
   it("matches nested child tags when querying the parent", async () => {
     // note-d.md has #nested/archive — searching for `nested` should find it.
     const result = await env.client.callTool({
@@ -293,6 +320,30 @@ describe("tag handlers — rename_tag", () => {
     });
     expect(textContent(search)).toContain("note-a.md");
     expect(textContent(search)).toContain("note-b.md");
+  });
+
+  it("rewrites numeric-leading tags with non-numeric characters", async () => {
+    await env.client.callTool({
+      name: "create_note",
+      arguments: {
+        path: "numeric-leading-rename.md",
+        content: "#1a",
+        frontmatter: JSON.stringify({ tags: ["1a"] }),
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "rename_tag",
+      arguments: { oldName: "1a", newName: "2026-goals", confirmTag: "2026-goals" },
+    });
+    expect(isError(result)).toBe(false);
+    expect(textContent(result)).toMatch(/Rewrote #1a/);
+
+    const search = await env.client.callTool({
+      name: "search_by_tag",
+      arguments: { tag: "2026-goals" },
+    });
+    expect(textContent(search)).toContain("numeric-leading-rename.md");
   });
 
   it("dryRun reports counts without writing", async () => {

--- a/src/__tests__/markdown.test.ts
+++ b/src/__tests__/markdown.test.ts
@@ -316,6 +316,15 @@ describe("extractTags", () => {
     expect(tags).toContain("project/alpha");
   });
 
+  it("should extract numeric-leading inline tags with non-numeric characters", () => {
+    const tags = extractTags("#1a #2026-goals #1984 #1984/2020 #a1");
+    expect(tags).toContain("1a");
+    expect(tags).toContain("2026-goals");
+    expect(tags).toContain("a1");
+    expect(tags).not.toContain("1984");
+    expect(tags).not.toContain("1984/2020");
+  });
+
   it("should extract tags from frontmatter tags array", () => {
     const content = `---
 tags:

--- a/src/__tests__/tag-rewriter.test.ts
+++ b/src/__tests__/tag-rewriter.test.ts
@@ -3,6 +3,7 @@ import {
   rewriteInlineTags,
   rewriteFrontmatterTags,
   rewriteAllTags,
+  isValidTagName,
 } from "../lib/tag-rewriter.js";
 
 const opts = (oldName: string, newName: string, hierarchical = true) => ({
@@ -23,6 +24,13 @@ describe("rewriteInlineTags", () => {
     const input = "x #project/alpha y";
     const { body, count } = rewriteInlineTags(input, opts("project", "client"));
     expect(body).toBe("x #client/alpha y");
+    expect(count).toBe(1);
+  });
+
+  it("renames numeric-leading inline tags with non-numeric characters", () => {
+    const input = "#1a #2026-goals #1984 #1984/2020";
+    const { body, count } = rewriteInlineTags(input, opts("1a", "2026-goals"));
+    expect(body).toBe("#2026-goals #2026-goals #1984 #1984/2020");
     expect(count).toBe(1);
   });
 
@@ -53,6 +61,15 @@ describe("rewriteInlineTags", () => {
     const { body, count } = rewriteInlineTags(input, opts("project", "client"));
     expect(body).toBe("outside #client, inside `#project` text\n");
     expect(count).toBe(1);
+  });
+});
+
+describe("isValidTagName", () => {
+  it("allows numeric-leading names only when they include a non-numeric character", () => {
+    expect(isValidTagName("1a")).toBe(true);
+    expect(isValidTagName("2026-goals")).toBe(true);
+    expect(isValidTagName("1984")).toBe(false);
+    expect(isValidTagName("1984/2020")).toBe(false);
   });
 });
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -652,7 +652,7 @@ export function extractTags(content: string): string[] {
   // Extract inline tags from body
   const lines = body.split("\n");
   const isInsideCodeBlock = createCodeBlockTracker();
-  const tagRegex = /(?:^|\s)#([a-zA-Z\u00C0-\u024F\u0400-\u04FF\u4E00-\u9FFF\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF_][a-zA-Z0-9\u00C0-\u024F\u0400-\u04FF\u4E00-\u9FFF\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF_/-]*)/g;
+  const tagRegex = /(?:^|\s)#([a-zA-Z0-9\u00C0-\u024F\u0400-\u04FF\u4E00-\u9FFF\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF_][a-zA-Z0-9\u00C0-\u024F\u0400-\u04FF\u4E00-\u9FFF\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF_/-]*)/g;
 
   for (const line of lines) {
     if (isInsideCodeBlock(line)) continue;
@@ -665,7 +665,8 @@ export function extractTags(content: string): string[] {
     tagRegex.lastIndex = 0;
 
     while ((match = tagRegex.exec(cleaned)) !== null) {
-      tagSet.add(match[1]!);
+      const tag = normalizeFrontmatterTag(match[1]!);
+      if (tag) tagSet.add(tag);
     }
   }
 

--- a/src/lib/tag-rewriter.ts
+++ b/src/lib/tag-rewriter.ts
@@ -19,11 +19,11 @@ import {
 // renames the parser wouldn't see. Anchored to start-of-line or whitespace
 // so `#anchor` inside a heading isn't matched as a tag.
 const TAG_CHAR = "[a-zA-Z0-9\\u00C0-\\u024F\\u0400-\\u04FF\\u4E00-\\u9FFF\\u3040-\\u309F\\u30A0-\\u30FF\\uAC00-\\uD7AF_/-]";
-const TAG_HEAD = "[a-zA-Z\\u00C0-\\u024F\\u0400-\\u04FF\\u4E00-\\u9FFF\\u3040-\\u309F\\u30A0-\\u30FF\\uAC00-\\uD7AF_]";
+const TAG_HEAD = "[a-zA-Z0-9\\u00C0-\\u024F\\u0400-\\u04FF\\u4E00-\\u9FFF\\u3040-\\u309F\\u30A0-\\u30FF\\uAC00-\\uD7AF_]";
 const TAG_NAME_RE = new RegExp(`^${TAG_HEAD}${TAG_CHAR}*$`);
 
 export function isValidTagName(name: string): boolean {
-  return TAG_NAME_RE.test(name);
+  return TAG_NAME_RE.test(name) && /[^\d/]/u.test(name);
 }
 
 interface FenceState {
@@ -147,6 +147,7 @@ export function rewriteInlineTags(
       const tagStart = m.index + leading.length;
       // Skip if the `#` (one byte before tag start) is inside inline code.
       if (mask[tagStart] || mask[m.index]) continue;
+      if (!isValidTagName(matchedTag)) continue;
       const renamed = applyRename(matchedTag, opts);
       if (renamed === null) continue;
       result += line.slice(cursor, tagStart);


### PR DESCRIPTION
Inline tag extraction and `rename_tag` validation now accept numeric-leading tags such as `#1a` and `#2026-goals`, while numeric-only tags such as `#1984` remain ignored. This matches Obsidian's tag format docs and keeps frontmatter, search, and rename behavior aligned.

Docs: https://obsidian.md/help/tags and https://obsidian.md/help/properties

Risk: low; this widens accepted tag names for existing tools without changing schemas or return shapes. Numeric-only tags remain invalid, and heading/code exclusions are still covered.

Score: 8 = correctness 4 x reach 4 / effort 2.

Tested: `npm test -- src/__tests__/markdown.test.ts src/__tests__/tag-rewriter.test.ts src/__tests__/handlers/tags.test.ts src/__tests__/regression-tools-tags.test.ts`; `npm run build`; `node scripts/bench-tag-leading-number-quality.mjs --json`; `npm run verify`.