### PR TITLE
fix: ignore remote attachment links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI embedding setup now treats blank `OBSIDIAN_EMBEDDING_API_KEY` values as unset, falling back to `OPENAI_API_KEY` when present instead of sending a whitespace bearer token.
 - Permission allowlist folders now normalize config-side dot segments, so entries such as `./projects` and `archive/./logs` match their intended vault folders.
 - Folder-scoped `list_notes` calls now return canonical note paths when the folder argument contains `.` or `..` segments.
+- `find_unused_attachments` now ignores remote markdown URLs before basename matching, so links to external images do not mark local files as referenced.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.

--- a/src/__tests__/handlers/attachments.test.ts
+++ b/src/__tests__/handlers/attachments.test.ts
@@ -134,6 +134,22 @@ describe("attachments handlers — find_unused_attachments", () => {
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
   });
 
+  it("does not treat remote markdown URLs as local attachment references", async () => {
+    await fs.appendFile(
+      path.join(env.vaultDir, "embed-host.md"),
+      "\nRemote-only image: [remote](https://cdn.example/assets/orphan-image.png)\n",
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "find_unused_attachments",
+      arguments: {},
+    });
+
+    expect(isError(result)).toBe(false);
+    expect(textContent(result)).toMatch(/orphan-image\.png/);
+  });
+
   it("serves repeated unused scans without changing output", async () => {
     const first = await env.client.callTool({
       name: "find_unused_attachments",

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -168,6 +168,12 @@ async function noteStatsFingerprint(
   return parts.join("\0");
 }
 
+function isExternalMarkdownTarget(target: string): boolean {
+  if (target.startsWith("//")) return true;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(target)) return true;
+  return /^(?:data|file|http|https|mailto|obsidian|tel):/i.test(target);
+}
+
 /**
  * Resolve the set of attachment paths referenced by a single note. Considers:
  *   - `![[file.png]]` and `![[file.png|alt]]` wikilink embeds
@@ -186,7 +192,10 @@ function collectReferencedAttachments(
   const unresolved: string[] = [];
 
   const consider = (rawTarget: string): void => {
-    const t = rawTarget.split("#")[0]!.split("^")[0]!.trim();
+    const trimmedTarget = rawTarget.trim();
+    if (isExternalMarkdownTarget(trimmedTarget)) return;
+
+    const t = trimmedTarget.split("#")[0]!.split("^")[0]!.trim();
     if (!t) return;
 
     // 1) Exact relative-path match (case-insensitive on case-insensitive FS,


### PR DESCRIPTION
find_unused_attachments now ignores external markdown URL targets before applying local attachment basename matching, so a remote image URL does not make a same-named vault file look referenced.

Risk is low: local wikilink embeds, local markdown links, exact path matching, and basename fallback for vault files are unchanged.

Score: 2 severity x 2 reach / 1 effort = 4.

Tests: npm test -- --run src/__tests__/handlers/attachments.test.ts src/__tests__/regression-tools-attachments.test.ts src/__tests__/attachments-display.test.ts; npm run verify.