### PR TITLE
chore(health): fallow scan cleanup + triage PR-surface flag

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,5 +1,7 @@
 {
   "health": {
     "ignore": ["scripts/**", "src/__tests__/**"]
-  }
+  },
+  "ignorePatterns": ["scripts/**"],
+  "ignoreExportsUsedInFile": true
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ maintenance loop or publish releases.
 
 ### Issue tracker
 
-Issues are tracked in GitHub Issues; external pull requests are not a triage
+Issues are tracked in GitHub Issues; external pull requests are also a triage
 surface. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -15,7 +15,7 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 
 ## Pull requests as a triage surface
 
-**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+**PRs as a request surface: yes.** _(Set to `no` if this repo should not treat external PRs as feature requests; `/triage` reads this flag.)_
 
 When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
 

--- a/src/tools/bases.ts
+++ b/src/tools/bases.ts
@@ -2,7 +2,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerListBases } from "./bases/list-bases.js";
 import { registerReadBase } from "./bases/read-base.js";
 import { registerQueryBase } from "./bases/query-base.js";
-export { textResult, untrustedTextResult, errorResult, displayBaseValue, untrustedBaseBlock } from "./bases/shared.js";
 
 export function registerBaseTools(server: McpServer, vaultPath: string): void {
   registerListBases(server, vaultPath);

--- a/src/tools/read/shared.ts
+++ b/src/tools/read/shared.ts
@@ -1,4 +1,8 @@
-import { formatUntrustedVaultContent, indentBlock, untrustedTextContent, untrustedVaultContentMeta } from "../../lib/tool-output.js";
+import {
+  formatUntrustedVaultContent,
+  indentBlock,
+  untrustedTextContent,
+} from "../../lib/tool-output.js";
 import { escapeControlChars } from "../../lib/errors.js";
 
 export function displayReadValue(value: string): string {
@@ -7,18 +11,24 @@ export function displayReadValue(value: string): string {
 
 export function errorResult(text: string, meta?: Record<string, unknown>) {
   return {
-    content: [{ type: "text" as const, text, ...(meta ? { _meta: meta } : {}) }],
+    content: [
+      { type: "text" as const, text, ...(meta ? { _meta: meta } : {}) },
+    ],
     isError: true as const,
   };
 }
 
-export function untrustedReadBlock(label: string, text: string, indent = ""): string {
+export function untrustedReadBlock(
+  label: string,
+  text: string,
+  indent = ""
+): string {
   return indentBlock(formatUntrustedVaultContent(label, text), indent);
 }
 
 export function frontmatterValueForProperty(
   data: Record<string, unknown>,
-  property: string,
+  property: string
 ): unknown {
   if (Object.prototype.hasOwnProperty.call(data, property)) {
     return data[property];
@@ -36,7 +46,9 @@ export function parseRequestedLine(value: string): number | null {
   return Math.max(1, line);
 }
 
-export function parseRequestedLineRange(value: string): { start: number; end: number } | null {
+export function parseRequestedLineRange(
+  value: string
+): { start: number; end: number } | null {
   const m = /^(\d+)(?:-(\d+))?$/.exec(value);
   if (!m) return null;
   const [, startText, endText] = m;
@@ -50,7 +62,11 @@ export function parseRequestedLineRange(value: string): { start: number; end: nu
 export function toSearchableString(value: unknown): string {
   if (value === null || value === undefined) return "";
   if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
     return String(value);
   }
   try {
@@ -73,7 +89,8 @@ export function parseSince(input: string): number | null {
   if (rel) {
     const n = Number(rel[1]);
     const unit = rel[2]!.toLowerCase();
-    const ms = unit === "h" ? 3600_000 : unit === "d" ? 86_400_000 : 7 * 86_400_000;
+    const ms =
+      unit === "h" ? 3600_000 : unit === "d" ? 86_400_000 : 7 * 86_400_000;
     return Date.now() - n * ms;
   }
   // ISO date: YYYY-MM-DD or full timestamp.
@@ -82,4 +99,4 @@ export function parseSince(input: string): number | null {
   return null;
 }
 
-export { untrustedTextContent, untrustedVaultContentMeta, formatUntrustedVaultContent, indentBlock };
+export { untrustedTextContent };


### PR DESCRIPTION
## Summary

Codebase-health cleanup from a fallow scan, plus a triage-config flag flip. Two independent commits.

### `chore(health)`: scope fallow off scripts, prune dead re-exports

The scan's raw numbers were mostly noise. Root cause: the `scripts/**` ignore was scoped to the `health` command only, so `dead-code` and `dupes` still scanned the 28 `bench-*.mjs` scripts — reporting them as "unused files" and counting their copy-pasted boilerplate as 14% duplication.

- Add top-level `ignorePatterns: ["scripts/**"]` → 28 false unused-files → 0; duplication drops to benign test-setup boilerplate.
- Set `ignoreExportsUsedInFile: true` → silences 23 exports that are used only within their own file (a benign pattern, not dead code).
- That isolated **8 genuinely dead pass-through re-exports** left over from the earlier per-tool split: `tools/bases.ts` and `tools/read/shared.ts` re-exported symbols every consumer imports from `lib/` directly. Removed.

`fallow dead-code`: **64 issues → 1** (the remaining one is the `vault.ts` ↔ `link-rewriter.ts` cycle, tracked separately in #230).

### `docs(agents)`: treat external PRs as a triage surface

Flip the PRs-as-request-surface flag to `yes` so `/triage` pulls external (non-collaborator) PRs into the same queue and labels as issues.

## Verification

- `tsc --noEmit`: pass
- `vitest run`: **970 passed**, 15 skipped, 50 files
- pre-commit hooks (prettier + lint-staged): pass

## Not included

The `vault.ts` decomposition that breaks the remaining cycle is planned separately as wayfinder map #230 (tickets #231–#237).
