### PR TITLE
fix openai embedding row indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - OpenAI embedding setup now treats blank `OBSIDIAN_EMBEDDING_API_KEY` values as unset, falling back to `OPENAI_API_KEY` when present instead of sending a whitespace bearer token.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
+- OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.
 - `search_semantic` now validates live query vectors before scoring, so malformed embedding provider responses cannot produce `NaN` ranks or low-level cosine errors.
 - Embedding provider base URLs now reject embedded credentials, query strings, and fragments before provider setup, without echoing the rejected URL.
 - HTTP transport now requires the actual `application/json` media type for MCP POST bodies instead of accepting `Content-Type` values that only mention it in parameters.

--- a/src/__tests__/regression-embedding-fixes.test.ts
+++ b/src/__tests__/regression-embedding-fixes.test.ts
@@ -419,6 +419,63 @@ describe("OpenAI provider API key resolution", () => {
   });
 });
 
+describe("OpenAI provider response index validation", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    resetProviderForTests();
+    process.env.OBSIDIAN_EMBEDDING_PROVIDER = "openai";
+    process.env.OBSIDIAN_EMBEDDING_URL = "https://api.example.com/v1";
+    process.env.OBSIDIAN_EMBEDDING_MODEL = "text-embedding-3-small";
+    process.env.OBSIDIAN_EMBEDDING_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    setProviderForTests(null);
+    resetProviderForTests();
+    delete process.env.OBSIDIAN_EMBEDDING_PROVIDER;
+    delete process.env.OBSIDIAN_EMBEDDING_URL;
+    delete process.env.OBSIDIAN_EMBEDDING_MODEL;
+    delete process.env.OBSIDIAN_EMBEDDING_API_KEY;
+  });
+
+  it.each([
+    {
+      label: "duplicate indexes",
+      data: [
+        { index: 0, embedding: [1, 0, 0] },
+        { index: 0, embedding: [0, 1, 0] },
+      ],
+    },
+    {
+      label: "missing indexes",
+      data: [
+        { embedding: [1, 0, 0] },
+        { index: 1, embedding: [0, 1, 0] },
+      ],
+    },
+    {
+      label: "out-of-range indexes",
+      data: [
+        { index: 0, embedding: [1, 0, 0] },
+        { index: 2, embedding: [0, 1, 0] },
+      ],
+    },
+  ])("rejects OpenAI embedding responses with $label", async ({ data }) => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ data }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const provider = getActiveProvider();
+    expect(provider?.id).toBe("openai");
+    await expect(provider!.embed(["first", "second"])).rejects.toThrow(/row indexes/i);
+  });
+});
+
 describe("embedding provider blank env defaults", () => {
   const originalFetch = globalThis.fetch;
 

--- a/src/lib/embedding-providers.ts
+++ b/src/lib/embedding-providers.ts
@@ -250,14 +250,30 @@ class OpenAIProvider implements EmbeddingProvider {
     if (!Array.isArray(data.data) || data.data.length !== texts.length) {
       throw new Error("OpenAI embeddings returned an unexpected shape");
     }
-    // Sort by index to be safe — the API guarantees order, but let's not
-    // rely on it.
-    const sorted = data.data.slice().sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
-    return sorted.map((row, i) => {
-      if (!Array.isArray(row.embedding)) {
-        throw new Error(`OpenAI embeddings: missing vector at row ${i}`);
+    const vectors: Array<number[] | undefined> = Array.from({ length: texts.length }, () => undefined);
+    const seen = new Set<number>();
+    for (const [rowPosition, row] of data.data.entries()) {
+      const index = row.index;
+      if (
+        typeof index !== "number" ||
+        !Number.isInteger(index) ||
+        index < 0 ||
+        index >= texts.length ||
+        seen.has(index)
+      ) {
+        throw new Error("OpenAI embeddings returned invalid row indexes");
       }
-      return row.embedding;
+      if (!Array.isArray(row.embedding)) {
+        throw new Error(`OpenAI embeddings: missing vector at row ${rowPosition}`);
+      }
+      seen.add(index);
+      vectors[index] = row.embedding;
+    }
+    return vectors.map((vector) => {
+      if (!vector) {
+        throw new Error("OpenAI embeddings returned invalid row indexes");
+      }
+      return vector;
     });
   }
 }


### PR DESCRIPTION
OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input texts. This keeps malformed provider responses from silently corrupting semantic chunks.

Risk: low; valid OpenAI responses keep their existing order and invalid shapes already fail other validation paths. Score: 3 severity x 2 reach / 1 effort = 6.

Tested: `npm test -- --run src/__tests__/regression-embedding-fixes.test.ts`; `npm run verify`.