### PR TITLE
test: run vitest with one worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Trash deletes now use no-replace semantics for the selected `.trash` destination, preventing races from overwriting a newly created trashed file.
 - Semantic search folder filters now normalize slash and dot segments before matching stored note paths.
 - Daily-note folder settings now normalize slash and dot segments before building tool and resource paths.
+- Local verification now runs Vitest with one worker by default to avoid fork-worker OOM/spawn failures on busy Windows hosts.
 - Embedding provider setup now treats blank provider, model, and base-URL env vars as unset, so documented defaults still apply in empty shell or dotenv entries.
 - Embedding snapshot loading now ignores malformed dimensions and malformed entry fields before rehydrating the semantic index.
 - OpenAI embedding responses now reject missing, duplicate, or out-of-range row indexes before vectors are paired with input chunks.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    maxWorkers: 1,
     testTimeout: 30000,
     include: ["src/__tests__/**/*.test.ts"],
   },


### PR DESCRIPTION
Default Vitest to one worker so local verification does not trip over fork-worker OOM/spawn failures on busy Windows hosts. The suite still supports overriding workers through Vitest CLI/env settings when a runner has more headroom.

Risk: low; this slows the test phase but leaves test coverage and package behavior unchanged. Score: 2 severity x 1 reach / 1 effort = 2.

Tested: npm run lint; npm run verify.