### PR TITLE
fix: protect trash deletes from races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wikilink resolution now normalizes dot segments before basename fallback, preventing links such as `[[./projects/idea]]` from resolving to the wrong duplicate basename.
 - Base `file.linksTo()` and `file.hasLink()` filters now strip link fragments and require folder-qualified targets to match by path before falling back to basename-only shorthand.
 - Base `file.inFolder()` filters now normalize slash and dot segments in folder arguments before matching note paths.
+- Trash deletes now use no-replace semantics for the selected `.trash` destination, preventing races from overwriting a newly created trashed file.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.

--- a/src/__tests__/vault.test.ts
+++ b/src/__tests__/vault.test.ts
@@ -543,17 +543,49 @@ describe("deleteNote", () => {
     expect(await fs.readFile(path.join(trashDir, collisionCopy!), "utf-8")).toBe("second");
   });
 
-  itWin32("retries transient Windows rename failures while moving to trash", async () => {
-    await writeNote(vaultDir, "doomed.md", "bye");
+  it("does not overwrite a trash destination created after collision selection", async () => {
+    await writeNote(vaultDir, "raced.md", "source content");
+    const racedDest = path.join(vaultDir, ".trash", "raced.md");
+
+    const raceDestination = async (candidate: unknown): Promise<void> => {
+      const dest = String(candidate);
+      if (dest === racedDest) {
+        await fs.writeFile(dest, "racer content", "utf-8");
+      }
+    };
+
     const realRename = fs.rename.bind(fs);
-    const renameSpy = vi.spyOn(fs, "rename");
-    renameSpy
+    const realLink = fs.link.bind(fs);
+    vi.spyOn(fs, "rename").mockImplementation(async (...args: Parameters<typeof fs.rename>) => {
+      await raceDestination(args[1]);
+      return realRename(...args);
+    });
+    vi.spyOn(fs, "link").mockImplementation(async (...args: Parameters<typeof fs.link>) => {
+      await raceDestination(args[1]);
+      return realLink(...args);
+    });
+
+    await expect(deleteNote(vaultDir, "raced.md")).rejects.toThrow(
+      "Destination already exists: .trash/raced.md",
+    );
+
+    await expect(fs.readFile(path.join(vaultDir, "raced.md"), "utf-8")).resolves.toBe(
+      "source content",
+    );
+    await expect(fs.readFile(racedDest, "utf-8")).resolves.toBe("racer content");
+  });
+
+  itWin32("retries transient Windows unlink failures while moving to trash", async () => {
+    await writeNote(vaultDir, "doomed.md", "bye");
+    const realUnlink = fs.unlink.bind(fs);
+    const unlinkSpy = vi.spyOn(fs, "unlink");
+    unlinkSpy
       .mockRejectedValueOnce(Object.assign(new Error("simulated EPERM"), { code: "EPERM" }))
-      .mockImplementation(realRename);
+      .mockImplementation(realUnlink);
 
     await deleteNote(vaultDir, "doomed.md");
 
-    expect(renameSpy).toHaveBeenCalledTimes(2);
+    expect(unlinkSpy).toHaveBeenCalledTimes(2);
     await expect(fs.access(path.join(vaultDir, "doomed.md"))).rejects.toThrow();
     await expect(fs.access(path.join(vaultDir, ".trash", "doomed.md"))).resolves.toBeUndefined();
   });

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1070,7 +1070,8 @@ export async function deleteNote(
         // after parent creation but before the rename.
         await assertRealPathWithinVault(trashFullPath, vaultPath);
         const finalTrashPath = await chooseTrashPath(trashFullPath);
-        await renameWithRetry(fullPath, finalTrashPath);
+        const finalTrashRelPath = path.relative(resolvedVault, finalTrashPath).replace(/\\/g, "/");
+        await movePathNoReplace(vaultPath, fullPath, finalTrashPath, finalTrashRelPath);
       } else {
         await fs.unlink(fullPath);
       }


### PR DESCRIPTION
Trash deletes now move the selected .trash destination through the same no-replace path used by note moves. If another process creates that destination after collision selection, the delete rejects and keeps the source note plus the competing trash file intact.\n\nRisk: low. Recoverable deletes may leave both source and trash candidate present if the final unlink fails, but they no longer overwrite a newly created trash file. Permanent deletes are unchanged.\n\nScore: 3 severity x 2 reach / 1 effort = 6. This is a destructive-file correctness issue with a narrow race window and a small reuse of existing move code.\n\nTests: reproduced with a failing regression in src/__tests__/vault.test.ts before the fix; ran npm test -- --run src/__tests__/vault.test.ts; ran npm test -- --run src/__tests__/vault.test.ts src/__tests__/security.test.ts src/__tests__/handlers/write.test.ts src/__tests__/regression-fn-cluster.test.ts; ran npm run verify.