### PR TITLE
fix: normalize base folder filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Link graph tools now canonicalize caller-provided note paths with dot segments before basename fallback, so duplicate basenames do not make `get_backlinks`, `get_outlinks`, or `get_graph_neighbors` inspect the wrong note.
 - Wikilink resolution now normalizes dot segments before basename fallback, preventing links such as `[[./projects/idea]]` from resolving to the wrong duplicate basename.
 - Base `file.linksTo()` and `file.hasLink()` filters now strip link fragments and require folder-qualified targets to match by path before falling back to basename-only shorthand.
+- Base `file.inFolder()` filters now normalize slash and dot segments in folder arguments before matching note paths.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.

--- a/src/__tests__/regression-bases-2026.test.ts
+++ b/src/__tests__/regression-bases-2026.test.ts
@@ -89,6 +89,19 @@ describe("O2: extended file.* properties", () => {
     expect(result.rows.map((r) => r.path)).toEqual(["Projects/alpha.md"]);
   });
 
+  it("file.inFolder normalizes dot segments in the folder argument", () => {
+    const rows = [
+      buildRow("Projects/alpha.md", noteWithFrontmatter({})),
+      buildRow("Archive/beta.md", noteWithFrontmatter({})),
+    ];
+
+    const projects = queryBase(rows, { filters: ['file.inFolder("./Projects/./")'] });
+    expect(projects.rows.map((r) => r.path)).toEqual(["Projects/alpha.md"]);
+
+    const archive = queryBase(rows, { filters: ['file.inFolder("Projects/../Archive")'] });
+    expect(archive.rows.map((r) => r.path)).toEqual(["Archive/beta.md"]);
+  });
+
   it("file.ext exposes the file extension", () => {
     const rows = [
       buildRow("notes/a.md", noteWithFrontmatter({})),

--- a/src/lib/bases.ts
+++ b/src/lib/bases.ts
@@ -506,9 +506,17 @@ function matchesTag(row: BaseRow, want: string | null): boolean {
   });
 }
 
+function normalizeBaseFolderTarget(folder: string): string {
+  const slashed = folder.trim().replace(/\\/g, "/");
+  const trimmed = slashed.replace(/^\/+|\/+$/g, "");
+  if (!trimmed) return "";
+  const normalized = path.posix.normalize(trimmed).replace(/\/+$/g, "");
+  return normalized === "." ? "" : normalized;
+}
+
 function matchesFolder(row: BaseRow, folder: string | null): boolean {
   if (folder === null) return false;
-  const norm = folder.replace(/^\/+|\/+$/g, "");
+  const norm = normalizeBaseFolderTarget(folder);
   if (norm === "") return true;
   return row.path.startsWith(norm + "/") || row.path === norm;
 }


### PR DESCRIPTION
Base file.inFolder() now canonicalizes slash and dot segments in folder arguments before comparing them with note paths. That lets filters such as ./Projects/./ and Projects/../Archive match the intended folders instead of returning empty rows.\n\nRisk: low. Matching stays case-sensitive and still compares against normalized vault-relative row paths. Empty and root-like arguments continue to match the vault root.\n\nScore: 2 severity x 2 reach / 1 effort = 4. Folder filters are correctness-sensitive but the change is tightly scoped.\n\nTests: reproduced with a failing regression in src/__tests__/regression-bases-2026.test.ts before the fix; ran npm test -- --run src/__tests__/regression-bases-2026.test.ts; ran npm test -- --run src/__tests__/bases.test.ts src/__tests__/regression-bases-2026.test.ts src/__tests__/handlers/bases.test.ts src/__tests__/markdown.test.ts; ran npm run verify.