### PR TITLE
fix: require exact HTTP JSON media type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- HTTP transport now requires the actual `application/json` media type for MCP POST bodies instead of accepting `Content-Type` values that only mention it in parameters.
 - Global Obsidian config auto-detection now ignores non-file or oversized `obsidian.json` files before parsing, preventing startup from spending unbounded memory on malformed local config data.
 - The `install` command now rejects existing client config files whose JSON root or `mcpServers` field is not an object, instead of crashing or reporting success without writing the server entry.
 

--- a/src/__tests__/regression-http-fixes.test.ts
+++ b/src/__tests__/regression-http-fixes.test.ts
@@ -319,6 +319,23 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
     expect(res.status).toBe(415);
   });
 
+  it("rejects media types that only mention application/json in parameters", async () => {
+    const handle = await startOnEphemeral();
+    handles.push(handle);
+
+    const res = await rawRequest(handle.port, {
+      method: "POST",
+      path: "/mcp",
+      headers: {
+        ...AUTH_HEADERS,
+        "Content-Type": "text/plain; profile=application/json",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+    });
+
+    expect(res.status).toBe(415);
+  });
+
   it("still accepts application/json with charset suffix", async () => {
     const handle = await startOnEphemeral();
     handles.push(handle);

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -62,6 +62,12 @@ function declaredBodyTooLarge(req: IncomingMessage): boolean {
   return BigInt(contentLength) > BigInt(MAX_BODY_BYTES);
 }
 
+function isJsonContentType(contentType: string | string[] | undefined): boolean {
+  if (typeof contentType !== "string") return false;
+  const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
+  return mediaType === "application/json";
+}
+
 function readBody(req: IncomingMessage): Promise<unknown> {
   return new Promise((resolve, reject) => {
     let size = 0;
@@ -423,8 +429,7 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
         // non-JSON data just to produce a parse error, and gives clients
         // a clearer 415 ("the server understands the request method but
         // the media type is unsupported") than a generic 400.
-        const contentType = req.headers["content-type"] ?? "";
-        if (!contentType.toLowerCase().includes("application/json")) {
+        if (!isJsonContentType(req.headers["content-type"])) {
           sendJson(res, 415, { error: "Unsupported Media Type: expected application/json" });
           return;
         }


### PR DESCRIPTION
Tightens the HTTP transport POST body gate so it accepts `application/json` plus normal parameters, but rejects other media types that only mention `application/json` in a parameter value. This keeps malformed authenticated POSTs on the intended 415 path before MCP handling.

Risk: low; valid `application/json` and `application/json; charset=utf-8` requests still pass.

Score: safety/correctness, 2 severity x 3 reach / 1 effort = 6.

Tests: npm test -- src/__tests__/regression-http-fixes.test.ts; npm run lint; npm run typecheck; npm run verify.