### PR TITLE
fix embedding snapshot entry validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - OpenAI embedding setup now treats blank `OBSIDIAN_EMBEDDING_API_KEY` values as unset, falling back to `OPENAI_API_KEY` when present instead of sending a whitespace bearer token.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
+- Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.
 - `index_vault` now records invalid live embedding vectors as failed notes instead of aborting the whole indexing pass.
 - `index_vault` now reports `Chunks embedded` from chunks persisted to the semantic index, not chunks staged before a failed note writeback.

--- a/src/__tests__/regression-embedding-fixes.test.ts
+++ b/src/__tests__/regression-embedding-fixes.test.ts
@@ -22,6 +22,8 @@ import {
 //          was deterministic per-PID so concurrent saves could collide.
 //   - #24 (LOW): loadStore accepted any vector; mismatched-dimension entries
 //          must be silently dropped to guard against hand-edited snapshots.
+//          Malformed dimensions and entry fields are also ignored before they
+//          reach search state.
 //   - M16: OllamaProvider probed batch with the full input, so a transient
 //          error retried the full batch every call instead of re-probing
 //          cheaply.
@@ -185,6 +187,68 @@ describe("snapshot dimension validation (finding #24)", () => {
     const allNotes = new Set(hits.map((h) => h.notePath));
     expect(allNotes.has("bad.md")).toBe(false);
     expect(noteIsCurrent(vaultDir, "bad.md", "h2")).toBe(false);
+  });
+
+  it("drops snapshot entries with malformed path, chunk, or text fields", async () => {
+    const file = path.join(vaultDir, ".obsidian", "cache", "mcp-pro-embeddings.json");
+    await fs.mkdir(path.dirname(file), { recursive: true });
+
+    const snapshot = {
+      version: 1,
+      vaultRoot: path.resolve(vaultDir),
+      providerId: "test",
+      model: "m",
+      dimension: 3,
+      noteHashes: { "good.md": "h1", "bad.md": "h2" },
+      embeddings: [
+        { notePath: "good.md", chunkIndex: 1, headingPath: [], text: "g", hash: "gh", vector: [1, 0, 0] },
+        { notePath: null, chunkIndex: 1, headingPath: [], text: "bad", hash: "bh", vector: [1, 0, 0] },
+        { notePath: "bad.md", chunkIndex: 0, headingPath: [], text: "bad", hash: "bh", vector: [1, 0, 0] },
+        { notePath: "bad.md", chunkIndex: 2, headingPath: [], text: 123, hash: "bh", vector: [1, 0, 0] },
+      ],
+    };
+    await fs.writeFile(file, JSON.stringify(snapshot), "utf-8");
+
+    await loadStore(vaultDir);
+
+    expect(snapshotForTests(vaultDir).totalChunks).toBe(1);
+    expect(() => searchEmbeddings(vaultDir, [1, 0, 0], { limit: 10, folder: "good.md" })).not.toThrow();
+    const hits = searchEmbeddings(vaultDir, [1, 0, 0], { limit: 10, folder: "good.md" });
+    expect(hits.map((h) => h.notePath)).toEqual(["good.md"]);
+    expect(noteIsCurrent(vaultDir, "bad.md", "h2")).toBe(false);
+  });
+
+  it("ignores snapshots with invalid dimension values", async () => {
+    const file = path.join(vaultDir, ".obsidian", "cache", "mcp-pro-embeddings.json");
+    await fs.mkdir(path.dirname(file), { recursive: true });
+
+    await fs.writeFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        vaultRoot: path.resolve(vaultDir),
+        providerId: "test",
+        model: "m",
+        dimension: -1,
+        noteHashes: {},
+        embeddings: [],
+      }),
+      "utf-8",
+    );
+
+    await loadStore(vaultDir);
+
+    expect(snapshotForTests(vaultDir).dimension).toBeNull();
+    expect(() =>
+      setNoteChunks(
+        vaultDir,
+        "fresh.md",
+        "h",
+        [{ notePath: "fresh.md", chunkIndex: 1, headingPath: [], text: "x", hash: "th", vector: [1, 0, 0] }],
+        "test",
+        "m",
+      ),
+    ).not.toThrow();
   });
 });
 

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -132,6 +132,25 @@ function key(notePath: string, chunkIndex: number): string {
   return `${notePath}::${chunkIndex}`;
 }
 
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) > 0;
+}
+
+function isSnapshotEntry(entry: unknown): entry is ChunkEmbedding {
+  if (!entry || typeof entry !== "object") return false;
+  const candidate = entry as Partial<ChunkEmbedding>;
+  return (
+    typeof candidate.notePath === "string" &&
+    candidate.notePath.length > 0 &&
+    isPositiveInteger(candidate.chunkIndex) &&
+    Array.isArray(candidate.headingPath) &&
+    candidate.headingPath.every((part): part is string => typeof part === "string") &&
+    typeof candidate.text === "string" &&
+    typeof candidate.hash === "string" &&
+    Array.isArray(candidate.vector)
+  );
+}
+
 export function validateEmbeddingVector(vector: unknown, expectedDimension: number | null): string | null {
   if (!Array.isArray(vector) || vector.length === 0) return "vector must be a non-empty number array";
   for (const value of vector) {
@@ -204,7 +223,7 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
       !Array.isArray(snapshot.embeddings) ||
       typeof snapshot.providerId !== "string" ||
       typeof snapshot.model !== "string" ||
-      typeof snapshot.dimension !== "number"
+      !isPositiveInteger(snapshot.dimension)
     ) {
       log.warn("embedding-store: snapshot has unexpected shape; ignoring");
       state.loaded = true;
@@ -225,7 +244,7 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
     state.model = snapshot.model;
     state.dimension = snapshot.dimension;
     for (const entry of snapshot.embeddings) {
-      if (!entry || !Array.isArray(entry.vector)) continue;
+      if (!isSnapshotEntry(entry)) continue;
       // Silently drop entries whose vector length doesn't match the snapshot's
       // declared dimension. Guards against hand-edited or partially-corrupted
       // snapshots where one row's length drifted from the rest.


### PR DESCRIPTION
Embedding snapshot loading now validates the persisted dimension and each entry's path, chunk index, heading path, text, hash, and vector shape before rehydrating the in-memory index. This keeps malformed local cache rows from reaching semantic search state or poisoning later re-indexing.

Risk is low: valid snapshots keep loading, malformed rows are ignored the same way mismatched vectors already were.

Score: 3 severity x 2 reach / 1 effort = 6.

Tested: `npm test -- --run src/__tests__/regression-embedding-fixes.test.ts`; `npm test -- --run src/__tests__/regression-embedding-fixes.test.ts src/__tests__/embedding-store.test.ts`; `npm run verify`.