### PR TITLE
fix(deps): bump hono to 4.12.26 to fix serve-static path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Global Obsidian config auto-detection now ignores non-file or oversized `obsidian.json` files before parsing, preventing startup from spending unbounded memory on malformed local config data.
 - The `install` command now rejects existing client config files whose JSON root or `mcpServers` field is not an object, instead of crashing or reporting success without writing the server entry.
 
+### Security
+
+- Bumped the transitively-resolved `hono` dependency to 4.12.26 (from 4.12.23), clearing the high-severity `npm audit` advisory GHSA-wwfh-h76j-fc44 (Windows `serve-static` path traversal via encoded backslash) and related findings. The bump stayed within `@modelcontextprotocol/sdk`'s existing dependency range, so no direct dependency changed.
+
 ## [4.0.0] - 2026-06-07
 
 ### Migration

--- a/package-lock.json
+++ b/package-lock.json
@@ -2035,9 +2035,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## What

Bumps the transitively-resolved `hono` from 4.12.23 to 4.12.26 (lockfile only).

## Why

`npm audit` flags `hono` 4.12.23 as high severity: GHSA-wwfh-h76j-fc44 (path traversal in `serve-static` on Windows via an encoded backslash `%5C`), plus related advisories. The patched line is 4.12.25+.

## How

`hono` is a transitive dependency via `@modelcontextprotocol/sdk`, whose declared range is `hono ^4.11.4` and already permits the patched release. `npm audit fix` (no `--force`) resolved it within range, so no direct dependency or SDK version changed. Only `package-lock.json` moved.

## Verification

- lint, typecheck, all 952 tests, and build pass.
- `npm audit --audit-level=high` is clean (the hono advisory is gone).

Two moderate `js-yaml` 3.x advisories remain on this branch; they come from `gray-matter` and are removed by the sibling PR #222 (`rps/swap-gray-matter-for-js-yaml`). `npm audit` is fully clean once both land.