### PR TITLE
fix index_vault invalid vector handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI embedding setup now treats blank `OBSIDIAN_EMBEDDING_API_KEY` values as unset, falling back to `OPENAI_API_KEY` when present instead of sending a whitespace bearer token.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.
+- `index_vault` now records invalid live embedding vectors as failed notes instead of aborting the whole indexing pass.
 - `search_semantic` now validates live query vectors before scoring, so malformed embedding provider responses cannot produce `NaN` ranks or low-level cosine errors.
 - Embedding provider base URLs now reject embedded credentials, query strings, and fragments before provider setup, without echoing the rejected URL.
 - HTTP transport now requires the actual `application/json` media type for MCP POST bodies instead of accepting `Content-Type` values that only mention it in parameters.

--- a/src/__tests__/handlers/semantic.test.ts
+++ b/src/__tests__/handlers/semantic.test.ts
@@ -191,6 +191,55 @@ describe("semantic handlers — index_vault", () => {
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
     expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("index_vault failed notes");
   });
+
+  it("records invalid live provider vectors as failed notes without aborting the index", async () => {
+    class InvalidVectorProvider extends MockProvider {
+      override embed(texts: string[]): Promise<number[][]> {
+        return Promise.resolve(
+          texts.map((text) =>
+            text.toLowerCase().includes("cat") ? [Number.NaN, 0, 0, 0] : [1, 0, 0, 0],
+          ),
+        );
+      }
+    }
+    setProviderForTests(new InvalidVectorProvider());
+
+    const result = await indexVault();
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toMatch(/Notes embedded:\s+3/);
+    expect(text).toContain("Failures:        1");
+    expect(text).toContain("vector contains a non-finite value");
+    expect(text).not.toContain("NaN");
+  });
+
+  it("records vectors that mismatch the stored dimension as failed notes", async () => {
+    await indexVault();
+    await fs.writeFile(
+      path.join(env.vaultDir, "cats.md"),
+      "# Cats\n\nCats changed enough to require a fresh embedding.",
+      "utf-8",
+    );
+
+    class WrongDimensionProvider implements EmbeddingProvider {
+      readonly id = "mock";
+      readonly model = "topic-counter";
+      embed(texts: string[]): Promise<number[][]> {
+        return Promise.resolve(texts.map(() => [1, 0]));
+      }
+    }
+    setProviderForTests(new WrongDimensionProvider());
+
+    const result = await indexVault();
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toMatch(/Notes unchanged:\s+3/);
+    expect(text).toMatch(/Notes embedded:\s+0/);
+    expect(text).toContain("Failures:        1");
+    expect(text).toContain("dimension mismatch");
+  });
 });
 
 describe("semantic handlers — search_semantic", () => {

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -316,6 +316,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
         // Embed pending chunks in batches.
         const noteChunks = new Map<string, ChunkEmbedding[]>();
         const failedNotes = new Set<string>();
+        let expectedVectorDimension: number | null = null;
         for (let i = 0; i < pending.length; i += EMBED_BATCH_SIZE) {
           const batch = pending.slice(i, i + EMBED_BATCH_SIZE);
           let vectors: number[][];
@@ -337,6 +338,13 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
               failedNotes.add(item.notePath);
               continue;
             }
+            const vectorError = validateEmbeddingVector(vector, expectedVectorDimension);
+            if (vectorError !== null) {
+              stats.failed.push({ path: item.notePath, error: vectorError });
+              failedNotes.add(item.notePath);
+              continue;
+            }
+            expectedVectorDimension ??= vector.length;
             const list = noteChunks.get(item.notePath) ?? [];
             list.push({
               notePath: item.notePath,
@@ -373,7 +381,13 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
             }
             continue;
           }
-          setNoteChunks(vaultPath, notePath, contentHash, chunks, provider.id, provider.model);
+          try {
+            setNoteChunks(vaultPath, notePath, contentHash, chunks, provider.id, provider.model);
+          } catch (err) {
+            stats.failed.push({ path: notePath, error: (err as Error).message });
+            failedNotes.add(notePath);
+            continue;
+          }
           if (chunks.length > 0) stats.notesEmbedded++;
         }
 


### PR DESCRIPTION
`index_vault` now validates live provider vectors before collecting chunks and catches store-level vector validation per note. Invalid vectors become failed-note rows instead of aborting the whole indexing pass.

Risk: low; valid vectors still store the same way, and malformed vectors already failed before this change. Score: 3 severity x 2 reach / 2 effort = 3.

Tested: `npm test -- --run src/__tests__/handlers/semantic.test.ts`; `npm run verify`.