### PR TITLE
fix index_vault persisted chunk count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.
 - `index_vault` now records invalid live embedding vectors as failed notes instead of aborting the whole indexing pass.
+- `index_vault` now reports `Chunks embedded` from chunks persisted to the semantic index, not chunks staged before a failed note writeback.
 - `search_semantic` now validates live query vectors before scoring, so malformed embedding provider responses cannot produce `NaN` ranks or low-level cosine errors.
 - Embedding provider base URLs now reject embedded credentials, query strings, and fragments before provider setup, without echoing the rejected URL.
 - HTTP transport now requires the actual `application/json` media type for MCP POST bodies instead of accepting `Content-Type` values that only mention it in parameters.

--- a/src/__tests__/handlers/semantic.test.ts
+++ b/src/__tests__/handlers/semantic.test.ts
@@ -237,6 +237,7 @@ describe("semantic handlers — index_vault", () => {
     expect(isError(result)).toBe(false);
     expect(text).toMatch(/Notes unchanged:\s+3/);
     expect(text).toMatch(/Notes embedded:\s+0/);
+    expect(text).toMatch(/Chunks embedded:\s+0/);
     expect(text).toContain("Failures:        1");
     expect(text).toContain("dimension mismatch");
   });

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -360,7 +360,6 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
               vector,
             });
             noteChunks.set(item.notePath, list);
-            stats.chunksEmbedded++;
           }
           await reportProgress(
             Math.min(i + batch.length, pending.length),
@@ -388,6 +387,7 @@ export function registerSemanticTools(server: McpServer, vaultPath: string): voi
             failedNotes.add(notePath);
             continue;
           }
+          stats.chunksEmbedded += chunks.length;
           if (chunks.length > 0) stats.notesEmbedded++;
         }
 


### PR DESCRIPTION
index_vault now increments `Chunks embedded` only after a note's chunks are accepted by the embedding store, so failed writebacks no longer overstate the persisted semantic index.

Risk is low: this changes summary accounting for failed semantic-index notes without changing tool arguments, stored schema, or embedding behavior.

Score: 2 severity x 2 reach / 1 effort = 4.

Tested: `npm test -- --run src/__tests__/handlers/semantic.test.ts src/__tests__/regression-tools-semantic.test.ts`; `npm run verify`.