### PR TITLE
fix: normalize semantic folder filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Base `file.linksTo()` and `file.hasLink()` filters now strip link fragments and require folder-qualified targets to match by path before falling back to basename-only shorthand.
 - Base `file.inFolder()` filters now normalize slash and dot segments in folder arguments before matching note paths.
 - Trash deletes now use no-replace semantics for the selected `.trash` destination, preventing races from overwriting a newly created trashed file.
+- Semantic search folder filters now normalize slash and dot segments before matching stored note paths.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.

--- a/src/__tests__/embedding-store.test.ts
+++ b/src/__tests__/embedding-store.test.ts
@@ -153,6 +153,28 @@ describe("setNoteChunks / searchEmbeddings", () => {
     expect(hits.map((h) => h.notePath)).toEqual(["projects/alpha.md"]);
   });
 
+  it("normalizes dot segments in folder filters", async () => {
+    await loadStore(vaultDir);
+    setNoteChunks(vaultDir, "projects/alpha.md", hashText("a"), [
+      { notePath: "projects/alpha.md", chunkIndex: 1, headingPath: [], text: "p", hash: "h", vector: [1, 0] },
+    ], "test", "m");
+    setNoteChunks(vaultDir, "archive/beta.md", hashText("b"), [
+      { notePath: "archive/beta.md", chunkIndex: 1, headingPath: [], text: "a", hash: "h", vector: [1, 0] },
+    ], "test", "m");
+
+    const projects = searchEmbeddings(vaultDir, [1, 0], {
+      limit: 5,
+      folder: "./projects/./",
+    });
+    expect(projects.map((h) => h.notePath)).toEqual(["projects/alpha.md"]);
+
+    const archive = searchEmbeddings(vaultDir, [1, 0], {
+      limit: 5,
+      folder: "projects/../archive",
+    });
+    expect(archive.map((h) => h.notePath)).toEqual(["archive/beta.md"]);
+  });
+
   it("excludes the source note when find-similar passes excludeNotes", async () => {
     await loadStore(vaultDir);
     setNoteChunks(vaultDir, "self.md", hashText("s"), [

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -521,6 +521,16 @@ export interface SearchOptions {
   filterNote?: (notePath: string) => boolean;
 }
 
+function normalizeSearchFolder(folder: string | undefined): string | null {
+  if (!folder) return null;
+  const slashed = folder.trim().replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+  if (!slashed) return null;
+  const normalized = path.posix.normalize(slashed).replace(/^\/+|\/+$/g, "");
+  if (normalized === "." || normalized === "") return null;
+  if (normalized === ".." || normalized.startsWith("../")) return slashed;
+  return normalized;
+}
+
 export function searchEmbeddings(
   vaultPath: string,
   queryVector: number[],
@@ -528,9 +538,7 @@ export function searchEmbeddings(
 ): SearchHit[] {
   const state = stateFor(vaultPath);
   const limit = options.limit ?? 10;
-  const folder = options.folder
-    ? options.folder.replace(/^\/+|\/+$/g, "")
-    : null;
+  const folder = normalizeSearchFolder(options.folder);
   const exclude = options.excludeNotes ?? null;
   const filterNote = options.filterNote ?? null;
 


### PR DESCRIPTION
Semantic search folder filters now canonicalize slashes and dot segments before matching stored note paths. Searches scoped to folders such as ./projects/./ and projects/../archive now match the same stored notes as their canonical folder names.\n\nRisk: low. Above-root folder spellings still do not broaden the search, and matching remains case-sensitive against stored vault-relative paths.\n\nScore: 2 severity x 2 reach / 1 effort = 4. Folder-scoped semantic search is user-facing correctness, and the change is confined to the stored-index filter.\n\nTests: reproduced with a failing regression in src/__tests__/embedding-store.test.ts before the fix; ran npm test -- --run src/__tests__/embedding-store.test.ts; ran npm test -- --run src/__tests__/embedding-store.test.ts src/__tests__/handlers/semantic.test.ts src/__tests__/regression-tools-semantic.test.ts src/__tests__/regression-embedding-fixes.test.ts; ran npm run verify.