### PR TITLE
fix: tighten base link filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `find_unused_attachments` now normalizes local markdown attachment paths with dot segments before basename matching, preventing duplicate filenames from being marked referenced together.
 - Vault-wide link cleanup now skips scheme-style markdown URLs such as `mailto:` before alias resolution, preventing move/delete reference rewrites from editing external links that resemble note aliases.
 - Link graph tools now canonicalize caller-provided note paths with dot segments before basename fallback, so duplicate basenames do not make `get_backlinks`, `get_outlinks`, or `get_graph_neighbors` inspect the wrong note.
+- Base `file.linksTo()` and `file.hasLink()` filters now strip link fragments and require folder-qualified targets to match by path before falling back to basename-only shorthand.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.

--- a/src/__tests__/regression-bases-2026.test.ts
+++ b/src/__tests__/regression-bases-2026.test.ts
@@ -136,6 +136,28 @@ describe("O3: file.hasProperty() and file.linksTo()", () => {
     const noMatch = queryBase([row], { filters: ['file.linksTo("Other")'] });
     expect(noMatch.rows).toHaveLength(0);
   });
+
+  it("file.linksTo keeps path targets from falling back to basename-only matches", () => {
+    const archiveRow = buildRow("archive-source.md", noteWithFrontmatter({}));
+    archiveRow.links = ["archive/idea"];
+    const projectRow = buildRow("project-source.md", noteWithFrontmatter({}));
+    projectRow.links = ["projects/idea"];
+
+    const result = queryBase([archiveRow, projectRow], {
+      filters: ['file.linksTo("projects/idea")'],
+    });
+
+    expect(result.rows.map((r) => r.path)).toEqual(["project-source.md"]);
+  });
+
+  it("file.hasLink ignores heading fragments when matching linked files", () => {
+    const row = buildRow("a.md", noteWithFrontmatter({}));
+    row.links = ["projects/idea#Heading"];
+
+    const result = queryBase([row], { filters: ['file.hasLink("projects/idea")'] });
+
+    expect(result.rows.map((r) => r.path)).toEqual(["a.md"]);
+  });
 });
 
 describe("C4: ReDoS hardening", () => {

--- a/src/lib/bases.ts
+++ b/src/lib/bases.ts
@@ -1,4 +1,5 @@
 import yaml from "js-yaml";
+import path from "path";
 import { parseFrontmatter, extractTags } from "./markdown.js";
 import { hasYamlAnchorOrAliasToken } from "./yaml.js";
 
@@ -512,14 +513,35 @@ function matchesFolder(row: BaseRow, folder: string | null): boolean {
   return row.path.startsWith(norm + "/") || row.path === norm;
 }
 
+function stripLinkFragment(target: string): string {
+  return target.split("#")[0]!.split("^")[0]!.trim();
+}
+
+function normalizeBaseLinkTarget(target: string): string {
+  const slashed = stripLinkFragment(target).replace(/\\/g, "/");
+  const withoutExt = slashed.replace(/\.md$/i, "");
+  if (!withoutExt) return "";
+  return path.posix.normalize(withoutExt).replace(/\/+$/g, "").toLowerCase();
+}
+
+function isPathQualifiedLinkTarget(target: string): boolean {
+  return stripLinkFragment(target).replace(/\\/g, "/").includes("/");
+}
+
 function matchesLink(links: readonly string[], target: string): boolean {
   // Loose match — Obsidian normalizes link targets in non-trivial ways
-  // (case, extension, fragment). Accept exact and basename-equal hits.
-  const t = target.toLowerCase();
-  const tBase = basenameWithoutExt(target).toLowerCase();
+  // (case, extension, fragment). Accept basename shorthand only when the
+  // filter target itself is basename-only.
+  const t = normalizeBaseLinkTarget(target);
+  if (!t) return false;
+  const targetHasPath = isPathQualifiedLinkTarget(target);
+  const tBase = basenameWithoutExt(t).toLowerCase();
   return links.some((l) => {
-    const ll = l.toLowerCase();
-    return ll === t || basenameWithoutExt(l).toLowerCase() === tBase;
+    const ll = normalizeBaseLinkTarget(l);
+    if (!ll) return false;
+    if (ll === t) return true;
+    if (targetHasPath) return false;
+    return basenameWithoutExt(ll).toLowerCase() === tBase;
   });
 }
 


### PR DESCRIPTION
Tightens Base `file.linksTo()` / `file.hasLink()` matching so folder-qualified targets match normalized paths instead of any note with the same basename. Fragment links such as `[[projects/idea#Heading]]` now count as links to `projects/idea`.

Obsidian Bases docs describe `file.hasLink(otherFile: file | string)` as checking whether the file links to another file: https://obsidian.md/help/bases/functions

Risk: low. Basename-only shorthand still falls back by basename; only path-qualified filters stop broadening across duplicate basenames.

Score: 2 severity x 2 reach / 1 effort = 4.

Tested with the pre-fix failing Base regressions, focused Base/markdown suites, and `npm run verify`.