### PR TITLE
fix permission allowlist dot segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - OpenAI embedding setup now treats blank `OBSIDIAN_EMBEDDING_API_KEY` values as unset, falling back to `OPENAI_API_KEY` when present instead of sending a whitespace bearer token.
+- Permission allowlist folders now normalize config-side dot segments, so entries such as `./projects` and `archive/./logs` match their intended vault folders.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.

--- a/src/__tests__/permissions.test.ts
+++ b/src/__tests__/permissions.test.ts
@@ -45,6 +45,18 @@ describe("permissions", () => {
     expect(() => assertAllowed("projects/sub/a.md", "read")).not.toThrow();
   });
 
+  it("normalizes dot segments in configured allowlist folders", () => {
+    setPermissions({ readPaths: ["./projects", "archive/./logs"], writePaths: null });
+    expect(() => assertAllowed("projects/a.md", "read")).not.toThrow();
+    expect(() => assertAllowed("archive/logs/a.md", "read")).not.toThrow();
+    expect(() => assertAllowed("private/a.md", "read")).toThrow(/Access denied/);
+  });
+
+  it("does not turn above-root allowlist folders into vault-root access", () => {
+    setPermissions({ readPaths: ["../private"], writePaths: null });
+    expect(() => assertAllowed("private/a.md", "read")).toThrow(/Access denied/);
+  });
+
   it("does not echo configured allowlist folders in denial errors", () => {
     setPermissions({ readPaths: ["sensitive/clients", "public/notes"], writePaths: null });
     expect(() => assertAllowed("other/note.md", "read")).toThrow(/OBSIDIAN_READ_PATHS/);

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -67,7 +67,10 @@ function normalizeFolder(folder: string): string {
   while (f.startsWith("/")) f = f.slice(1);
   while (f.endsWith("/")) f = f.slice(0, -1);
   if (f === "." || f === "") return "";
-  return f;
+  const normalized = path.posix.normalize(f);
+  if (normalized === ".") return "";
+  if (normalized === ".." || normalized.startsWith("../")) return f;
+  return normalized.replace(/^\/+|\/+$/g, "");
 }
 
 export function loadPermissionsFromEnv(): PermissionConfig {


### PR DESCRIPTION
Permission allowlist entries now normalize config-side dot segments, so common vault-relative forms like `./projects` and `archive/./logs` match the intended folders. Entries that climb above the vault root remain non-matching and do not widen access.

Risk is low: this only changes allowlist config normalization before the existing path checks run.

Score: 2 severity x 2 reach / 1 effort = 4.

Tested: `npm test -- --run src/__tests__/permissions.test.ts src/__tests__/regression-permissions.test.ts src/__tests__/security.test.ts`; `npm run verify`.