### PR TITLE
Fix vault traversal, atomic-read retry, and frontmatter YAML audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Vault path validation now rejects Windows-style `..\\` traversal separators on every platform before POSIX path resolution.
+- Frontmatter parsing now uses the direct `js-yaml` dependency instead of `gray-matter`, removing the vulnerable transitive `js-yaml` 3.x path reported by `npm audit`.
+- Concurrent atomic-read validation now retries through short rename churn instead of surfacing transient `Path changed during validation` errors.
 - OpenAI embedding setup now treats blank `OBSIDIAN_EMBEDDING_API_KEY` values as unset, falling back to `OPENAI_API_KEY` when present instead of sending a whitespace bearer token.
 - Permission allowlist folders now normalize config-side dot segments, so entries such as `./projects` and `archive/./logs` match their intended vault folders.
 - Folder-scoped `list_notes` calls now return canonical note paths when the folder argument contains `.` or `..` segments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "gray-matter": "^4.0.3",
         "js-yaml": "^4.2.0",
         "zod": "^4.4.3"
       },
@@ -439,9 +438,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -459,9 +455,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -479,9 +472,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -499,9 +489,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -519,9 +506,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -539,9 +523,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1561,19 +1542,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -1729,18 +1697,6 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
-      }
-    },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1973,43 +1929,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gray-matter": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/gray-matter/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -2123,15 +2042,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2232,15 +2142,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/levn": {
@@ -2400,9 +2301,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2424,9 +2322,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2448,9 +2343,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2472,9 +2364,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3011,19 +2900,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/section-matter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
-      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/semver": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
@@ -3198,12 +3074,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3226,15 +3096,6 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/strip-bom-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "gray-matter": "^4.0.3",
     "js-yaml": "^4.2.0",
     "zod": "^4.4.3"
   },

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,15 +1,14 @@
-import matter from "gray-matter";
+import yaml from "js-yaml";
 import path from "path";
 import type { NoteMetadata, LinkInfo } from "../types.js";
 import { hasYamlAnchorOrAliasToken } from "./yaml.js";
 
 const MAX_FRONTMATTER_BYTES = 262_144;
-const YAML_MATTER_OPTIONS = { language: "yaml" };
 
 type FrontmatterScan =
   | { kind: "none" }
   | { kind: "oversized"; bytes?: number }
-  | { kind: "found"; bytes: number; yaml: string };
+  | { kind: "found"; bytes: number; yaml: string; contentStart: number };
 
 export interface ParsedFrontmatter {
   data: Record<string, unknown>;
@@ -51,7 +50,7 @@ function scanYamlFrontmatter(content: string): FrontmatterScan {
       if (bytes > MAX_FRONTMATTER_BYTES) {
         return { kind: "oversized", bytes };
       }
-      return { kind: "found", bytes, yaml };
+      return { kind: "found", bytes, yaml, contentStart: lineEnd === -1 ? content.length : lineEnd + 1 };
     }
 
     if (lineEnd === -1) return { kind: "none" };
@@ -70,7 +69,7 @@ function asFrontmatterObject(value: unknown): Record<string, unknown> {
 
 /**
  * Parse only Obsidian-style YAML frontmatter: an opening `---` line, a
- * closing `---` line, and no gray-matter language auto-detection. This keeps
+ * closing `---` line, and no language auto-detection. This keeps
  * `---js` and similar blocks as body text instead of invoking non-YAML
  * engines while still preserving tolerant read behavior for vault scans.
  */
@@ -100,10 +99,10 @@ export function parseStrictYamlFrontmatter(content: string): ParsedFrontmatter {
   }
 
   try {
-    const result = matter(content, YAML_MATTER_OPTIONS);
+    const data = scan.yaml.trim() === "" ? {} : yaml.load(scan.yaml, { json: true });
     return {
-      data: asFrontmatterObject(result.data),
-      content: result.content,
+      data: asFrontmatterObject(data),
+      content: content.slice(scan.contentStart),
       hasFrontmatter: true,
       bytes: scan.bytes,
     };
@@ -134,27 +133,18 @@ function parseFrontmatterForMutation(content: string): ParsedFrontmatter {
   return parsed;
 }
 
-function quoteWikilinksInDocumentFrontmatter(stringified: string): string {
-  // gray-matter emits `---\n<yaml>---\n<body>`. Find the two delimiter lines
-  // and post-process only the YAML region.
-  if (!stringified.startsWith("---\n")) return stringified;
-  const closeIdx = stringified.indexOf("\n---", 4);
-  if (closeIdx === -1) return stringified;
-  const yamlBlock = stringified.slice(4, closeIdx + 1); // include trailing \n
-  const fixed = quoteWikilinksInFrontmatter(yamlBlock);
-  return `---\n${fixed}${stringified.slice(closeIdx + 1)}`;
-}
-
 export function stringifyYamlFrontmatter(
   content: string,
   data: Record<string, unknown>,
 ): string {
-  const stringified = matter.stringify(
-    { content },
-    data,
-    YAML_MATTER_OPTIONS,
-  );
-  return quoteWikilinksInDocumentFrontmatter(stringified);
+  const yamlBlock = yaml.dump(data, {
+    lineWidth: -1,
+    noRefs: true,
+    sortKeys: false,
+  });
+  const fixed = quoteWikilinksInFrontmatter(yamlBlock);
+  const body = content.endsWith("\n") ? content : `${content}\n`;
+  return `---\n${fixed}---\n${body}`;
 }
 
 /**

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -124,6 +124,13 @@ function rejectWindowsAlternateDataStreams(relativePath: string): void {
   }
 }
 
+function rejectWindowsTraversalSeparators(relativePath: string): void {
+  const normalized = path.win32.normalize(relativePath);
+  if (normalized === ".." || normalized.startsWith(`..${path.win32.sep}`)) {
+    throw new Error(`Path traversal detected: ${relativePath}`);
+  }
+}
+
 function rejectWindowsTrailingDotOrSpace(relativePath: string): void {
   if (!IS_WIN32) return;
   const badSegment = relativePath
@@ -352,6 +359,7 @@ export function resolveVaultPath(
       `Invalid path: must be vault-relative, not absolute (${relativePath})`,
     );
   }
+  rejectWindowsTraversalSeparators(relativePath);
   rejectWindowsAlternateDataStreams(relativePath);
   rejectWindowsTrailingDotOrSpace(relativePath);
   assertAllowed(relativePath, access);
@@ -500,7 +508,7 @@ async function openResolvedVaultFileForRead(
   access: AccessKind | null,
   options?: { realVaultRoot?: string },
 ): Promise<ValidatedVaultFile> {
-  for (let attempt = 0; attempt < 2; attempt++) {
+  for (let attempt = 0; attempt < 64; attempt++) {
     let handle: FileHandle | undefined;
     try {
       handle = await fs.open(fullPath, "r");
@@ -523,8 +531,8 @@ async function openResolvedVaultFileForRead(
 
       await handle.close();
       handle = undefined;
-      if (attempt === 0) continue;
-      throw new Error(`Path changed during validation: ${relativePath}`);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      continue;
     } catch (err) {
       await handle?.close();
       throw err;
@@ -582,6 +590,7 @@ export async function resolveVaultInternalPathSafe(
       `Invalid path: must be vault-relative, not absolute (${relativePath})`,
     );
   }
+  rejectWindowsTraversalSeparators(relativePath);
   rejectWindowsAlternateDataStreams(relativePath);
   const resolved = path.resolve(vaultPath, relativePath);
   const resolvedVault = path.resolve(vaultPath);


### PR DESCRIPTION
### Motivation
- Close a path-traversal regression where Windows-style `..\` separators could bypass the vault prefix check. 
- Avoid transient `Path changed during validation` failures observed under concurrent atomic writes. 
- Remove a vulnerable transitive `js-yaml` 3.x install reported by `npm audit` by switching off `gray-matter` to the direct `js-yaml` usage.

### Description
- Add `rejectWindowsTraversalSeparators(relativePath)` and call it from `resolveVaultPath` and `resolveVaultInternalPathSafe` to reject Windows-style `..\` traversal before POSIX resolution (file: `src/lib/vault.ts`).
- Make `openResolvedVaultFileForRead` resilient to short rename churn by retrying the validation loop (increase attempts and add a short `setTimeout` between retries) instead of immediately throwing on a transient mismatch (file: `src/lib/vault.ts`).
- Replace `gray-matter` usage with direct `js-yaml` parsing/emitting in frontmatter code paths, preserving Obsidian-style frontmatter semantics and the wikilink quoting post-processing; adjust parsing to return a body offset so mutation paths remain correct (file: `src/lib/markdown.ts`).
- Remove `gray-matter` from `package.json` dependencies and update the lockfile accordingly. 
- Update `CHANGELOG.md` to record the audit and correctness fixes.

### Testing
- Ran `npm run verify` (lint, typecheck, `vitest`, build, `npm audit --audit-level=moderate`, `npm run pack:check`), which completed successfully. 
- Unit test suite via `vitest` ran as part of `npm run verify`; the test run passed (all tests green with the expected skipped set). 
- `npm audit` shows the prior transitive `js-yaml` 3.x finding removed after eliminating `gray-matter` (no moderate vulnerabilities reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3140dcc9ac832e88ac2faf65ea4204)