### PR TITLE
fix: normalize wikilink target paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `find_unused_attachments` now normalizes local markdown attachment paths with dot segments before basename matching, preventing duplicate filenames from being marked referenced together.
 - Vault-wide link cleanup now skips scheme-style markdown URLs such as `mailto:` before alias resolution, preventing move/delete reference rewrites from editing external links that resemble note aliases.
 - Link graph tools now canonicalize caller-provided note paths with dot segments before basename fallback, so duplicate basenames do not make `get_backlinks`, `get_outlinks`, or `get_graph_neighbors` inspect the wrong note.
+- Wikilink resolution now normalizes dot segments before basename fallback, preventing links such as `[[./projects/idea]]` from resolving to the wrong duplicate basename.
 - Base `file.linksTo()` and `file.hasLink()` filters now strip link fragments and require folder-qualified targets to match by path before falling back to basename-only shorthand.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.

--- a/src/__tests__/handlers/links.test.ts
+++ b/src/__tests__/handlers/links.test.ts
@@ -163,6 +163,29 @@ describe("link handlers — get_outlinks", () => {
     expect(text).not.toContain("No outgoing links");
   });
 
+  it("canonicalizes wikilink target dot segments before basename fallback", async () => {
+    await env.cleanup();
+    env = await createTestEnv({
+      skipFixtures: true,
+      extraFiles: {
+        "archive/idea.md": "# Archive idea\n",
+        "projects/idea.md": "# Project idea\n",
+        "ref.md": "Links to [[./projects/idea]].\n",
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "get_outlinks",
+      arguments: { path: "ref.md" },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toMatch(/1 valid, 0 broken/);
+    expect(text).toContain("projects/idea.md");
+    expect(text).not.toContain("archive/idea.md");
+  });
+
   it("refreshes a warm graph before resolving a new source note", async () => {
     const warmed = await env.client.callTool({
       name: "get_outlinks",

--- a/src/__tests__/markdown.test.ts
+++ b/src/__tests__/markdown.test.ts
@@ -544,6 +544,14 @@ describe("resolveWikilink", () => {
     const result = resolveWikilink("sub/deep", "any.md", allPaths);
     expect(result).toBe("folder/sub/deep.md");
   });
+
+  it("normalizes path dot segments before basename fallback", () => {
+    const paths = ["archive/idea.md", "projects/idea.md"];
+    expect(resolveWikilink("./projects/idea", "ref.md", paths)).toBe("projects/idea.md");
+    expect(resolveWikilink("archive/../projects/idea#Heading", "ref.md", paths)).toBe(
+      "projects/idea.md",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -739,6 +739,13 @@ export interface ResolveWikilinkOptions {
   aliasMap?: Map<string, string>;
 }
 
+export function normalizeWikilinkTargetPath(link: string): string {
+  const slashed = link.replace(/\\/g, "/");
+  const withoutExt = slashed.replace(/\.md$/i, "");
+  if (!withoutExt) return "";
+  return path.posix.normalize(withoutExt).replace(/\/+$/g, "");
+}
+
 /**
  * Resolve a wikilink target to an actual file path.
  *
@@ -765,7 +772,7 @@ export function resolveWikilink(
   const cleanLink = link.split("#")[0]!.split("^")[0]!.trim();
   if (!cleanLink) return null;
 
-  const normalizedLink = cleanLink.replace(/\.md$/i, "");
+  const normalizedLink = normalizeWikilinkTargetPath(cleanLink);
   const normalizedLinkLower = normalizedLink.toLowerCase();
 
   // 1. Exact relative-path match

--- a/src/tools/links.ts
+++ b/src/tools/links.ts
@@ -3,7 +3,11 @@ import path from "path";
 import { z } from "zod";
 import { listNotes, getNoteStats, getVaultRootRealPath } from "../lib/vault.js";
 import { readAllCached } from "../lib/index-cache.js";
-import { extractWikilinks, extractAliases } from "../lib/markdown.js";
+import {
+  extractWikilinks,
+  extractAliases,
+  normalizeWikilinkTargetPath,
+} from "../lib/markdown.js";
 import { escapeControlChars, sanitizeError } from "../lib/errors.js";
 import {
   formatUntrustedVaultContent,
@@ -228,7 +232,7 @@ function resolveWikilinkWithIndex(
   const cleanLink = link.split("#")[0]!.split("^")[0]!.trim();
   if (!cleanLink) return null;
 
-  const normalizedLink = cleanLink.replace(/\.md$/i, "");
+  const normalizedLink = normalizeWikilinkTargetPath(cleanLink);
   const normalizedLinkLower = normalizedLink.toLowerCase();
 
   const exact = index.exact.get(normalizedLinkLower);


### PR DESCRIPTION
Normalizes wikilink target paths before exact and suffix lookup, so links such as `[[./projects/idea]]` and `[[archive/../projects/idea#Heading]]` resolve to the intended path before duplicate-basename fallback.

Risk: low. Basename fallback and alias fallback remain in the same order; the change only canonicalizes slash and dot segments before the existing matching steps.

Score: 2 severity x 2 reach / 1 effort = 4.

Tested with the pre-fix failing markdown and `get_outlinks` regressions, focused link/markdown/rewrite suites, and `npm run verify`.