### PR TITLE
fix: canonicalize link tool paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `find_unused_attachments` now ignores remote markdown URLs before basename matching, so links to external images do not mark local files as referenced.
 - `find_unused_attachments` now normalizes local markdown attachment paths with dot segments before basename matching, preventing duplicate filenames from being marked referenced together.
 - Vault-wide link cleanup now skips scheme-style markdown URLs such as `mailto:` before alias resolution, preventing move/delete reference rewrites from editing external links that resemble note aliases.
+- Link graph tools now canonicalize caller-provided note paths with dot segments before basename fallback, so duplicate basenames do not make `get_backlinks`, `get_outlinks`, or `get_graph_neighbors` inspect the wrong note.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.

--- a/src/__tests__/handlers/links.test.ts
+++ b/src/__tests__/handlers/links.test.ts
@@ -57,6 +57,29 @@ describe("link handlers — get_backlinks", () => {
     expect(textContent(withExt)).toEqual(textContent(withoutExt));
   });
 
+  it("canonicalizes target path dot segments before basename fallback", async () => {
+    await env.cleanup();
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "archive/idea.md": "# Archive idea\n",
+        "projects/idea.md": "# Project idea\n",
+        "ref.md": "Links to [[projects/idea]].\n",
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "get_backlinks",
+      arguments: { path: "./projects/idea.md" },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain("ref.md");
+    expect(text).toContain("projects/idea.md");
+    expect(text).not.toContain("No backlinks found");
+  });
+
   it("escapes control characters in missing target paths", async () => {
     const result = await env.client.callTool({
       name: "get_backlinks",
@@ -114,6 +137,30 @@ describe("link handlers — get_outlinks", () => {
     expect(text).toContain("note-b.md");
     expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks source path]");
     expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks resolved path]");
+  });
+
+  it("canonicalizes source path dot segments before basename fallback", async () => {
+    await env.cleanup();
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "archive/idea.md": "# Archive idea\n",
+        "projects/idea.md": "# Project idea\n\nLinks to [[target]].\n",
+        "target.md": "# Target\n",
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "get_outlinks",
+      arguments: { path: "./projects/idea.md" },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toMatch(/1 valid, 0 broken/);
+    expect(text).toContain("projects/idea.md");
+    expect(text).toContain("target.md");
+    expect(text).not.toContain("No outgoing links");
   });
 
   it("refreshes a warm graph before resolving a new source note", async () => {

--- a/src/tools/links.ts
+++ b/src/tools/links.ts
@@ -166,6 +166,29 @@ function buildSourceLookup(notes: string[]): Map<string, string> {
   return lookup;
 }
 
+function normalizeGraphInputPath(input: string): string {
+  const slashed = input.replace(/\\/g, "/");
+  const withoutExt = slashed.replace(/\.md$/i, "");
+  const normalized = path.posix.normalize(withoutExt);
+  if (
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.startsWith("/")
+  ) {
+    return withoutExt.toLowerCase();
+  }
+  return normalized.replace(/\/+$/g, "").toLowerCase();
+}
+
+function resolveGraphInputPath(graph: LinkGraphData, input: string): string | null {
+  const normalized = normalizeGraphInputPath(input);
+  const basename = normalized.split("/").pop() ?? normalized;
+  return graph.sourceLookup.get(`exact:${normalized}`) ??
+    graph.sourceLookup.get(`base:${basename}`) ??
+    null;
+}
+
 function sharedPathDepth(a: string, b: string): number {
   const as = a.toLowerCase().split("/");
   const bs = b.toLowerCase().split("/");
@@ -444,34 +467,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
       try {
         const graph = await buildLinkGraph(vaultPath);
 
-        // Normalize target for comparison
-        const targetNormalized = targetPath.replace(/\.md$/i, "").toLowerCase();
-        const targetBasename = targetNormalized.split("/").pop() ?? targetNormalized;
-
-        // Find the actual note path that matches the target
-        let resolvedTarget: string | null = null;
-        for (const notePath of graph.allNotes) {
-          const noteNormalized = notePath.replace(/\.md$/i, "").toLowerCase();
-          if (noteNormalized === targetNormalized) {
-            resolvedTarget = notePath;
-            break;
-          }
-        }
-
-        // Also try basename matching if exact match failed
-        if (!resolvedTarget) {
-          for (const notePath of graph.allNotes) {
-            const noteBasename = notePath
-              .replace(/\.md$/i, "")
-              .split("/")
-              .pop()
-              ?.toLowerCase();
-            if (noteBasename === targetBasename) {
-              resolvedTarget = notePath;
-              break;
-            }
-          }
-        }
+        const resolvedTarget = resolveGraphInputPath(graph, targetPath);
 
         if (!resolvedTarget) {
           return errorResult(`No note found matching path: ${displayLinkValue(targetPath)}`);
@@ -599,15 +595,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
         // calls. The graph already indexes raw links per source.
         const graph = await buildLinkGraph(vaultPath);
 
-        // Resolve caller-provided path to its canonical form in the graph
-        // (handles trailing-or-missing .md and basename-only inputs the way
-        // get_backlinks does).
-        const targetNormalized = notePath.replace(/\.md$/i, "").toLowerCase();
-        const targetBasename = targetNormalized.split("/").pop() ?? targetNormalized;
-        const resolvedSource =
-          graph.sourceLookup.get(`exact:${targetNormalized}`) ??
-          graph.sourceLookup.get(`base:${targetBasename}`) ??
-          null;
+        const resolvedSource = resolveGraphInputPath(graph, notePath);
         if (!resolvedSource) {
           return errorResult(`No note found matching path: ${displayLinkValue(notePath)}`);
         }
@@ -910,33 +898,7 @@ export function registerLinkTools(server: McpServer, vaultPath: string): void {
       try {
         const graph = await buildLinkGraph(vaultPath);
 
-        // Resolve the start path
-        const startNormalized = startPath.replace(/\.md$/i, "").toLowerCase();
-        let resolvedStart: string | null = null;
-
-        for (const notePath of graph.allNotes) {
-          const noteNormalized = notePath.replace(/\.md$/i, "").toLowerCase();
-          if (noteNormalized === startNormalized) {
-            resolvedStart = notePath;
-            break;
-          }
-        }
-
-        if (!resolvedStart) {
-          // Try basename matching
-          const startBasename = startNormalized.split("/").pop() ?? startNormalized;
-          for (const notePath of graph.allNotes) {
-            const noteBasename = notePath
-              .replace(/\.md$/i, "")
-              .split("/")
-              .pop()
-              ?.toLowerCase();
-            if (noteBasename === startBasename) {
-              resolvedStart = notePath;
-              break;
-            }
-          }
-        }
+        const resolvedStart = resolveGraphInputPath(graph, startPath);
 
         if (!resolvedStart) {
           return errorResult(`No note found matching path: ${displayLinkValue(startPath)}`);


### PR DESCRIPTION
Canonicalizes caller-provided link graph paths before exact lookup so inputs like `./projects/idea.md` resolve to the named note before duplicate-basename fallback. Risk: low; shorthand basename fallback remains, and invalid absolute or above-root-looking inputs retain the old fallback shape.

Score: 2 severity x 2 reach / 1 effort = 4.

Tested with the pre-fix failing handler regression, focused link suites, and `npm run verify`.