### PR TITLE
fix embedding blank env defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - OpenAI embedding setup now treats blank `OBSIDIAN_EMBEDDING_API_KEY` values as unset, falling back to `OPENAI_API_KEY` when present instead of sending a whitespace bearer token.
+- Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - `search_semantic` now validates live query vectors before scoring, so malformed embedding provider responses cannot produce `NaN` ranks or low-level cosine errors.
 - Embedding provider base URLs now reject embedded credentials, query strings, and fragments before provider setup, without echoing the rejected URL.
 - HTTP transport now requires the actual `application/json` media type for MCP POST bodies instead of accepting `Content-Type` values that only mention it in parameters.

--- a/README.md
+++ b/README.md
@@ -328,9 +328,9 @@ The semantic-search tools (`index_vault`, `search_semantic`, `find_similar_notes
 
 | Env var | Default | Notes |
 |---------|---------|-------|
-| `OBSIDIAN_EMBEDDING_PROVIDER` | `ollama` | `ollama`, `openai`, or `none` to disable. |
-| `OBSIDIAN_EMBEDDING_MODEL` | `nomic-embed-text` (Ollama), `text-embedding-3-small` (OpenAI) | Provider-specific model identifier. |
-| `OBSIDIAN_EMBEDDING_URL` | `http://localhost:11434` (Ollama), `https://api.openai.com/v1` (OpenAI) | Base URL without credentials, query strings, or fragments. |
+| `OBSIDIAN_EMBEDDING_PROVIDER` | `ollama` if unset or blank | `ollama`, `openai`, or `none` to disable. |
+| `OBSIDIAN_EMBEDDING_MODEL` | `nomic-embed-text` (Ollama), `text-embedding-3-small` (OpenAI) if unset or blank | Provider-specific model identifier. |
+| `OBSIDIAN_EMBEDDING_URL` | `http://localhost:11434` (Ollama), `https://api.openai.com/v1` (OpenAI) if unset or blank | Base URL without credentials, query strings, or fragments. |
 | `OBSIDIAN_EMBEDDING_API_KEY` | `OPENAI_API_KEY` falls back if unset or blank | Required for hosted providers. |
 
 For local Ollama: install [Ollama](https://ollama.com/), then `ollama pull nomic-embed-text`. The semantic tools register even when no provider is configured, so they're discoverable; calls return a configuration hint until set up.

--- a/src/__tests__/regression-embedding-fixes.test.ts
+++ b/src/__tests__/regression-embedding-fixes.test.ts
@@ -419,6 +419,76 @@ describe("OpenAI provider API key resolution", () => {
   });
 });
 
+describe("embedding provider blank env defaults", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    resetProviderForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    setProviderForTests(null);
+    resetProviderForTests();
+    delete process.env.OBSIDIAN_EMBEDDING_PROVIDER;
+    delete process.env.OBSIDIAN_EMBEDDING_URL;
+    delete process.env.OBSIDIAN_EMBEDDING_MODEL;
+    delete process.env.OBSIDIAN_EMBEDDING_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it("uses default Ollama settings when provider, model, and URL env values are blank", async () => {
+    process.env.OBSIDIAN_EMBEDDING_PROVIDER = " \t ";
+    process.env.OBSIDIAN_EMBEDDING_MODEL = " \n ";
+    process.env.OBSIDIAN_EMBEDDING_URL = " ";
+    globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+      expect(String(input)).toBe("http://localhost:11434/api/embed");
+      const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string; input?: string[] };
+      expect(body.model).toBe("nomic-embed-text");
+      expect(body.input).toEqual(["hello"]);
+      return new Response(JSON.stringify({ embeddings: [[1, 2, 3]] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const provider = getActiveProvider();
+    expect(provider?.id).toBe("ollama");
+    expect(provider?.model).toBe("nomic-embed-text");
+    await expect(provider!.embed(["hello"])).resolves.toEqual([[1, 2, 3]]);
+  });
+
+  it("uses default OpenAI model and URL when optional env values are blank", async () => {
+    process.env.OBSIDIAN_EMBEDDING_PROVIDER = "openai";
+    process.env.OBSIDIAN_EMBEDDING_API_KEY = "test-key";
+    process.env.OBSIDIAN_EMBEDDING_MODEL = " ";
+    process.env.OBSIDIAN_EMBEDDING_URL = "\t";
+    globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+      expect(String(input)).toBe("https://api.openai.com/v1/embeddings");
+      const body = JSON.parse(String(init?.body ?? "{}")) as { model?: string; input?: string[] };
+      expect(body.model).toBe("text-embedding-3-small");
+      expect(body.input).toEqual(["hello"]);
+      return new Response(JSON.stringify({ data: [{ index: 0, embedding: [1, 2, 3] }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const provider = getActiveProvider();
+    expect(provider?.id).toBe("openai");
+    expect(provider?.model).toBe("text-embedding-3-small");
+    await expect(provider!.embed(["hello"])).resolves.toEqual([[1, 2, 3]]);
+  });
+
+  it("still treats explicit none/off/disabled providers as disabled", () => {
+    for (const value of ["none", " off ", "disabled"]) {
+      resetProviderForTests();
+      process.env.OBSIDIAN_EMBEDDING_PROVIDER = value;
+      expect(getActiveProvider()).toBeNull();
+    }
+  });
+});
+
 describe("OllamaProvider probe (M16)", () => {
   const originalFetch = globalThis.fetch;
 

--- a/src/lib/embedding-providers.ts
+++ b/src/lib/embedding-providers.ts
@@ -271,18 +271,18 @@ let cachedProvider: EmbeddingProvider | null | undefined;
  */
 export function getActiveProvider(): EmbeddingProvider | null {
   if (cachedProvider !== undefined) return cachedProvider;
-  const kind = (process.env.OBSIDIAN_EMBEDDING_PROVIDER ?? "ollama").toLowerCase().trim();
+  const kind = (firstNonBlankEnvValue(process.env.OBSIDIAN_EMBEDDING_PROVIDER) ?? "ollama").toLowerCase();
   if (kind === "" || kind === "none" || kind === "off" || kind === "disabled") {
     cachedProvider = null;
     return null;
   }
   if (kind === "ollama") {
     const model = validateModelName(
-      process.env.OBSIDIAN_EMBEDDING_MODEL ?? "nomic-embed-text",
+      firstNonBlankEnvValue(process.env.OBSIDIAN_EMBEDDING_MODEL) ?? "nomic-embed-text",
       "ollama",
     );
     const url = validateEmbeddingUrl(
-      process.env.OBSIDIAN_EMBEDDING_URL ?? "http://localhost:11434",
+      firstNonBlankEnvValue(process.env.OBSIDIAN_EMBEDDING_URL) ?? "http://localhost:11434",
     );
     cachedProvider = new OllamaProvider(model, url);
     return cachedProvider;
@@ -297,11 +297,11 @@ export function getActiveProvider(): EmbeddingProvider | null {
       return null;
     }
     const model = validateModelName(
-      process.env.OBSIDIAN_EMBEDDING_MODEL ?? "text-embedding-3-small",
+      firstNonBlankEnvValue(process.env.OBSIDIAN_EMBEDDING_MODEL) ?? "text-embedding-3-small",
       "openai",
     );
     const url = validateEmbeddingUrl(
-      process.env.OBSIDIAN_EMBEDDING_URL ?? "https://api.openai.com/v1",
+      firstNonBlankEnvValue(process.env.OBSIDIAN_EMBEDDING_URL) ?? "https://api.openai.com/v1",
     );
     cachedProvider = new OpenAIProvider(model, url, apiKey);
     return cachedProvider;


### PR DESCRIPTION
Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply when shells or dotenv files carry empty entries. Explicit `none`, `off`, and `disabled` still turn the provider off.

Risk: low; nonblank values keep their current behavior, and invalid nonblank model/URL values still fail validation. Score: 2 severity x 2 reach / 1 effort = 4.

Tested: `npm test -- --run src/__tests__/regression-embedding-fixes.test.ts`; `npm run verify`.