### PR TITLE
fix: normalize daily note folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Base `file.inFolder()` filters now normalize slash and dot segments in folder arguments before matching note paths.
 - Trash deletes now use no-replace semantics for the selected `.trash` destination, preventing races from overwriting a newly created trashed file.
 - Semantic search folder filters now normalize slash and dot segments before matching stored note paths.
+- Daily-note folder settings now normalize slash and dot segments before building tool and resource paths.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -114,4 +114,24 @@ describe("getDailyNoteConfig", () => {
       format: "YYYY-MM-DD",
     });
   });
+
+  it("normalizes dot segments in daily-note folder config", async () => {
+    await writeDailyConfig(JSON.stringify({
+      folder: "./daily/../journal/./",
+      format: "YYYY-MM-DD",
+    }));
+
+    const config = await getDailyNoteConfig(vaultDir);
+    expect(config.folder).toBe("journal");
+  });
+
+  it("does not turn above-root daily-note folders into vault-root access", async () => {
+    await writeDailyConfig(JSON.stringify({
+      folder: "daily/../../outside",
+      format: "YYYY-MM-DD",
+    }));
+
+    const config = await getDailyNoteConfig(vaultDir);
+    expect(config.folder).toBe("daily/../../outside");
+  });
 });

--- a/src/__tests__/handlers/read.test.ts
+++ b/src/__tests__/handlers/read.test.ts
@@ -559,6 +559,24 @@ describe("read handlers — get_daily_note", () => {
     expect(content._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("get_daily_note expected path");
   });
 
+  it("reports canonical paths when configured daily-note folders contain dot segments", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "./daily/./", format: "YYYY-MM-DD" }),
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "get_daily_note",
+      arguments: { date: "2026-04-24" },
+    });
+
+    const text = textContent(result);
+    expect(isError(result)).toBe(false);
+    expect(text).toContain("Path: daily/2026-04-24.md");
+    expect(text).not.toContain("./daily/./2026-04-24.md");
+  });
+
   it("escapes generated daily-note frontmatter labels", async () => {
     const dirtyKey = "daily\x7fkey";
     const dirtyValue = "daily\x7fvalue";

--- a/src/__tests__/handlers/resources.test.ts
+++ b/src/__tests__/handlers/resources.test.ts
@@ -171,4 +171,22 @@ describe("MCP resources", () => {
     expect(message).toContain("daily\\nnotes/");
     expect(message).not.toContain(dirtyFolder);
   });
+
+  it("reports canonical missing daily resource paths for dot-segment folders", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "./missing/./", format: "YYYY-MM-DD" }),
+    );
+
+    let message = "";
+    try {
+      await env.client.readResource({ uri: "obsidian://daily" });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(message).toContain("[BEGIN UNTRUSTED VAULT CONTENT: daily note resource expected path]");
+    expect(message).toContain("missing/");
+    expect(message).not.toContain("./missing/./");
+  });
 });

--- a/src/__tests__/handlers/write.test.ts
+++ b/src/__tests__/handlers/write.test.ts
@@ -325,6 +325,27 @@ describe("write handlers — create_daily_note", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("reports canonical paths when configured daily-note folders contain dot segments", async () => {
+    await fs.writeFile(
+      path.join(env.vaultDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "daily/../journal/./", format: "YYYY-MM-DD" }),
+      "utf-8",
+    );
+
+    const result = await env.client.callTool({
+      name: "create_daily_note",
+      arguments: { date: "2026-05-09", content: "May 9 entry." },
+    });
+
+    expect(isError(result)).toBe(false);
+    const text = textContent(result);
+    expect(text).toContain("journal/2026-05-09.md");
+    expect(text).not.toContain("daily/../journal/./2026-05-09.md");
+    await expect(
+      fs.access(path.join(env.vaultDir, "journal", "2026-05-09.md")),
+    ).resolves.toBeUndefined();
+  });
+
   it("marks configured daily-note paths in already-exists output as untrusted", async () => {
     const dirtyFolder = "daily\x7fnotes";
     await fs.writeFile(

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,17 @@ function boundedDailyConfigString(value: unknown): string | undefined {
   return value;
 }
 
+function normalizeDailyNoteFolder(folder: string | undefined): string | undefined {
+  if (folder === undefined) return undefined;
+  const slashed = folder.replace(/\/+$/g, "");
+  if (slashed === "") return "";
+  if (slashed.startsWith("/")) return folder;
+  const normalized = path.posix.normalize(slashed).replace(/\/+$/g, "");
+  if (normalized === ".") return "";
+  if (normalized === ".." || normalized.startsWith("../")) return slashed;
+  return normalized;
+}
+
 function isValidVaultPath(vaultPath: string): boolean {
   try {
     const obsidianDir = path.join(vaultPath, ".obsidian");
@@ -269,7 +280,7 @@ export async function getDailyNoteConfig(vaultPath?: string): Promise<DailyNoteC
   try {
     const parsed: unknown = JSON.parse(raw);
     if (!isPlainObject(parsed)) return defaults;
-    const folder = boundedDailyConfigString(parsed.folder);
+    const folder = normalizeDailyNoteFolder(boundedDailyConfigString(parsed.folder));
     const format = boundedDailyConfigString(parsed.format);
     const template = boundedDailyConfigString(parsed.template);
     return {


### PR DESCRIPTION
Normalize daily-note folder config before tool and resource paths are built, so settings like ./daily/./ and daily/../journal report canonical vault-relative paths while above-root values keep failing at the vault boundary.

Risk: low; this is a shared config-reader cleanup for existing daily-note paths. Score: 2 severity x 2 reach / 1 effort = 4.

Tested: npm test -- --run src/__tests__/config.test.ts src/__tests__/handlers/read.test.ts src/__tests__/handlers/write.test.ts src/__tests__/handlers/resources.test.ts; npm test -- --run src/__tests__/config.test.ts src/__tests__/handlers/read.test.ts src/__tests__/handlers/write.test.ts src/__tests__/handlers/resources.test.ts src/__tests__/regression-tools-write.test.ts src/__tests__/regression-dates.test.ts; npm run verify.