### PR TITLE
fix: normalize local attachment links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Permission allowlist folders now normalize config-side dot segments, so entries such as `./projects` and `archive/./logs` match their intended vault folders.
 - Folder-scoped `list_notes` calls now return canonical note paths when the folder argument contains `.` or `..` segments.
 - `find_unused_attachments` now ignores remote markdown URLs before basename matching, so links to external images do not mark local files as referenced.
+- `find_unused_attachments` now normalizes local markdown attachment paths with dot segments before basename matching, preventing duplicate filenames from being marked referenced together.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.

--- a/src/__tests__/handlers/attachments.test.ts
+++ b/src/__tests__/handlers/attachments.test.ts
@@ -150,6 +150,28 @@ describe("attachments handlers — find_unused_attachments", () => {
     expect(textContent(result)).toMatch(/orphan-image\.png/);
   });
 
+  it("normalizes local markdown link dot segments before basename fallback", async () => {
+    await env.cleanup();
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "assets/used.png": "referenced",
+        "other/used.png": "unused duplicate basename",
+        "note.md": "Local path: ![img](./assets/used.png)\n",
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "find_unused_attachments",
+      arguments: {},
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).not.toMatch(/assets\/used\.png/);
+    expect(text).toMatch(/other\/used\.png/);
+  });
+
   it("serves repeated unused scans without changing output", async () => {
     const first = await env.client.callTool({
       name: "find_unused_attachments",

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -174,6 +174,20 @@ function isExternalMarkdownTarget(target: string): boolean {
   return /^(?:data|file|http|https|mailto|obsidian|tel):/i.test(target);
 }
 
+function normalizeLocalMarkdownTarget(target: string): string {
+  const slashed = target.replace(/\\/g, "/");
+  const normalized = path.posix.normalize(slashed);
+  if (
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.startsWith("/")
+  ) {
+    return slashed;
+  }
+  return normalized.replace(/\/+$/g, "");
+}
+
 /**
  * Resolve the set of attachment paths referenced by a single note. Considers:
  *   - `![[file.png]]` and `![[file.png|alt]]` wikilink embeds
@@ -195,7 +209,9 @@ function collectReferencedAttachments(
     const trimmedTarget = rawTarget.trim();
     if (isExternalMarkdownTarget(trimmedTarget)) return;
 
-    const t = trimmedTarget.split("#")[0]!.split("^")[0]!.trim();
+    const t = normalizeLocalMarkdownTarget(
+      trimmedTarget.split("#")[0]!.split("^")[0]!.trim(),
+    );
     if (!t) return;
 
     // 1) Exact relative-path match (case-insensitive on case-insensitive FS,


### PR DESCRIPTION
Normalizes local markdown attachment targets before exact path lookup so links like ./assets/used.png do not fall back to basename matching and mark every duplicate filename as referenced. This keeps remote URL skipping and existing basename fallback behavior intact while fixing the duplicate-basename edge case.\n\nRisk: low; only local markdown targets with dot segments now exact-match the same vault-relative attachment path they already named.\nScore: 2 severity x 2 reach / 1 effort = 4.\nTests: npm test -- --run src/__tests__/handlers/attachments.test.ts src/__tests__/regression-tools-attachments.test.ts src/__tests__/attachments-display.test.ts; npm run verify.