### PR TITLE
fix openai embedding key fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- OpenAI embedding setup now treats blank `OBSIDIAN_EMBEDDING_API_KEY` values as unset, falling back to `OPENAI_API_KEY` when present instead of sending a whitespace bearer token.
 - `search_semantic` now validates live query vectors before scoring, so malformed embedding provider responses cannot produce `NaN` ranks or low-level cosine errors.
 - Embedding provider base URLs now reject embedded credentials, query strings, and fragments before provider setup, without echoing the rejected URL.
 - HTTP transport now requires the actual `application/json` media type for MCP POST bodies instead of accepting `Content-Type` values that only mention it in parameters.

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ The semantic-search tools (`index_vault`, `search_semantic`, `find_similar_notes
 | `OBSIDIAN_EMBEDDING_PROVIDER` | `ollama` | `ollama`, `openai`, or `none` to disable. |
 | `OBSIDIAN_EMBEDDING_MODEL` | `nomic-embed-text` (Ollama), `text-embedding-3-small` (OpenAI) | Provider-specific model identifier. |
 | `OBSIDIAN_EMBEDDING_URL` | `http://localhost:11434` (Ollama), `https://api.openai.com/v1` (OpenAI) | Base URL without credentials, query strings, or fragments. |
-| `OBSIDIAN_EMBEDDING_API_KEY` | `OPENAI_API_KEY` falls back if unset | Required for hosted providers. |
+| `OBSIDIAN_EMBEDDING_API_KEY` | `OPENAI_API_KEY` falls back if unset or blank | Required for hosted providers. |
 
 For local Ollama: install [Ollama](https://ollama.com/), then `ollama pull nomic-embed-text`. The semantic tools register even when no provider is configured, so they're discoverable; calls return a configuration hint until set up.
 

--- a/src/__tests__/regression-embedding-fixes.test.ts
+++ b/src/__tests__/regression-embedding-fixes.test.ts
@@ -373,6 +373,52 @@ describe("embedding provider URL validation", () => {
   });
 });
 
+describe("OpenAI provider API key resolution", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    resetProviderForTests();
+    process.env.OBSIDIAN_EMBEDDING_PROVIDER = "openai";
+    process.env.OBSIDIAN_EMBEDDING_URL = "https://api.example.com/v1";
+    process.env.OBSIDIAN_EMBEDDING_MODEL = "text-embedding-3-small";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    setProviderForTests(null);
+    resetProviderForTests();
+    delete process.env.OBSIDIAN_EMBEDDING_PROVIDER;
+    delete process.env.OBSIDIAN_EMBEDDING_URL;
+    delete process.env.OBSIDIAN_EMBEDDING_MODEL;
+    delete process.env.OBSIDIAN_EMBEDDING_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it("falls back to OPENAI_API_KEY when the provider-specific key is blank", async () => {
+    process.env.OBSIDIAN_EMBEDDING_API_KEY = " \t ";
+    process.env.OPENAI_API_KEY = " fallback-key \n";
+    globalThis.fetch = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer fallback-key");
+      return new Response(JSON.stringify({ data: [{ index: 0, embedding: [1, 2, 3] }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const provider = getActiveProvider();
+    expect(provider?.id).toBe("openai");
+    await expect(provider!.embed(["hello"])).resolves.toEqual([[1, 2, 3]]);
+  });
+
+  it("treats whitespace-only OpenAI API keys as missing", () => {
+    process.env.OBSIDIAN_EMBEDDING_API_KEY = " ";
+    process.env.OPENAI_API_KEY = "\t";
+
+    expect(getActiveProvider()).toBeNull();
+  });
+});
+
 describe("OllamaProvider probe (M16)", () => {
   const originalFetch = globalThis.fetch;
 

--- a/src/lib/embedding-providers.ts
+++ b/src/lib/embedding-providers.ts
@@ -113,6 +113,14 @@ function validateModelName(name: string, context: string): string {
   return name;
 }
 
+function firstNonBlankEnvValue(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
 class OllamaProvider implements EmbeddingProvider {
   readonly id = "ollama";
   readonly model: string;
@@ -280,7 +288,10 @@ export function getActiveProvider(): EmbeddingProvider | null {
     return cachedProvider;
   }
   if (kind === "openai") {
-    const apiKey = process.env.OBSIDIAN_EMBEDDING_API_KEY ?? process.env.OPENAI_API_KEY;
+    const apiKey = firstNonBlankEnvValue(
+      process.env.OBSIDIAN_EMBEDDING_API_KEY,
+      process.env.OPENAI_API_KEY,
+    );
     if (!apiKey) {
       cachedProvider = null;
       return null;


### PR DESCRIPTION
OpenAI embedding setup now treats blank provider-specific API keys as unset, so `OPENAI_API_KEY` can be used as the documented fallback and whitespace is not sent as a bearer token.

Risk: low; configured nonblank keys keep taking precedence, and missing keys still disable the provider. Score: 2 severity x 2 reach / 1 effort = 4.

Tested: `npm run verify`.