### PR TITLE
fix: cap global Obsidian config reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Global Obsidian config auto-detection now ignores non-file or oversized `obsidian.json` files before parsing, preventing startup from spending unbounded memory on malformed local config data.
 - The `install` command now rejects existing client config files whose JSON root or `mcpServers` field is not an object, instead of crashing or reporting success without writing the server entry.
 
 ## [4.0.0] - 2026-06-07

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,23 +1,92 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
-import { getDailyNoteConfig } from "../config.js";
+import { getDailyNoteConfig, getVaultConfig } from "../config.js";
 
 let vaultDir: string;
+let configRoot: string;
+let originalEnv: NodeJS.ProcessEnv;
 
 beforeEach(async () => {
+  originalEnv = { ...process.env };
   vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "config-test-"));
+  configRoot = await fs.mkdtemp(path.join(os.tmpdir(), "obsidian-config-test-"));
   await fs.mkdir(path.join(vaultDir, ".obsidian"), { recursive: true });
+  delete process.env.OBSIDIAN_VAULT_NAME;
+  delete process.env.OBSIDIAN_VAULT_PATH;
+  process.env.APPDATA = configRoot;
+  process.env.HOME = configRoot;
+  process.env.XDG_CONFIG_HOME = configRoot;
+  vi.spyOn(os, "homedir").mockReturnValue(configRoot);
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await fs.rm(vaultDir, { recursive: true, force: true });
+  await fs.rm(configRoot, { recursive: true, force: true });
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
 });
 
 async function writeDailyConfig(content: string): Promise<void> {
   await fs.writeFile(path.join(vaultDir, ".obsidian", "daily-notes.json"), content, "utf-8");
 }
+
+function getTestObsidianConfigPath(): string {
+  const platform = os.platform();
+  if (platform === "win32") {
+    return path.join(configRoot, "obsidian", "obsidian.json");
+  }
+  if (platform === "darwin") {
+    return path.join(
+      configRoot,
+      "Library",
+      "Application Support",
+      "obsidian",
+      "obsidian.json"
+    );
+  }
+  return path.join(configRoot, "obsidian", "obsidian.json");
+}
+
+async function writeObsidianConfig(content: string): Promise<void> {
+  const configPath = getTestObsidianConfigPath();
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, content, "utf-8");
+}
+
+describe("getVaultConfig", () => {
+  it("auto-detects a valid vault from a bounded Obsidian config", async () => {
+    await writeObsidianConfig(JSON.stringify({
+      vaults: {
+        primary: {
+          path: vaultDir,
+        },
+      },
+    }));
+
+    expect(getVaultConfig()).toEqual({
+      vaultPath: path.resolve(vaultDir),
+      configPath: path.join(path.resolve(vaultDir), ".obsidian"),
+    });
+  });
+
+  it("ignores oversized Obsidian configs instead of auto-selecting a vault", async () => {
+    await writeObsidianConfig(JSON.stringify({
+      vaults: {
+        primary: {
+          path: vaultDir,
+        },
+      },
+      filler: "x".repeat(2 * 1024 * 1024),
+    }));
+
+    expect(() => getVaultConfig()).toThrow(/Unable to find an Obsidian vault/);
+  });
+});
 
 describe("getDailyNoteConfig", () => {
   it("uses defaults when daily-notes.json exceeds the size cap", async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import { log } from "./lib/logger.js";
 import { openVaultInternalFileForRead } from "./lib/vault.js";
 
 const DAILY_NOTES_CONFIG_REL_PATH = ".obsidian/daily-notes.json";
+const MAX_OBSIDIAN_CONFIG_BYTES = 1024 * 1024;
 const MAX_DAILY_NOTES_CONFIG_BYTES = 64 * 1024;
 const MAX_DAILY_NOTES_CONFIG_FIELD_CHARS = 500;
 
@@ -115,6 +116,25 @@ function resolveVaultFromObsidianConfig(): string | null {
 
   if (!fs.existsSync(configPath)) {
     log.warn("Obsidian config not found", { configPath });
+    return null;
+  }
+
+  try {
+    const stats = fs.statSync(configPath);
+    if (!stats.isFile()) {
+      log.warn("Obsidian config path is not a regular file", { configPath });
+      return null;
+    }
+    if (stats.size > MAX_OBSIDIAN_CONFIG_BYTES) {
+      log.warn("Obsidian config exceeds size cap; ignoring", {
+        configPath,
+        bytes: stats.size,
+        max: MAX_OBSIDIAN_CONFIG_BYTES,
+      });
+      return null;
+    }
+  } catch (err) {
+    log.warn("Failed to inspect Obsidian config", { configPath, err: err as Error });
     return null;
   }
 


### PR DESCRIPTION
Caps global Obsidian config reads before parsing, and rejects config paths that are not regular files. This keeps startup from accepting or spending unbounded memory on malformed local `obsidian.json` data while preserving normal vault auto-detection.

Risk: low; only auto-detection fallback behavior changes for invalid oversized or non-file global config paths.

Score: safety/correctness, 3 severity x 3 reach / 1 effort = 9.

Tests: npm test -- src/__tests__/config.test.ts; npm run lint; npm run typecheck; npm run verify.