### PR TITLE
fix: skip scheme markdown rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Folder-scoped `list_notes` calls now return canonical note paths when the folder argument contains `.` or `..` segments.
 - `find_unused_attachments` now ignores remote markdown URLs before basename matching, so links to external images do not mark local files as referenced.
 - `find_unused_attachments` now normalizes local markdown attachment paths with dot segments before basename matching, preventing duplicate filenames from being marked referenced together.
+- Vault-wide link cleanup now skips scheme-style markdown URLs such as `mailto:` before alias resolution, preventing move/delete reference rewrites from editing external links that resemble note aliases.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.

--- a/src/__tests__/link-rewriter.test.ts
+++ b/src/__tests__/link-rewriter.test.ts
@@ -122,6 +122,15 @@ describe("moveNote — wikilink rewriting", () => {
     );
   });
 
+  it("does not rewrite scheme-style markdown URLs that match an alias", async () => {
+    await seed("inbox/idea.md", "---\naliases:\n  - \"mailto:idea\"\n---\nx");
+    await seed("ref.md", "[mail](mailto:idea)");
+
+    await moveNote(vaultDir, "inbox/idea.md", "archive/idea.md");
+
+    expect(await readNote(vaultDir, "ref.md")).toBe("[mail](mailto:idea)");
+  });
+
   it("does not rewrite wikilinks inside fenced code blocks", async () => {
     await seed("inbox/idea.md", "x");
     const body = ["normal [[inbox/idea]]", "```", "[[inbox/idea]]", "```"].join("\n");
@@ -596,6 +605,20 @@ describe("planDeleteRewrites", () => {
 
     expect(result.updated).toEqual(["ref.md"]);
     expect(await readNote(vaultDir, "ref.md")).toBe("Read the topic carefully.");
+  });
+
+  it("does not strip scheme-style markdown URLs that match an alias", async () => {
+    await seed("notes/topic.md", "---\naliases:\n  - \"mailto:topic\"\n---\n# Topic");
+    await seed("ref.md", "Mail [the topic](mailto:topic) later.");
+
+    const preDeleteNotes = await listNotes(vaultDir);
+    const plan = await planDeleteRewrites(vaultDir, "notes/topic.md", preDeleteNotes);
+    const result = await applyRewrites(vaultDir, plan);
+
+    expect(result.updated).toEqual([]);
+    expect(await readNote(vaultDir, "ref.md")).toBe(
+      "Mail [the topic](mailto:topic) later.",
+    );
   });
 
   it("strips explicitly relative markdown links to the deleted file", async () => {

--- a/src/lib/link-rewriter.ts
+++ b/src/lib/link-rewriter.ts
@@ -38,6 +38,10 @@ function assertCanvasJsonObject(parsed: unknown, relativePath: string): Record<s
   return parsed as Record<string, unknown>;
 }
 
+function isExternalMarkdownUrl(url: string): boolean {
+  return url.startsWith("/") || /^[a-z][a-z0-9+.-]*:/i.test(url);
+}
+
 /** A single in-place edit on a referrer file, expressed as a byte-offset slice
  *  to replace. Edits within a file are listed in increasing-offset order.
  *
@@ -157,7 +161,7 @@ export async function planMoveRewrites(
       if (notePath === oldPath) continue;
       const url = span.urlPath;
       // Skip absolute / external URLs — only intra-vault references rewrite.
-      if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url) || url.startsWith("/")) continue;
+      if (isExternalMarkdownUrl(url)) continue;
       const decoded = safeDecode(url);
       const resolved = resolveMarkdownLinkPath(decoded, notePath, preMoveNotes, aliasMap);
       if (resolved !== oldPath) continue;
@@ -311,7 +315,7 @@ export async function planDeleteRewrites(
     for (const span of extractMarkdownLinkSpans(content)) {
       const url = span.urlPath;
       // Skip absolute / external URLs — only intra-vault refs strip.
-      if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url) || url.startsWith("/")) continue;
+      if (isExternalMarkdownUrl(url)) continue;
       const decoded = safeDecode(url);
       const resolved = resolveMarkdownLinkPath(decoded, notePath, preDeleteNotes, aliasMap);
       if (resolved !== deletedPath) continue;


### PR DESCRIPTION
Skips markdown URLs with URI schemes before alias resolution in move/delete reference cleanup. Without this, an alias such as mailto:idea could make an external mail link get rewritten or stripped during vault-wide cleanup.\n\nRisk: low; intra-vault relative markdown links still rewrite, while scheme-style URLs and root-absolute URLs stay outside cleanup.\nScore: 3 severity x 2 reach / 1 effort = 6.\nTests: npm test -- --run src/__tests__/link-rewriter.test.ts; npm test -- --run src/__tests__/link-rewriter.test.ts src/__tests__/handlers/write.test.ts src/__tests__/regression-tools-write.test.ts src/__tests__/markdown.test.ts; npm run verify.