### PR TITLE
fix semantic query vector validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `search_semantic` now validates live query vectors before scoring, so malformed embedding provider responses cannot produce `NaN` ranks or low-level cosine errors.
 - Embedding provider base URLs now reject embedded credentials, query strings, and fragments before provider setup, without echoing the rejected URL.
 - HTTP transport now requires the actual `application/json` media type for MCP POST bodies instead of accepting `Content-Type` values that only mention it in parameters.
 - Global Obsidian config auto-detection now ignores non-file or oversized `obsidian.json` files before parsing, preventing startup from spending unbounded memory on malformed local config data.

--- a/src/__tests__/handlers/semantic.test.ts
+++ b/src/__tests__/handlers/semantic.test.ts
@@ -216,6 +216,54 @@ describe("semantic handlers — search_semantic", () => {
     expect(textContent(result)).toMatch(/index_vault/i);
   });
 
+  it("rejects non-finite query vectors before scoring stored chunks", async () => {
+    await indexVault();
+    class BadQueryProvider implements EmbeddingProvider {
+      readonly id = "mock";
+      readonly model = "topic-counter";
+      embed(texts: string[]): Promise<number[][]> {
+        return Promise.resolve(texts.map(() => [Number.NaN, 0, 0, 0]));
+      }
+    }
+    setProviderForTests(new BadQueryProvider());
+
+    const result = await env.client.callTool({
+      name: "search_semantic",
+      arguments: { query: "cats", limit: 3 },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(true);
+    expect(text).toContain("Provider returned an invalid query vector");
+    expect(text).toContain("non-finite");
+    expect(text).not.toContain("NaN");
+    expect(text).not.toContain("cats.md");
+  });
+
+  it("rejects wrong-dimension query vectors before cosine scoring", async () => {
+    await indexVault();
+    class WrongDimensionProvider implements EmbeddingProvider {
+      readonly id = "mock";
+      readonly model = "topic-counter";
+      embed(texts: string[]): Promise<number[][]> {
+        return Promise.resolve(texts.map(() => [1, 0]));
+      }
+    }
+    setProviderForTests(new WrongDimensionProvider());
+
+    const result = await env.client.callTool({
+      name: "search_semantic",
+      arguments: { query: "cats", limit: 3 },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(true);
+    expect(text).toContain("Provider returned an invalid query vector");
+    expect(text).toContain("dimension mismatch");
+    expect(text).not.toContain("cosineSimilarity");
+    expect(text).not.toContain("cats.md");
+  });
+
   it("respects the folder filter", async () => {
     await indexVault();
     // Force the search to a folder that contains nothing.

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -132,7 +132,7 @@ function key(notePath: string, chunkIndex: number): string {
   return `${notePath}::${chunkIndex}`;
 }
 
-function validateVector(vector: unknown, expectedDimension: number | null): string | null {
+export function validateEmbeddingVector(vector: unknown, expectedDimension: number | null): string | null {
   if (!Array.isArray(vector) || vector.length === 0) return "vector must be a non-empty number array";
   for (const value of vector) {
     if (typeof value !== "number" || !Number.isFinite(value)) {
@@ -229,7 +229,7 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
       // Silently drop entries whose vector length doesn't match the snapshot's
       // declared dimension. Guards against hand-edited or partially-corrupted
       // snapshots where one row's length drifted from the rest.
-      if (validateVector(entry.vector, snapshot.dimension) !== null) continue;
+      if (validateEmbeddingVector(entry.vector, snapshot.dimension) !== null) continue;
       state.byKey.set(key(entry.notePath, entry.chunkIndex), entry);
       let owned = state.byNote.get(entry.notePath);
       if (!owned) {
@@ -387,7 +387,7 @@ export function setNoteChunks(
   const state = stateFor(vaultPath);
   let nextDimension = state.dimension;
   for (const ch of chunks) {
-    const error = validateVector(ch.vector, nextDimension);
+    const error = validateEmbeddingVector(ch.vector, nextDimension);
     if (error !== null) {
       throw new Error(`Invalid embedding vector at chunk ${ch.chunkIndex}: ${error}`);
     }

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -17,6 +17,7 @@ import {
   buildSimilarNotesQueryVector,
   snapshotForTests,
   invalidateIfIncompatible,
+  validateEmbeddingVector,
   type ChunkEmbedding,
   type SearchHit,
 } from "../lib/embedding-store.js";
@@ -477,6 +478,10 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         const [vector] = await provider.embed([query]);
         if (!Array.isArray(vector)) {
           return errorResult("Provider did not return a vector for the query.");
+        }
+        const vectorError = validateEmbeddingVector(vector, snap.dimension);
+        if (vectorError !== null) {
+          return errorResult(`Provider returned an invalid query vector: ${vectorError}.`);
         }
         const { hits } = await searchFreshEmbeddings(vaultPath, vector, {
           limit,


### PR DESCRIPTION
`search_semantic` now validates the provider's live query vector against the active index dimension before scoring. Malformed provider responses return a clear tool error instead of `NaN` ranks or a lower-level cosine mismatch.

Risk: low; stored vectors already used the same validation, and this only moves query-vector failures earlier. Score: 3 severity x 2 reach / 1 effort = 6.

Tested: `npm run verify`.