### PR TITLE
fix: validate install config shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The `install` command now rejects existing client config files whose JSON root or `mcpServers` field is not an object, instead of crashing or reporting success without writing the server entry.
+
 ## [4.0.0] - 2026-06-07
 
 ### Migration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-mcp-pro",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-mcp-pro",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-mcp-pro",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "The most feature-complete MCP server for Obsidian vaults — search, read, write, tag, link analysis, graph traversal, canvas support, and more.",
   "type": "module",
   "bin": {

--- a/src/__tests__/regression-cli-install.test.ts
+++ b/src/__tests__/regression-cli-install.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
 import { parseArgs } from "../index.js";
 import { runInstall } from "../install.js";
 
@@ -100,5 +103,68 @@ describe("runInstall serverName sanitization (H2)", () => {
         serverName: "\x1b[31mfake-server\x1b[0m",
       }),
     ).toThrow(/control characters/i);
+  });
+});
+
+describe("runInstall config shape validation", () => {
+  let tmpDir: string;
+  let configPath: string;
+  let originalAppData: string | undefined;
+  let originalXdgConfigHome: string | undefined;
+  let originalHome: string | undefined;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "install-config-test-"));
+    originalAppData = process.env.APPDATA;
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    originalHome = process.env.HOME;
+
+    if (process.platform === "win32") {
+      process.env.APPDATA = tmpDir;
+      configPath = path.join(tmpDir, "Claude", "claude_desktop_config.json");
+    } else if (process.platform === "darwin") {
+      process.env.HOME = tmpDir;
+      configPath = path.join(tmpDir, "Library", "Application Support", "Claude", "claude_desktop_config.json");
+    } else {
+      process.env.XDG_CONFIG_HOME = tmpDir;
+      configPath = path.join(tmpDir, "Claude", "claude_desktop_config.json");
+    }
+
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    if (originalAppData === undefined) delete process.env.APPDATA;
+    else process.env.APPDATA = originalAppData;
+    if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeExistingConfig(content: string): Promise<void> {
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(configPath, content, "utf-8");
+  }
+
+  it("rejects a non-object config root before writing", async () => {
+    await writeExistingConfig("[]");
+
+    expect(() => runInstall({ client: "claude" })).toThrow(/must be a JSON object/i);
+    await expect(fs.readFile(configPath, "utf-8")).resolves.toBe("[]");
+  });
+
+  it("rejects a non-object mcpServers value before reporting success", async () => {
+    const existing = JSON.stringify({ mcpServers: [] });
+    await writeExistingConfig(existing);
+
+    expect(() => runInstall({ client: "claude" })).toThrow(/mcpServers.*JSON object/i);
+    await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(existing);
   });
 });

--- a/src/install.ts
+++ b/src/install.ts
@@ -16,6 +16,10 @@ interface McpConfigFile {
   [key: string]: unknown;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 function claudeDesktopConfigPath(): string {
   const platform = os.platform();
   if (platform === "darwin") {
@@ -46,16 +50,24 @@ function getConfigPath(client: InstallClient): string {
 
 function readConfig(configPath: string): McpConfigFile {
   if (!fs.existsSync(configPath)) return {};
+  let parsed: unknown;
   try {
     const raw = fs.readFileSync(configPath, "utf-8");
     if (!raw.trim()) return {};
-    return JSON.parse(raw) as McpConfigFile;
+    parsed = JSON.parse(raw);
   } catch (err) {
     throw new Error(
       `Existing config at ${configPath} is not valid JSON. Fix or delete it before re-running install. (${sanitizeError(err)})`,
       { cause: err },
     );
   }
+  if (!isPlainObject(parsed)) {
+    throw new Error(`Existing config at ${configPath} must be a JSON object. Fix or delete it before re-running install.`);
+  }
+  if (parsed.mcpServers !== undefined && parsed.mcpServers !== null && !isPlainObject(parsed.mcpServers)) {
+    throw new Error(`Existing config at ${configPath} has invalid mcpServers; expected a JSON object.`);
+  }
+  return parsed;
 }
 
 function backupConfig(configPath: string): string | null {


### PR DESCRIPTION
Validates the existing client config root and mcpServers shape before the installer mutates it. Malformed configs now fail before backup/write, rather than crashing or reporting success without serializing the server entry.

Risk: low; this only changes malformed existing config handling. Score: 3 x 2 / 1 = 6; install config writes are a release-engineering path, but the affected users are limited to malformed client configs.

Tested: npm test -- src/__tests__/regression-cli-install.test.ts; npm run lint; npm run typecheck; npm run verify.

Release: package metadata is at 4.0.1 for the next patch batch; do not publish today because 4.0.0 already shipped on 2026-06-07.