### PR TITLE
fix: canonicalize folder-scoped note listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - OpenAI embedding setup now treats blank `OBSIDIAN_EMBEDDING_API_KEY` values as unset, falling back to `OPENAI_API_KEY` when present instead of sending a whitespace bearer token.
 - Permission allowlist folders now normalize config-side dot segments, so entries such as `./projects` and `archive/./logs` match their intended vault folders.
+- Folder-scoped `list_notes` calls now return canonical note paths when the folder argument contains `.` or `..` segments.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.

--- a/src/__tests__/regression-vault-fixes.test.ts
+++ b/src/__tests__/regression-vault-fixes.test.ts
@@ -65,6 +65,24 @@ describe("H12: listNotes folder normalization", () => {
     expect(notes).toEqual(["a/b/c/note.md"]);
   });
 
+  it("canonicalizes dot segments before prefixing folder-scoped results", async () => {
+    await fs.mkdir(path.join(vaultDir, "projects"), { recursive: true });
+    await fs.mkdir(path.join(vaultDir, "private"), { recursive: true });
+    await fs.writeFile(path.join(vaultDir, "projects", "active.md"), "x");
+    await fs.writeFile(path.join(vaultDir, "private", "secret.md"), "x");
+
+    await expect(listNotes(vaultDir, ".")).resolves.toEqual([
+      "private/secret.md",
+      "projects/active.md",
+    ]);
+    await expect(listNotes(vaultDir, "projects/sub/..")).resolves.toEqual([
+      "projects/active.md",
+    ]);
+    await expect(listNotes(vaultDir, "projects/../private")).resolves.toEqual([
+      "private/secret.md",
+    ]);
+  });
+
   it("still excludes nested .git/.obsidian/.trash inside the folder", async () => {
     await fs.mkdir(path.join(vaultDir, "projects", ".git"), { recursive: true });
     await fs.writeFile(

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -612,17 +612,23 @@ export async function readVaultInternalTextFile(
   }
 }
 
+function normalizeListFolder(folder: string | undefined): string {
+  if (!folder) return "";
+  const slashed = folder.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+  if (slashed === "") return "";
+  const normalized = path.posix.normalize(slashed);
+  if (normalized === ".") return "";
+  return normalized.replace(/^\/+|\/+$/g, "");
+}
+
 export async function listNotes(
   vaultPath: string,
   folder?: string,
 ): Promise<string[]> {
-  // Normalize folder before joining: callers may pass trailing slashes,
-  // backslashes, or mixed separators (e.g. `projects/`, `projects\nested`).
-  // Without normalization the prefix concatenation below produces malformed
-  // paths like `projects//note.md` or `projects\nested/note.md`.
-  const normalizedFolder = folder
-    ? folder.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "")
-    : "";
+  // Normalize folder before joining and before prefixing returned entries:
+  // callers may pass trailing slashes, mixed separators, or dot segments.
+  // Returned note paths must stay canonical vault-relative paths.
+  const normalizedFolder = normalizeListFolder(folder);
 
   const baseDir = normalizedFolder
     ? await resolveVaultPathSafe(vaultPath, normalizedFolder)


### PR DESCRIPTION
Folder-scoped list_notes calls now canonicalize folder arguments before reusing them in returned note paths, so flexible input like . or projects/../private does not leak ./ or .. into client-facing paths.

Risk is low: the resolver still performs the same vault-boundary and permission checks, and root listings continue to filter by readable paths.

Score: 2 severity x 2 reach / 1 effort = 4.

Tests: npm test -- --run src/__tests__/regression-vault-fixes.test.ts src/__tests__/vault.test.ts src/__tests__/security.test.ts; npm run verify.