### PR TITLE
fix embedding URL base validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Embedding provider base URLs now reject embedded credentials, query strings, and fragments before provider setup, without echoing the rejected URL.
 - HTTP transport now requires the actual `application/json` media type for MCP POST bodies instead of accepting `Content-Type` values that only mention it in parameters.
 - Global Obsidian config auto-detection now ignores non-file or oversized `obsidian.json` files before parsing, preventing startup from spending unbounded memory on malformed local config data.
 - The `install` command now rejects existing client config files whose JSON root or `mcpServers` field is not an object, instead of crashing or reporting success without writing the server entry.

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ The semantic-search tools (`index_vault`, `search_semantic`, `find_similar_notes
 |---------|---------|-------|
 | `OBSIDIAN_EMBEDDING_PROVIDER` | `ollama` | `ollama`, `openai`, or `none` to disable. |
 | `OBSIDIAN_EMBEDDING_MODEL` | `nomic-embed-text` (Ollama), `text-embedding-3-small` (OpenAI) | Provider-specific model identifier. |
-| `OBSIDIAN_EMBEDDING_URL` | `http://localhost:11434` (Ollama), `https://api.openai.com/v1` (OpenAI) | Base URL. |
+| `OBSIDIAN_EMBEDDING_URL` | `http://localhost:11434` (Ollama), `https://api.openai.com/v1` (OpenAI) | Base URL without credentials, query strings, or fragments. |
 | `OBSIDIAN_EMBEDDING_API_KEY` | `OPENAI_API_KEY` falls back if unset | Required for hosted providers. |
 
 For local Ollama: install [Ollama](https://ollama.com/), then `ollama pull nomic-embed-text`. The semantic tools register even when no provider is configured, so they're discoverable; calls return a configuration hint until set up.

--- a/src/__tests__/regression-embedding-fixes.test.ts
+++ b/src/__tests__/regression-embedding-fixes.test.ts
@@ -302,6 +302,77 @@ describe("OBSIDIAN_CACHE_DISABLED covers embedding persistence", () => {
 
 // ─── M16: Ollama batch probe re-probes after transient failure ──────
 
+describe("embedding provider URL validation", () => {
+  beforeEach(() => {
+    resetProviderForTests();
+    process.env.OBSIDIAN_EMBEDDING_PROVIDER = "openai";
+    process.env.OBSIDIAN_EMBEDDING_MODEL = "text-embedding-3-small";
+    process.env.OBSIDIAN_EMBEDDING_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    setProviderForTests(null);
+    resetProviderForTests();
+    delete process.env.OBSIDIAN_EMBEDDING_PROVIDER;
+    delete process.env.OBSIDIAN_EMBEDDING_URL;
+    delete process.env.OBSIDIAN_EMBEDDING_MODEL;
+    delete process.env.OBSIDIAN_EMBEDDING_API_KEY;
+  });
+
+  it.each([
+    {
+      label: "credentials",
+      url: "https://user:pa55@example.internal/v1",
+      expected: /must not include credentials/i,
+      forbidden: ["user", "pa55", "example.internal"],
+    },
+    {
+      label: "query strings",
+      url: "https://api.example.internal/v1?token=secret",
+      expected: /must not include query strings or fragments/i,
+      forbidden: ["api.example.internal", "token=secret"],
+    },
+    {
+      label: "empty query delimiters",
+      url: "https://api.example.internal/v1?",
+      expected: /must not include query strings or fragments/i,
+      forbidden: ["api.example.internal", "?"],
+    },
+    {
+      label: "fragments",
+      url: "https://api.example.internal/v1#debug",
+      expected: /must not include query strings or fragments/i,
+      forbidden: ["api.example.internal", "#debug"],
+    },
+    {
+      label: "empty fragment delimiters",
+      url: "https://api.example.internal/v1#",
+      expected: /must not include query strings or fragments/i,
+      forbidden: ["api.example.internal", "#"],
+    },
+  ])("rejects embedding base URLs with $label without echoing the URL", ({ url, expected, forbidden }) => {
+    process.env.OBSIDIAN_EMBEDDING_URL = url;
+
+    let message = "";
+    try {
+      getActiveProvider();
+    } catch (err) {
+      message = (err as Error).message;
+    }
+
+    expect(message).toMatch(expected);
+    for (const value of forbidden) {
+      expect(message).not.toContain(value);
+    }
+  });
+
+  it("allows a clean https base URL with a path prefix", () => {
+    process.env.OBSIDIAN_EMBEDDING_URL = "https://api.example.internal/custom/v1";
+
+    expect(getActiveProvider()?.id).toBe("openai");
+  });
+});
+
 describe("OllamaProvider probe (M16)", () => {
   const originalFetch = globalThis.fetch;
 

--- a/src/lib/embedding-providers.ts
+++ b/src/lib/embedding-providers.ts
@@ -35,14 +35,15 @@ export interface EmbeddingProvider {
  *  past 30s is almost certainly a hung connection or a misconfigured URL. */
 const EMBED_REQUEST_TIMEOUT_MS = 30_000;
 
-/** SEC-3: Validate that an embedding URL uses an allowed scheme.
+/** SEC-3: Validate that an embedding URL uses an allowed scheme and base shape.
  *  Only https:// and http:// to loopback addresses are permitted.
  *  This prevents SSRF and API-key exfiltration if an attacker can
  *  influence the OBSIDIAN_EMBEDDING_URL environment variable. */
 function validateEmbeddingUrl(raw: string): string {
+  const value = raw.trim();
   let parsed: URL;
   try {
-    parsed = new URL(raw);
+    parsed = new URL(value);
   } catch {
     throw new Error(
       "OBSIDIAN_EMBEDDING_URL is not a valid URL. " +
@@ -65,7 +66,21 @@ function validateEmbeddingUrl(raw: string): string {
     );
   }
 
-  return raw;
+  if (parsed.username || parsed.password) {
+    throw new Error(
+      "OBSIDIAN_EMBEDDING_URL must not include credentials. " +
+        "Provide the provider base URL without embedded credentials.",
+    );
+  }
+
+  if (parsed.search || value.includes("?") || parsed.hash || value.includes("#")) {
+    throw new Error(
+      "OBSIDIAN_EMBEDDING_URL must not include query strings or fragments. " +
+        "Provide only the provider base URL.",
+    );
+  }
+
+  return value;
 }
 
 /** SEC-15: Validate that a model name looks reasonable.


### PR DESCRIPTION
Embedding provider setup now rejects clean-base violations on `OBSIDIAN_EMBEDDING_URL`: embedded credentials, query strings, and fragments no longer construct a provider, and the error text does not echo the rejected URL.

Risk: low; clean http(s) base URLs with path prefixes still work, and invalid schemes keep the existing message. Score: 3 severity x 2 reach / 1 effort = 6.

Tested: `npm run verify`.