### PR TITLE
refactor(tools): add tool seam and migrate read group through it

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,77 @@
+# Domain glossary
+
+The ubiquitous language of obsidian-mcp-pro: the nouns the code, tests, and docs
+should all use for the same thing. This is the domain vocabulary; architectural
+vocabulary (module, interface, seam, depth) lives in the design notes, not here.
+Grow this file lazily as terms are named or sharpened.
+
+## Vault and notes
+
+**Vault**: the Obsidian vault this server is bound to, resolved once at startup
+from `OBSIDIAN_VAULT_PATH` or the Obsidian config. Every path a tool touches is
+validated relative to the vault root.
+
+**Note**: a Markdown file (`.md`) inside the vault. The unit most tools read and
+write.
+
+**Frontmatter**: the YAML mapping at the top of a note, between `---` fences.
+Parsed strictly (anchors and aliases are rejected).
+
+**Section**: the body under a heading, addressed by a heading path such as
+`Tasks/Today`. A section ends at the next heading of any depth.
+
+**Block**: a paragraph or element tagged with a `^id` reference, addressable on
+its own.
+
+**Tag**: an inline `#tag` in the body or a `tags` entry in frontmatter.
+Hierarchical (`#area/subarea`).
+
+## Links
+
+**Wikilink**: an Obsidian `[[target]]` reference. Resolution follows Obsidian's
+own four-step rule with a proximity tie-break.
+
+**Backlink / Outlink**: a link pointing at a note (backlink) versus a link a note
+points out to (outlink).
+
+**Orphan**: a note with no backlinks. **Broken link**: a wikilink whose target
+does not resolve anywhere in the vault.
+
+## Other file types
+
+**Canvas**: an Obsidian `.canvas` file: a JSON graph of nodes and edges.
+
+**Base**: an Obsidian `.base` file: a saved query/view over notes, with its own
+filter language.
+
+**Attachment**: a non-text file in the vault (image, audio, PDF, and so on),
+served as bytes rather than parsed as text.
+
+**Daily Note**: the note for a given day, located and named per the vault's
+`daily-notes` configuration.
+
+## Retrieval
+
+**Semantic index**: the persisted store of note embeddings that powers
+`search_semantic` and `find_similar_notes`.
+
+**Chunk**: a heading-aware slice of a note that gets embedded as one vector.
+
+**Embedding provider**: the external service that turns chunk text into vectors
+(Ollama by default, OpenAI optional). Swappable behind one interface.
+
+## Tools and trust
+
+**Tool**: one callable MCP operation (there are 41). **Tool group**: a family of
+related tools (read, write, tags, links, canvas, sections, bases, attachments,
+semantic) registered together.
+
+**Untrusted vault content**: any vault-derived text surfaced to the model. It is
+wrapped in explicit BEGIN/END markers and tagged with trust metadata so the model
+treats it as data, never as instructions. This is the vault's prompt-injection
+trust boundary: the dividing line between text the server authored (trusted) and
+text that came out of the vault (untrusted).
+
+**Permission allowlist**: the optional `OBSIDIAN_READ_PATHS` / `OBSIDIAN_WRITE_PATHS`
+folders that scope what tools may read or modify. Enforced at a single choke point
+when a path is resolved.

--- a/docs/TOOL_AUTHORING.md
+++ b/docs/TOOL_AUTHORING.md
@@ -40,13 +40,13 @@ C-grade even if the schema is perfect (empirically: 2.9–3.5/5).
 
 A complete description answers **five questions**, in roughly this order:
 
-| Question | Example from `find_broken_links` |
-|---|---|
-| **What does it do?** | "Scan notes for wikilinks whose target does not resolve" |
-| **What's in the return value?** | "Returns a per-source report grouping each note with its broken link text and line numbers, plus a total count" |
-| **When should you reach for it?** | "Use after renaming, moving, or deleting notes to catch dangling references" |
-| **Any important edge cases?** | "Resolution uses the whole vault even when scanning a single folder" |
-| **Cross-references to related tools?** | (implicit — mentions renaming/moving/deleting workflows) |
+| Question                               | Example from `find_broken_links`                                                                                |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| **What does it do?**                   | "Scan notes for wikilinks whose target does not resolve"                                                        |
+| **What's in the return value?**        | "Returns a per-source report grouping each note with its broken link text and line numbers, plus a total count" |
+| **When should you reach for it?**      | "Use after renaming, moving, or deleting notes to catch dangling references"                                    |
+| **Any important edge cases?**          | "Resolution uses the whole vault even when scanning a single folder"                                            |
+| **Cross-references to related tools?** | (implicit — mentions renaming/moving/deleting workflows)                                                        |
 
 ### Good description template
 
@@ -74,23 +74,23 @@ Every tool gets an `annotations` object. The flags are **hints** — MCP
 clients may use them to surface confirmation UIs, cache results, or
 reorder calls.
 
-| Flag | Meaning | When `true` |
-|---|---|---|
-| `readOnlyHint` | Does not modify any state | Tool only reads the vault |
-| `destructiveHint` | May destroy or overwrite user data | `delete_note`, `move_note`, `update_frontmatter` (overwrites keys) |
-| `idempotentHint` | Calling N times ≡ calling once (same args → same final state) | All read-only tools; also `update_frontmatter` |
-| `openWorldHint` | Interacts with external systems (network, shell, APIs) | Always `false` in this server (local filesystem only) |
+| Flag              | Meaning                                                       | When `true`                                                        |
+| ----------------- | ------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `readOnlyHint`    | Does not modify any state                                     | Tool only reads the vault                                          |
+| `destructiveHint` | May destroy or overwrite user data                            | `delete_note`, `move_note`, `update_frontmatter` (overwrites keys) |
+| `idempotentHint`  | Calling N times ≡ calling once (same args → same final state) | All read-only tools; also `update_frontmatter`                     |
+| `openWorldHint`   | Interacts with external systems (network, shell, APIs)        | Always `false` in this server (local filesystem only)              |
 
 ### Decision matrix for this server's tools
 
-| Category | readOnly | destructive | idempotent |
-|---|---|---|---|
-| `get_*`, `list_*`, `search_*`, `read_*`, `find_*` | `true` | (omit) | `true` |
-| `create_*` | `false` | `false` | `false` (fails on second call) |
-| `append_*`, `prepend_*` | `false` | `false` | `false` (content grows each call) |
-| `update_frontmatter` | `false` | `true` | `true` (same payload → same state) |
-| `move_note`, `delete_note` | `false` | `true` | `false` (source no longer exists) |
-| `add_canvas_node`, `add_canvas_edge` | `false` | `false` | `false` (new UUID each call) |
+| Category                                          | readOnly | destructive | idempotent                         |
+| ------------------------------------------------- | -------- | ----------- | ---------------------------------- |
+| `get_*`, `list_*`, `search_*`, `read_*`, `find_*` | `true`   | (omit)      | `true`                             |
+| `create_*`                                        | `false`  | `false`     | `false` (fails on second call)     |
+| `append_*`, `prepend_*`                           | `false`  | `false`     | `false` (content grows each call)  |
+| `update_frontmatter`                              | `false`  | `true`      | `true` (same payload → same state) |
+| `move_note`, `delete_note`                        | `false`  | `true`      | `false` (source no longer exists)  |
+| `add_canvas_node`, `add_canvas_edge`              | `false`  | `false`     | `false` (new UUID each call)       |
 
 ### Subtle choices to watch for
 
@@ -124,14 +124,14 @@ folder: z
 
 ### Add every applicable constraint
 
-| Constraint | Use it for |
-|---|---|
-| `.min(1)` | Required non-empty strings (paths, queries, ids) |
-| `.int()` | Integer counts (`maxResults`, `depth`, `width`, `height`) |
-| `.min(N).max(M)` | Numeric bounds with clear rationale (e.g. depth 1–5) |
-| `.enum([...])` | Finite choice sets (`sortBy`, `direction`, node `type`) |
-| `.regex(/pattern/, "message")` | Structured strings (e.g., `YYYY-MM-DD` dates) |
-| `.optional().default(X)` | Optional with a sensible fallback |
+| Constraint                     | Use it for                                                |
+| ------------------------------ | --------------------------------------------------------- |
+| `.min(1)`                      | Required non-empty strings (paths, queries, ids)          |
+| `.int()`                       | Integer counts (`maxResults`, `depth`, `width`, `height`) |
+| `.min(N).max(M)`               | Numeric bounds with clear rationale (e.g. depth 1–5)      |
+| `.enum([...])`                 | Finite choice sets (`sortBy`, `direction`, node `type`)   |
+| `.regex(/pattern/, "message")` | Structured strings (e.g., `YYYY-MM-DD` dates)             |
+| `.optional().default(X)`       | Optional with a sensible fallback                         |
 
 ### Parameter description template
 
@@ -160,6 +160,13 @@ All four things are there: range, default, semantics, tradeoff.
 ---
 
 ## § 4 — Handler conventions
+
+> **Migration in progress (ADR 0001).** The `read` group now registers through
+> the tool seam (`src/lib/tool-seam.ts`): handlers return a `ToolResult` built
+> via `text` / `untrustedText` / `richText` / `error`, and the seam owns error
+> sanitization and untrusted-content wrapping. When editing a seam-migrated
+> group, follow that pattern, **not** the per-file recipe below. The recipe
+> still describes the 8 groups not yet migrated. See `docs/adr/0001-tool-seam.md`.
 
 Keep handlers thin. The scorer doesn't see handler code, but reviewers do:
 

--- a/docs/adr/0001-tool-seam.md
+++ b/docs/adr/0001-tool-seam.md
@@ -80,14 +80,15 @@ Non-text blocks (to be added when the attachments/canvas groups migrate;
 
 ## Consequences
 
-- Trust-wrapping and error sanitization become choke points. `add_canvas_edge`'s
-  raw-`err.message` leak is fixed once, at the seam.
+- Trust-wrapping and error sanitization become choke points. The seam is where
+  `add_canvas_edge`'s raw-`err.message` leak gets fixed once — when the canvas
+  group migrates through it. This change migrates only the read group, so that
+  leak is still open (see Migration).
 - Output is **byte-preserving**. The seam reuses the existing `tool-output.ts`
   primitives, so every `regression-tools-*` and `handlers/*` interface test
-  stays green unchanged. Two intentional exceptions are recorded:
-  1. `add_canvas_edge` inner catches are now sanitized.
-  2. The generic thrown-error prefix replaces per-tool verbs (thrown path only;
-     no test pins the wording).
+  stays green unchanged. One intentional exception is recorded: the generic
+  thrown-error prefix replaces per-tool verbs (thrown path only; no test pins
+  the wording).
 - `docs/TOOL_AUTHORING.md §4` is superseded: handlers no longer write the recipe.
   The per-tool `title`/`description`/`annotations`/`inputSchema` surface is
   unchanged.
@@ -124,6 +125,7 @@ compiler will not catch mis-threaded `extra`. Verify that plumbing at runtime
 Read group first (this change). Remaining 8 groups are file-disjoint and convert
 independently, deleting each group's duplicated recipe helpers as it goes and
 extending the seam with the non-text block constructors when
-attachments/canvas migrate. Collapsing the 9 `display*Value` aliases to a single
+attachments/canvas migrate. Routing `add_canvas_edge` through the seam closes
+its raw-`err.message` leak as part of the canvas group's conversion. Collapsing the 9 `display*Value` aliases to a single
 `escapeControlChars` import is a follow-up sweep. `TOOL_AUTHORING.md §4` is
 rewritten last, once the pattern is proven across all groups.

--- a/docs/adr/0001-tool-seam.md
+++ b/docs/adr/0001-tool-seam.md
@@ -1,0 +1,129 @@
+# ADR 0001: One deep tool seam behind every MCP tool
+
+- Status: Accepted (read group migrated as the pattern-setter; other 8 groups to follow)
+- Date: 2026-07-18
+
+## Context
+
+The server exposes 41 tools across 9 groups. Each tool lived in its own file
+and re-implemented the same recipe inline:
+
+- a terminal `try/catch` that logged `"<tool> failed"` and returned
+  `errorResult(\`Error <verb>: ${sanitizeError(err)}\`)`, and
+- manual wrapping of every vault-derived string via
+  `formatUntrustedVaultContent` + `untrustedVaultContentMeta`.
+
+The consequences:
+
+- The error boundary was copied 41 times; `errorResult` was defined 9 times,
+  `display*Value` 9 times, the `untrusted*Block` helper 6 times, `textResult`
+  5 times.
+- Two security concerns had **no single choke point**. Error-response
+  sanitization was smeared: `errorResult` takes pre-formatted text and does not
+  sanitize, so any handler writing `errorResult(\`...: ${err}\`)`leaks raw
+paths or secrets. Untrusted-content wrapping was smeared across ~45 call
+sites and applied inconsistently; a new handler returning a plain`{ type: "text", text }` would compile and silently emit vault text as if it
+  were trusted.
+- One real instance already leaked: `add_canvas_edge`'s inner catches returned
+  `err.message` raw, bypassing `sanitizeError`.
+
+By contrast, the **log** channel already sanitizes inside `emit()` (a choke
+point), and permissions enforce at a single point in the vault layer. The
+error-response and trust-wrapping channels were the outliers.
+
+## Decision
+
+Introduce a **tool seam** (`src/lib/tool-seam.ts`): one deep module every tool
+is registered through. `defineTool(server, vaultPath, spec, handler)` owns
+registration, context assembly, the error boundary, and result rendering.
+Handlers become schema plus pure logic that return a `ToolResult` or throw.
+
+### Enforcement by construction
+
+`ToolResult` is a branded type. A raw `{ content: [...] }` literal does not
+satisfy it, so the only way to surface model-readable vault text is through the
+vocabulary's constructors, which wrap it. There is no raw-text escape hatch.
+
+### Result vocabulary (frozen shape)
+
+Text (used by the read group):
+
+- `text(body)` - one trusted, unwrapped text block.
+- `untrustedText(label, body)` - one block that is entirely untrusted vault
+  text; wraps it and attaches the trust `_meta`.
+- `richText(itemTrustLabel, build)` - one block mixing `b.trusted(line)` framing
+  with `b.untrusted(label, body, indent?)` sections; the block-level `_meta` is
+  attached only if at least one untrusted section was appended.
+- `error(message)` - a verbatim, server-authored error block.
+- `asError(result)` - flag a built result as an error (e.g. an error message
+  that carries an untrusted path).
+
+Non-text blocks (to be added when the attachments/canvas groups migrate;
+`get_attachment` is the only multi-type tool): `image`, `audio`, `blobResource`,
+`untrustedResource`. The block taxonomy is closed - no tool uses
+`structuredContent`/`outputSchema`, and every result `_meta` is trust metadata.
+
+### Context
+
+`defineTool` passes `ctx = { vaultPath, server, extra }`. Read handlers use only
+`vaultPath`; elicitation tools use `server`; progress tools use the raw `extra`
+(progress-reporter construction stays a handler concern).
+
+### Error model
+
+- Thrown (unexpected): the seam logs `"<name> failed"` and returns
+  `Error: ${sanitizeError(err)}` - a single **generic** prefix. Sanitization is
+  now always applied.
+- Domain (expected/validation): handler-authored messages via `error` /
+  `asError`, passed through verbatim (already control-char-escaped by the
+  handler); the seam does not re-sanitize them.
+
+## Consequences
+
+- Trust-wrapping and error sanitization become choke points. `add_canvas_edge`'s
+  raw-`err.message` leak is fixed once, at the seam.
+- Output is **byte-preserving**. The seam reuses the existing `tool-output.ts`
+  primitives, so every `regression-tools-*` and `handlers/*` interface test
+  stays green unchanged. Two intentional exceptions are recorded:
+  1. `add_canvas_edge` inner catches are now sanitized.
+  2. The generic thrown-error prefix replaces per-tool verbs (thrown path only;
+     no test pins the wording).
+- `docs/TOOL_AUTHORING.md §4` is superseded: handlers no longer write the recipe.
+  The per-tool `title`/`description`/`annotations`/`inputSchema` surface is
+  unchanged.
+- Trade-off: a shared seam is one more module to trace than a fully
+  self-contained handler file. Accepted because error and trust behaviour is now
+  learned in one place, and that is where correctness lives.
+
+## Verification gates (proven on the read group before fan-out)
+
+1. **Zod arg inference survives.** `defineTool` is generic over the input schema
+   (`InputArgs extends ZodRawShapeCompat`) and types handler `args` as the SDK's
+   own `ShapeOutput<InputArgs>`, so per-tool argument types are preserved and do
+   not degrade to `any`.
+2. **The builder reproduces the hairiest layouts.** Verified against the
+   independent-label case (`search_notes`), conditional `_meta`
+   (`get_vault_stats`, `list_notes`), dynamic item label (`resolve_alias`), and
+   an untrusted-carrying error (`get_daily_note`). The `index_vault`
+   failed-paths block (indented, wrapped, item `_meta`) is expressible via
+   `richText` + `b.untrusted(..., indent)` and will be exercised when the
+   semantic group migrates.
+
+## Note for migrating the semantic/progress group
+
+`defineTool` casts its callback (`cb as unknown as ToolCallback<InputArgs>`)
+because `ToolCallback` is an unreduced conditional over the generic shape. That
+cast disables type-checking at the `extra` boundary. The read group never reads
+`ctx.extra`, so it is inert here — but when the semantic group migrates and
+actually uses `extra.sendNotification` / `extra._meta.progressToken`, the
+compiler will not catch mis-threaded `extra`. Verify that plumbing at runtime
+(a progress-notification test) when converting that group.
+
+## Migration
+
+Read group first (this change). Remaining 8 groups are file-disjoint and convert
+independently, deleting each group's duplicated recipe helpers as it goes and
+extending the seam with the non-text block constructors when
+attachments/canvas migrate. Collapsing the 9 `display*Value` aliases to a single
+`escapeControlChars` import is a follow-up sweep. `TOOL_AUTHORING.md §4` is
+rewritten last, once the pattern is proven across all groups.

--- a/src/__tests__/tool-seam.test.ts
+++ b/src/__tests__/tool-seam.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  asError,
+  defineTool,
+  error,
+  richText,
+  text,
+  untrustedText,
+} from "../lib/tool-seam.js";
+import {
+  formatUntrustedVaultContent,
+  untrustedVaultContentMeta,
+} from "../lib/tool-output.js";
+
+// The seam's ToolResult is the wire shape (CallToolResult) plus a phantom
+// brand; read the fields off it as a plain result for assertions.
+type Item = { type: string; text?: string; _meta?: Record<string, unknown> };
+function firstItem(result: unknown): Item {
+  return (result as CallToolResult).content[0] as Item;
+}
+function flags(result: unknown): { isError?: boolean } {
+  return result as { isError?: boolean };
+}
+
+describe("tool-seam vocabulary", () => {
+  it("text produces a trusted block with no trust _meta", () => {
+    const item = firstItem(text("hello"));
+    expect(item).toEqual({ type: "text", text: "hello" });
+    expect(item._meta).toBeUndefined();
+    expect(flags(text("hello")).isError).toBeUndefined();
+  });
+
+  it("untrustedText wraps the whole body and tags item _meta", () => {
+    const item = firstItem(untrustedText("note body", "vault text"));
+    expect(item.text).toBe(
+      formatUntrustedVaultContent("note body", "vault text")
+    );
+    expect(item._meta).toEqual(untrustedVaultContentMeta("note body"));
+  });
+
+  it("error carries the message verbatim and sets isError", () => {
+    const result = error("Note already exists at 'x.md'.");
+    expect(firstItem(result).text).toBe("Note already exists at 'x.md'.");
+    expect(flags(result).isError).toBe(true);
+    // Domain errors are not re-wrapped as untrusted content.
+    expect(firstItem(result)._meta).toBeUndefined();
+  });
+
+  it("richText joins trusted framing with inline untrusted segments", () => {
+    const result = richText("item label", (b) => {
+      b.trusted("Header:");
+      b.untrusted("seg label", "PATH", "  ");
+    });
+    const item = firstItem(result);
+    expect(item.text).toBe(
+      "Header:\n" +
+        formatUntrustedVaultContent("seg label", "PATH")
+          .split("\n")
+          .map((l) => `  ${l}`)
+          .join("\n")
+    );
+    // Independent labels: the block-level _meta uses the item label, not the
+    // segment label.
+    expect(item._meta).toEqual(untrustedVaultContentMeta("item label"));
+  });
+
+  it("richText omits _meta when no untrusted section is appended", () => {
+    const result = richText("item label", (b) => {
+      b.trusted("Nothing untrusted here.");
+    });
+    expect(firstItem(result)._meta).toBeUndefined();
+  });
+
+  it("asError flags a built (untrusted-carrying) result as an error", () => {
+    const result = asError(
+      richText("expected path", (b) => {
+        b.trusted("Not found.");
+        b.untrusted("expected path", "daily/x.md");
+      })
+    );
+    expect(flags(result).isError).toBe(true);
+    expect(firstItem(result)._meta).toEqual(
+      untrustedVaultContentMeta("expected path")
+    );
+  });
+});
+
+describe("defineTool boundary", () => {
+  async function callThrough(
+    register: (server: McpServer) => void,
+    toolName: string
+  ): Promise<CallToolResult> {
+    const server = new McpServer(
+      { name: "seam-test", version: "0.0.0" },
+      { capabilities: {} }
+    );
+    register(server);
+    const client = new Client({ name: "seam-test-client", version: "0.0.0" });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverT), client.connect(clientT)]);
+    try {
+      return (await client.callTool({
+        name: toolName,
+        arguments: {},
+      })) as CallToolResult;
+    } finally {
+      await client.close();
+    }
+  }
+
+  const baseSpec = {
+    title: "Probe",
+    description: "Test-only tool exercising the seam boundary.",
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {},
+  };
+
+  it("sanitizes thrown errors, applies the generic prefix, and sets isError", async () => {
+    const secretPath = "/Users/secret/vault/private.md";
+    const result = await callThrough((server) => {
+      defineTool(server, "/vault", { name: "boom", ...baseSpec }, () => {
+        throw new Error(`disk exploded at ${secretPath}`);
+      });
+    }, "boom");
+
+    const item = firstItem(result);
+    expect(result.isError).toBe(true);
+    expect(item.text?.startsWith("Error: ")).toBe(true);
+    // The leak is closed: the absolute path must not survive into the response.
+    expect(item.text).not.toContain(secretPath);
+  });
+
+  it("renders an untrusted ToolResult with markers and trust _meta", async () => {
+    const result = await callThrough((server) => {
+      defineTool(server, "/vault", { name: "reads", ...baseSpec }, () =>
+        untrustedText("probe body", "row-one\nrow-two")
+      );
+    }, "reads");
+
+    const item = firstItem(result);
+    expect(item.text).toBe(
+      formatUntrustedVaultContent("probe body", "row-one\nrow-two")
+    );
+    expect(item._meta).toEqual(untrustedVaultContentMeta("probe body"));
+    expect(result.isError).toBeFalsy();
+  });
+});

--- a/src/lib/tool-seam.ts
+++ b/src/lib/tool-seam.ts
@@ -1,0 +1,209 @@
+/**
+ * The tool seam: one deep module every MCP tool is registered through.
+ *
+ * Before this module, all 41 tools re-implemented the same recipe inline: a
+ * terminal `try/catch` that logged and sanitized thrown errors, plus manual
+ * `formatUntrustedVaultContent` / `untrustedVaultContentMeta` wrapping of every
+ * piece of vault-derived text. Two security concerns (error-response
+ * sanitization and untrusted-content trust-wrapping) were smeared across ~45
+ * call sites with no single place enforcing them.
+ *
+ * `defineTool` collapses that recipe into one place. A handler becomes schema
+ * plus pure logic that returns a `ToolResult` (built only via the constructors
+ * below) or throws. The seam owns:
+ *   - registration (the tool's title/description/annotations/inputSchema pass
+ *     through untouched, preserving the per-tool surface third-party scorers
+ *     grade),
+ *   - context assembly (`ctx = { vaultPath, server, extra }`),
+ *   - the terminal error boundary (log + `sanitizeError` on anything thrown),
+ *   - result rendering and untrusted-content wrapping.
+ *
+ * `ToolResult` is a branded type: a raw `{ content: [...] }` literal does not
+ * satisfy it, so the ONLY way to surface model-readable vault text is through
+ * `untrustedText` / `richText(...).untrusted(...)`, which wrap it by
+ * construction. See `docs/adr/0001-tool-seam.md` for the decision record.
+ *
+ * The rendering primitives (`formatUntrustedVaultContent`,
+ * `untrustedVaultContentMeta`, `indentBlock`) still live in `tool-output.ts`;
+ * this seam is now their sole caller from the tool layer.
+ */
+
+import type {
+  McpServer,
+  ToolCallback,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import type {
+  ShapeOutput,
+  ZodRawShapeCompat,
+} from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import type {
+  CallToolResult,
+  ServerNotification,
+  ServerRequest,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import { sanitizeError } from "./errors.js";
+import {
+  formatUntrustedVaultContent,
+  indentBlock,
+  untrustedVaultContentMeta,
+} from "./tool-output.js";
+import { log } from "./logger.js";
+
+/** The request-scoped SDK context handed to every tool handler. */
+export type ToolExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+/**
+ * Everything a handler may reach for beyond its validated `args`. Assembled
+ * once by the seam. Most read handlers use only `vaultPath`; elicitation tools
+ * reach `server`; progress-reporting tools reach `extra`.
+ */
+export interface ToolCtx {
+  vaultPath: string;
+  server: McpServer;
+  extra: ToolExtra;
+}
+
+// A branded MCP result. The brand is phantom (compile-time only) so a raw
+// object literal won't satisfy `ToolResult` — handlers must go through the
+// constructors below, which is what makes trust-wrapping unforgettable.
+declare const toolResultBrand: unique symbol;
+export type ToolResult = CallToolResult & { readonly [toolResultBrand]: true };
+
+function seal(result: CallToolResult): ToolResult {
+  return result as ToolResult;
+}
+
+/** A single trusted text block: server-authored text, never wrapped. */
+export function text(body: string): ToolResult {
+  return seal({ content: [{ type: "text", text: body }] });
+}
+
+/**
+ * A single block that is entirely untrusted vault-derived text. Wraps the body
+ * in BEGIN/END markers and attaches the trust `_meta` tag under `label`.
+ */
+export function untrustedText(label: string, body: string): ToolResult {
+  return seal({
+    content: [
+      {
+        type: "text",
+        text: formatUntrustedVaultContent(label, body),
+        _meta: untrustedVaultContentMeta(label),
+      },
+    ],
+  });
+}
+
+/** A single error block carrying a server-authored message verbatim. */
+export function error(message: string): ToolResult {
+  return seal({ content: [{ type: "text", text: message }], isError: true });
+}
+
+/** Flag an already-built result as an error (e.g. a `richText` that carries an
+ *  untrusted path in its error message). */
+export function asError(result: ToolResult): ToolResult {
+  return seal({ ...(result as CallToolResult), isError: true });
+}
+
+/**
+ * Builder for a single text block that interleaves server-authored framing with
+ * inline untrusted vault-content sections. `trusted` appends framing verbatim;
+ * `untrusted` appends a BEGIN/END-wrapped (optionally indented) section and
+ * marks the block as carrying untrusted content. Segments join with "\n", the
+ * same way handlers used to `lines.join("\n")`.
+ */
+export interface RichTextBuilder {
+  /** Append a server-authored line verbatim. Naming it `trusted` makes any
+   *  attempt to pass vault text here read wrong at review time. */
+  trusted(line: string): void;
+  /** Append an untrusted vault-content section, wrapped and optionally indented. */
+  untrusted(label: string, body: string, indent?: string): void;
+}
+
+/**
+ * Compose a mixed text block. `itemTrustLabel` names the block-level trust tag,
+ * which is attached only if at least one `untrusted` section was appended — so
+ * an all-trusted result (e.g. an empty-result message) carries no `_meta`,
+ * matching the prior per-handler behaviour.
+ */
+export function richText(
+  itemTrustLabel: string,
+  build: (b: RichTextBuilder) => void
+): ToolResult {
+  const pieces: string[] = [];
+  let hasUntrusted = false;
+  build({
+    trusted(line) {
+      pieces.push(line);
+    },
+    untrusted(label, body, indent = "") {
+      pieces.push(
+        indentBlock(formatUntrustedVaultContent(label, body), indent)
+      );
+      hasUntrusted = true;
+    },
+  });
+  const item: CallToolResult["content"][number] = {
+    type: "text",
+    text: pieces.join("\n"),
+    ...(hasUntrusted
+      ? { _meta: untrustedVaultContentMeta(itemTrustLabel) }
+      : {}),
+  };
+  return seal({ content: [item] });
+}
+
+/** The static configuration half of a tool: everything the MCP client sees. */
+export interface ToolSpec<InputArgs extends ZodRawShapeCompat> {
+  name: string;
+  title: string;
+  description: string;
+  annotations: ToolAnnotations;
+  inputSchema: InputArgs;
+}
+
+/**
+ * Register a tool through the seam. The handler receives its validated `args`
+ * (type inferred from `inputSchema`, exactly as the SDK infers it) and `ctx`,
+ * and returns a `ToolResult` or throws. Anything thrown is logged as
+ * `"<name> failed"` and returned as a sanitized `isError` result — the single
+ * place error sanitization is now enforced.
+ */
+export function defineTool<InputArgs extends ZodRawShapeCompat>(
+  server: McpServer,
+  vaultPath: string,
+  spec: ToolSpec<InputArgs>,
+  handler: (
+    args: ShapeOutput<InputArgs>,
+    ctx: ToolCtx
+  ) => ToolResult | Promise<ToolResult>
+): void {
+  const cb = async (
+    args: ShapeOutput<InputArgs>,
+    extra: ToolExtra
+  ): Promise<ToolResult> => {
+    try {
+      return await handler(args, { vaultPath, server, extra });
+    } catch (err) {
+      log.error(`${spec.name} failed`, { tool: spec.name, err: err as Error });
+      return error(`Error: ${sanitizeError(err)}`);
+    }
+  };
+  server.registerTool(
+    spec.name,
+    {
+      title: spec.title,
+      description: spec.description,
+      annotations: spec.annotations,
+      inputSchema: spec.inputSchema,
+    },
+    // `ToolCallback<InputArgs>` is an unreduced conditional over the generic
+    // shape, so a structurally-matching callback (args typed as the SDK's own
+    // `ShapeOutput<InputArgs>`, returning a `CallToolResult`) can't be assigned
+    // to it directly. The shape is matched deliberately; cast at this single
+    // boundary.
+    cb as unknown as ToolCallback<InputArgs>
+  );
+}

--- a/src/tools/read/get_daily_note.ts
+++ b/src/tools/read/get_daily_note.ts
@@ -1,18 +1,31 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { readNote } from "../../lib/vault.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
-import { formatUntrustedVaultContent, untrustedVaultContentMeta } from "../../lib/tool-output.js";
-import { formatLocalDateOnly, formatMomentDate, parseLocalDateOnly } from "../../lib/dates.js";
+import {
+  formatLocalDateOnly,
+  formatMomentDate,
+  parseLocalDateOnly,
+} from "../../lib/dates.js";
 import { parseFrontmatter } from "../../lib/markdown.js";
 import { getDailyNoteConfig } from "../../config.js";
-import { displayReadValue, errorResult, untrustedReadBlock } from "./shared.js";
+import {
+  asError,
+  defineTool,
+  error,
+  richText,
+  untrustedText,
+} from "../../lib/tool-seam.js";
+import { displayReadValue } from "./shared.js";
 
-export function registerGetDailyNoteTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "get_daily_note",
+export function registerGetDailyNoteTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "get_daily_note",
       title: "Get Daily Note",
       description:
         "Read the daily note for today or for a specific date, resolved via the vault's configured daily-note folder and filename format. Returns the note path, parsed frontmatter (as a labeled header block), and body. Errors if no daily note exists for that date — use create_daily_note to create one.",
@@ -26,72 +39,76 @@ export function registerGetDailyNoteTool(server: McpServer, vaultPath: string): 
           .string()
           .regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD")
           .optional()
-          .describe("Target date in YYYY-MM-DD format (defaults to today's local date)"),
+          .describe(
+            "Target date in YYYY-MM-DD format (defaults to today's local date)"
+          ),
       },
     },
     async ({ date }) => {
+      const config = await getDailyNoteConfig(vaultPath);
+      const targetDate = date ?? formatLocalDateOnly();
+
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(targetDate)) {
+        return error(
+          `Invalid date format: "${displayReadValue(targetDate)}". Use YYYY-MM-DD.`
+        );
+      }
+      const parsed = parseLocalDateOnly(targetDate);
+      if (!parsed) {
+        return error(`Invalid date: "${displayReadValue(targetDate)}".`);
+      }
+
+      // Build the filename using moment-style tokens (YYYY, MMM, ddd, etc).
+      let filename = formatMomentDate(parsed, config.format);
+      if (!filename.endsWith(".md")) {
+        filename += ".md";
+      }
+
+      const notePath = config.folder
+        ? `${config.folder}/${filename}`
+        : filename;
+
+      let content: string;
       try {
-        const config = await getDailyNoteConfig(vaultPath);
-        const targetDate = date ?? formatLocalDateOnly();
+        content = await readNote(vaultPath, notePath);
+      } catch {
+        // A read failure here means the daily note does not exist yet — a
+        // domain outcome, not an unexpected error. Surface the expected path
+        // as untrusted vault content so the client can offer to create it.
+        const pathLabel = "get_daily_note expected path";
+        return asError(
+          richText(pathLabel, (b) => {
+            b.trusted(
+              `Daily note not found for ${displayReadValue(targetDate)}.`
+            );
+            b.untrusted(pathLabel, displayReadValue(notePath));
+          })
+        );
+      }
 
-        if (!/^\d{4}-\d{2}-\d{2}$/.test(targetDate)) {
-          return errorResult(`Invalid date format: "${displayReadValue(targetDate)}". Use YYYY-MM-DD.`);
-        }
-        const parsed = parseLocalDateOnly(targetDate);
-        if (!parsed) {
-          return errorResult(`Invalid date: "${displayReadValue(targetDate)}".`);
-        }
+      const { data: dailyFrontmatter, content: dailyBody } =
+        parseFrontmatter(content);
+      const header: string[] = [
+        `Daily Note: ${displayReadValue(targetDate)}`,
+        `Path: ${displayReadValue(notePath)}`,
+        "",
+      ];
 
-        // Build the filename using moment-style tokens (YYYY, MMM, ddd, etc).
-        let filename = formatMomentDate(parsed, config.format);
-        if (!filename.endsWith(".md")) {
-          filename += ".md";
-        }
-
-        const notePath = config.folder
-          ? `${config.folder}/${filename}`
-          : filename;
-
-        let content: string;
-        try {
-          content = await readNote(vaultPath, notePath);
-        } catch {
-          const pathLabel = "get_daily_note expected path";
-          return errorResult(
-            `Daily note not found for ${displayReadValue(targetDate)}.\n${untrustedReadBlock(pathLabel, displayReadValue(notePath))}`,
-            untrustedVaultContentMeta(pathLabel),
+      if (Object.keys(dailyFrontmatter).length > 0) {
+        header.push("--- Frontmatter ---");
+        for (const [key, value] of Object.entries(dailyFrontmatter)) {
+          header.push(
+            `${displayReadValue(key)}: ${displayReadValue(JSON.stringify(value) ?? "")}`
           );
         }
-
-        const { data: dailyFrontmatter, content: dailyBody } = parseFrontmatter(content);
-        const header: string[] = [
-          `Daily Note: ${displayReadValue(targetDate)}`,
-          `Path: ${displayReadValue(notePath)}`,
-          "",
-        ];
-
-        if (Object.keys(dailyFrontmatter).length > 0) {
-          header.push("--- Frontmatter ---");
-          for (const [key, value] of Object.entries(dailyFrontmatter)) {
-            header.push(`${displayReadValue(key)}: ${displayReadValue(JSON.stringify(value) ?? "")}`);
-          }
-          header.push("--- End Frontmatter ---");
-          header.push("");
-        }
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: formatUntrustedVaultContent("get_daily_note body", header.join("\n") + dailyBody),
-              _meta: untrustedVaultContentMeta("get_daily_note body"),
-            },
-          ],
-        };
-      } catch (err) {
-        log.error("get_daily_note failed", { tool: "get_daily_note", err: err as Error });
-        return errorResult(`Error reading daily note: ${sanitizeError(err)}`);
+        header.push("--- End Frontmatter ---");
+        header.push("");
       }
-    },
+
+      return untrustedText(
+        "get_daily_note body",
+        header.join("\n") + dailyBody
+      );
+    }
   );
 }

--- a/src/tools/read/get_note.ts
+++ b/src/tools/read/get_note.ts
@@ -1,17 +1,24 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { readNote, readNoteLineRange } from "../../lib/vault.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
-import { formatUntrustedVaultContent, untrustedVaultContentMeta } from "../../lib/tool-output.js";
 import { parseFrontmatter, extractTags } from "../../lib/markdown.js";
-import { findSection, findBlockById, stripBlockId } from "../../lib/sections.js";
-import { displayReadValue, errorResult, parseRequestedLineRange, untrustedTextContent } from "./shared.js";
+import {
+  findSection,
+  findBlockById,
+  stripBlockId,
+} from "../../lib/sections.js";
+import { defineTool, error, untrustedText } from "../../lib/tool-seam.js";
+import { displayReadValue, parseRequestedLineRange } from "./shared.js";
 
-export function registerGetNoteTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "get_note",
+export function registerGetNoteTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "get_note",
       title: "Get Note",
       description:
         "Read a note in full or as a fragment. With no fragment options, returns parsed frontmatter (as a labeled header), a flat list of inline #tags, and the body. With `section`, returns just the body under that heading (path-form like 'Tasks/Today' is supported). With `block`, returns the paragraph or block tagged `^id`. With `lines`, returns the inclusive 1-indexed line range. Fragment modes skip the frontmatter/tag header and return raw text — use them to keep token usage tight on long notes.",
@@ -25,113 +32,128 @@ export function registerGetNoteTool(server: McpServer, vaultPath: string): void 
           .string()
           .min(1)
           .max(500)
-          .describe("Relative path from vault root to the note (e.g., 'folder/note.md'). Extension required."),
+          .describe(
+            "Relative path from vault root to the note (e.g., 'folder/note.md'). Extension required."
+          ),
         section: z
           .string()
           .max(500)
           .optional()
-          .describe("Heading path (e.g., 'Tasks' or 'Project A/Status'). Returns just that section's body."),
+          .describe(
+            "Heading path (e.g., 'Tasks' or 'Project A/Status'). Returns just that section's body."
+          ),
         block: z
           .string()
           .max(200)
           .optional()
-          .describe("Block id (without the leading `^`). Returns just the paragraph or block tagged with that id."),
+          .describe(
+            "Block id (without the leading `^`). Returns just the paragraph or block tagged with that id."
+          ),
         lines: z
           .string()
           .regex(/^\d+(-\d+)?$/, "Must be N or N-M (1-indexed, inclusive)")
           .optional()
-          .describe("Line range, 1-indexed and inclusive (e.g., '10-25' or '42'). Returns just those lines."),
+          .describe(
+            "Line range, 1-indexed and inclusive (e.g., '10-25' or '42'). Returns just those lines."
+          ),
       },
     },
     async ({ path: notePath, section, block, lines }) => {
-      try {
-        if (!section && !block && lines) {
-          const parsedRange = parseRequestedLineRange(lines);
-          if (!parsedRange) {
-            return errorResult(`Invalid lines format: "${displayReadValue(lines)}"`);
-          }
-          const range = await readNoteLineRange(vaultPath, notePath, parsedRange.start, parsedRange.end);
-          if (range.pastEndLine) {
-            return errorResult(`Line ${range.pastEndLine.requested} is past end of file (${range.pastEndLine.total} lines)`);
-          }
-          return {
-            content: [untrustedTextContent("get_note fragment", range.text)],
-          };
+      if (!section && !block && lines) {
+        const parsedRange = parseRequestedLineRange(lines);
+        if (!parsedRange) {
+          return error(`Invalid lines format: "${displayReadValue(lines)}"`);
         }
-
-        const content = await readNote(vaultPath, notePath);
-
-        // Fragment modes are mutually exclusive — picking one skips the
-        // frontmatter/tag header and returns raw text. Mode order: section
-        // first (most user-facing), then block, then lines.
-        if (section) {
-          const headingPath = section.split("/").map((s) => s.trim()).filter(Boolean);
-          const found = findSection(content, headingPath);
-          if (!found) {
-            return errorResult(`Section not found: "${displayReadValue(section)}" in ${displayReadValue(notePath)}`);
-          }
-          return {
-            content: [untrustedTextContent("get_note section", content.slice(found.start, found.end))],
-          };
+        const range = await readNoteLineRange(
+          vaultPath,
+          notePath,
+          parsedRange.start,
+          parsedRange.end
+        );
+        if (range.pastEndLine) {
+          return error(
+            `Line ${range.pastEndLine.requested} is past end of file (${range.pastEndLine.total} lines)`
+          );
         }
-
-        if (block) {
-          const found = findBlockById(content, block);
-          if (!found) {
-            return errorResult(`Block not found: "^${displayReadValue(block)}" in ${displayReadValue(notePath)}`);
-          }
-          return {
-            content: [untrustedTextContent("get_note block", stripBlockId(content.slice(found.start, found.end)))],
-          };
-        }
-
-        if (lines) {
-          const allLines = content.split("\n");
-          const parsedRange = parseRequestedLineRange(lines);
-          if (!parsedRange) return errorResult(`Invalid lines format: "${displayReadValue(lines)}"`);
-          if (parsedRange.start > allLines.length) {
-            return errorResult(`Line ${parsedRange.start} is past end of file (${allLines.length} lines)`);
-          }
-          const slice = allLines.slice(parsedRange.start - 1, Math.min(parsedRange.end, allLines.length));
-          return {
-            content: [untrustedTextContent("get_note fragment", slice.join("\n"))],
-          };
-        }
-
-        const { data: frontmatterData, content: bodyContent } = parseFrontmatter(content);
-
-        const header: string[] = [];
-        if (Object.keys(frontmatterData).length > 0) {
-          header.push("--- Frontmatter ---");
-          for (const [key, value] of Object.entries(frontmatterData)) {
-            header.push(`${displayReadValue(key)}: ${displayReadValue(JSON.stringify(value) ?? "")}`);
-          }
-          header.push("--- End Frontmatter ---");
-          header.push("");
-        }
-
-        const tags = extractTags(content);
-        if (tags.length > 0) {
-          header.push(`Tags: ${tags.map(displayReadValue).join(", ")}`);
-          header.push("");
-        }
-
-        const renderedNote = header.length > 0
-          ? header.join("\n") + bodyContent
-          : content;
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: formatUntrustedVaultContent("get_note body", renderedNote),
-              _meta: untrustedVaultContentMeta("get_note body"),
-            },
-          ],
-        };
-      } catch (err) {
-        log.error("get_note failed", { tool: "get_note", err: err as Error });
-        return errorResult(`Error reading note: ${sanitizeError(err)}`);
+        return untrustedText("get_note fragment", range.text);
       }
-    },
+
+      const content = await readNote(vaultPath, notePath);
+
+      // Fragment modes are mutually exclusive — picking one skips the
+      // frontmatter/tag header and returns raw text. Mode order: section
+      // first (most user-facing), then block, then lines.
+      if (section) {
+        const headingPath = section
+          .split("/")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        const found = findSection(content, headingPath);
+        if (!found) {
+          return error(
+            `Section not found: "${displayReadValue(section)}" in ${displayReadValue(notePath)}`
+          );
+        }
+        return untrustedText(
+          "get_note section",
+          content.slice(found.start, found.end)
+        );
+      }
+
+      if (block) {
+        const found = findBlockById(content, block);
+        if (!found) {
+          return error(
+            `Block not found: "^${displayReadValue(block)}" in ${displayReadValue(notePath)}`
+          );
+        }
+        return untrustedText(
+          "get_note block",
+          stripBlockId(content.slice(found.start, found.end))
+        );
+      }
+
+      if (lines) {
+        const allLines = content.split("\n");
+        const parsedRange = parseRequestedLineRange(lines);
+        if (!parsedRange)
+          return error(`Invalid lines format: "${displayReadValue(lines)}"`);
+        if (parsedRange.start > allLines.length) {
+          return error(
+            `Line ${parsedRange.start} is past end of file (${allLines.length} lines)`
+          );
+        }
+        const slice = allLines.slice(
+          parsedRange.start - 1,
+          Math.min(parsedRange.end, allLines.length)
+        );
+        return untrustedText("get_note fragment", slice.join("\n"));
+      }
+
+      const { data: frontmatterData, content: bodyContent } =
+        parseFrontmatter(content);
+
+      const header: string[] = [];
+      if (Object.keys(frontmatterData).length > 0) {
+        header.push("--- Frontmatter ---");
+        for (const [key, value] of Object.entries(frontmatterData)) {
+          header.push(
+            `${displayReadValue(key)}: ${displayReadValue(JSON.stringify(value) ?? "")}`
+          );
+        }
+        header.push("--- End Frontmatter ---");
+        header.push("");
+      }
+
+      const tags = extractTags(content);
+      if (tags.length > 0) {
+        header.push(`Tags: ${tags.map(displayReadValue).join(", ")}`);
+        header.push("");
+      }
+
+      const renderedNote =
+        header.length > 0 ? header.join("\n") + bodyContent : content;
+      return untrustedText("get_note body", renderedNote);
+    }
   );
 }

--- a/src/tools/read/get_recent_notes.ts
+++ b/src/tools/read/get_recent_notes.ts
@@ -1,19 +1,26 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { listNotes, getNoteStats, getVaultRootRealPath } from "../../lib/vault.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
+import {
+  listNotes,
+  getNoteStats,
+  getVaultRootRealPath,
+} from "../../lib/vault.js";
 import { mapConcurrent } from "../../lib/concurrency.js";
-import { untrustedVaultContentMeta } from "../../lib/tool-output.js";
-import { displayReadValue, errorResult, parseSince, untrustedReadBlock } from "./shared.js";
+import { defineTool, error, richText, text } from "../../lib/tool-seam.js";
+import { displayReadValue, parseSince } from "./shared.js";
 
 /** Maximum number of concurrent file I/O operations for parallel vault scans. */
 const MAX_CONCURRENT_OPS = 16;
 
-export function registerGetRecentNotesTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "get_recent_notes",
+export function registerGetRecentNotesTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "get_recent_notes",
       title: "Get Recent Notes",
       description:
         "List notes ordered by most-recently-modified first. Optional `since` filter accepts an ISO date (e.g. '2026-04-01') or a relative span ('7d', '24h', '2w'); only notes modified at or after that time are returned. Use to surface what you've been working on, build a 'what changed this week' digest, or pick targets for review.",
@@ -35,74 +42,76 @@ export function registerGetRecentNotesTool(server: McpServer, vaultPath: string)
           .string()
           .max(50)
           .optional()
-          .describe("Filter to notes modified at or after this point. Accepts ISO 8601 (YYYY-MM-DD or full timestamp) or a relative span like '7d', '24h', '2w'."),
+          .describe(
+            "Filter to notes modified at or after this point. Accepts ISO 8601 (YYYY-MM-DD or full timestamp) or a relative span like '7d', '24h', '2w'."
+          ),
         folder: z
           .string()
           .max(500)
           .optional()
-          .describe("Restrict to notes within this folder (relative to vault root). Omit to scan the entire vault."),
+          .describe(
+            "Restrict to notes within this folder (relative to vault root). Omit to scan the entire vault."
+          ),
       },
     },
     async ({ limit, since, folder }) => {
-      try {
-        const sinceMs = since ? parseSince(since) : null;
-        if (since && sinceMs === null) {
-          return errorResult(`Invalid 'since' value: "${displayReadValue(since)}". Use ISO date or relative span like '7d', '24h', '2w'.`);
-        }
-        const notes = await listNotes(vaultPath, folder);
-
-        // Stat each note for mtime without reading bodies.
-        type Row = { path: string; mtimeMs: number };
-        const realVaultRoot = await getVaultRootRealPath(vaultPath);
-        const stats = await mapConcurrent<string, Row | undefined>(
-          notes,
-          MAX_CONCURRENT_OPS,
-          async (notePath) => {
-            try {
-              const st = await getNoteStats(vaultPath, notePath, { realVaultRoot });
-              return { path: notePath, mtimeMs: st.modified?.getTime() ?? 0 };
-            } catch {
-              return undefined;
-            }
-          },
+      const sinceMs = since ? parseSince(since) : null;
+      if (since && sinceMs === null) {
+        return error(
+          `Invalid 'since' value: "${displayReadValue(since)}". Use ISO date or relative span like '7d', '24h', '2w'.`
         );
-
-        const rows: Row[] = [];
-        for (const r of stats) {
-          if (!r) continue;
-          if (sinceMs !== null && r.mtimeMs < sinceMs) continue;
-          rows.push(r);
-        }
-        rows.sort((a, b) => b.mtimeMs - a.mtimeMs);
-        const top = rows.slice(0, limit);
-
-        if (top.length === 0) {
-          return { content: [{ type: "text" as const, text: since ? `No notes modified since ${displayReadValue(since)}.` : "No notes in the vault." }] };
-        }
-
-        const lines: string[] = [
-          `${rows.length} note(s)${since ? ` modified since ${displayReadValue(since)}` : ""}${rows.length > limit ? ` (showing first ${limit})` : ""}:`,
-          "",
-        ];
-        const rowLines: string[] = [];
-        for (const r of top) {
-          const iso = new Date(r.mtimeMs).toISOString();
-          rowLines.push(`- ${displayReadValue(r.path)}  (${iso})`);
-        }
-        if (rowLines.length > 0) {
-          lines.push(untrustedReadBlock("get_recent_notes paths", rowLines.join("\n")));
-        }
-        return {
-          content: [{
-            type: "text" as const,
-            text: lines.join("\n"),
-            ...(rowLines.length > 0 ? { _meta: untrustedVaultContentMeta("get_recent_notes paths") } : {}),
-          }],
-        };
-      } catch (err) {
-        log.error("get_recent_notes failed", { tool: "get_recent_notes", err: err as Error });
-        return errorResult(`Error listing recent notes: ${sanitizeError(err)}`);
       }
-    },
+      const notes = await listNotes(vaultPath, folder);
+
+      // Stat each note for mtime without reading bodies.
+      type Row = { path: string; mtimeMs: number };
+      const realVaultRoot = await getVaultRootRealPath(vaultPath);
+      const stats = await mapConcurrent<string, Row | undefined>(
+        notes,
+        MAX_CONCURRENT_OPS,
+        async (notePath) => {
+          try {
+            const st = await getNoteStats(vaultPath, notePath, {
+              realVaultRoot,
+            });
+            return { path: notePath, mtimeMs: st.modified?.getTime() ?? 0 };
+          } catch {
+            return undefined;
+          }
+        }
+      );
+
+      const rows: Row[] = [];
+      for (const r of stats) {
+        if (!r) continue;
+        if (sinceMs !== null && r.mtimeMs < sinceMs) continue;
+        rows.push(r);
+      }
+      rows.sort((a, b) => b.mtimeMs - a.mtimeMs);
+      const top = rows.slice(0, limit);
+
+      if (top.length === 0) {
+        return text(
+          since
+            ? `No notes modified since ${displayReadValue(since)}.`
+            : "No notes in the vault."
+        );
+      }
+
+      const rowLines: string[] = [];
+      for (const r of top) {
+        const iso = new Date(r.mtimeMs).toISOString();
+        rowLines.push(`- ${displayReadValue(r.path)}  (${iso})`);
+      }
+      return richText("get_recent_notes paths", (b) => {
+        b.trusted(
+          `${rows.length} note(s)${since ? ` modified since ${displayReadValue(since)}` : ""}${rows.length > limit ? ` (showing first ${limit})` : ""}:`
+        );
+        b.trusted("");
+        if (rowLines.length > 0) {
+          b.untrusted("get_recent_notes paths", rowLines.join("\n"));
+        }
+      });
+    }
   );
 }

--- a/src/tools/read/get_vault_stats.ts
+++ b/src/tools/read/get_vault_stats.ts
@@ -2,16 +2,20 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { listNotes } from "../../lib/vault.js";
 import { readAllCached } from "../../lib/index-cache.js";
-import { sanitizeError } from "../../lib/errors.js";
 import { log } from "../../lib/logger.js";
-import { untrustedVaultContentMeta } from "../../lib/tool-output.js";
 import { parseFrontmatter, extractTags } from "../../lib/markdown.js";
-import { displayReadValue, errorResult, untrustedReadBlock } from "./shared.js";
+import { defineTool, richText, text } from "../../lib/tool-seam.js";
+import { displayReadValue } from "./shared.js";
 
-export function registerGetVaultStatsTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "get_vault_stats",
+export function registerGetVaultStatsTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "get_vault_stats",
       title: "Get Vault Stats",
       description:
         "Return a quick health snapshot of the vault: note count, total bytes, total words, unique tag count, untagged-note count, and the most-recently-modified note. Useful for dashboards and 'is this vault healthy?' checks. Reads through the mtime cache so repeat calls are cheap.",
@@ -25,78 +29,78 @@ export function registerGetVaultStatsTool(server: McpServer, vaultPath: string):
           .string()
           .max(500)
           .optional()
-          .describe("Restrict stats to this folder (relative to vault root). Omit for whole-vault stats."),
+          .describe(
+            "Restrict stats to this folder (relative to vault root). Omit for whole-vault stats."
+          ),
       },
     },
     async ({ folder }) => {
-      try {
-        const notes = await listNotes(vaultPath, folder);
-        if (notes.length === 0) {
-          return { content: [{ type: "text" as const, text: folder ? `No notes in "${displayReadValue(folder)}"` : "Vault is empty." }] };
-        }
-        const { contents, stats } = await readAllCached(vaultPath, notes, (note, err) => {
+      const notes = await listNotes(vaultPath, folder);
+      if (notes.length === 0) {
+        return text(
+          folder
+            ? `No notes in "${displayReadValue(folder)}"`
+            : "Vault is empty."
+        );
+      }
+      const { contents, stats } = await readAllCached(
+        vaultPath,
+        notes,
+        (note, err) => {
           log.warn("get_vault_stats: note read failed", { note, err });
-        });
-
-        // Aggregate over already-cached content and stats. `readAllCached`
-        // already resolves and stats each note safely, so most-recent can use
-        // that metadata without a second filesystem pass.
-        let totalBytes = 0;
-        let totalWords = 0;
-        let untagged = 0;
-        const tagSet = new Set<string>();
-        let mostRecent: { path: string; mtimeMs: number } | null = null;
-        for (const notePath of notes) {
-          const stat = stats.get(notePath);
-          if (stat && (!mostRecent || stat.mtime > mostRecent.mtimeMs)) {
-            mostRecent = { path: notePath, mtimeMs: stat.mtime };
-          }
-          const content = contents.get(notePath);
-          if (content === undefined) continue;
-          totalBytes += Buffer.byteLength(content, "utf-8");
-          const { content: body } = parseFrontmatter(content);
-          const wordMatches = body.match(/\S+/g);
-          totalWords += wordMatches ? wordMatches.length : 0;
-          const tags = extractTags(content);
-          if (tags.length === 0) untagged++;
-          for (const t of tags) tagSet.add(t.toLowerCase());
         }
+      );
 
-        const avgBytes = Math.round(totalBytes / notes.length);
-        const avgWords = Math.round(totalWords / notes.length);
-        const untaggedPct = ((untagged / notes.length) * 100).toFixed(1);
-        const lines = [
-          `Vault stats${folder ? ` (folder: ${displayReadValue(folder)})` : ""}`,
-          "",
-          `  Notes:           ${notes.length}`,
-          `  Total bytes:     ${totalBytes.toLocaleString()}`,
-          `  Total words:     ${totalWords.toLocaleString()}`,
-          `  Avg bytes/note:  ${avgBytes.toLocaleString()}`,
-          `  Avg words/note:  ${avgWords.toLocaleString()}`,
-          `  Unique tags:     ${tagSet.size}`,
-          `  Untagged notes:  ${untagged} (${untaggedPct}%)`,
-        ];
+      // Aggregate over already-cached content and stats. `readAllCached`
+      // already resolves and stats each note safely, so most-recent can use
+      // that metadata without a second filesystem pass.
+      let totalBytes = 0;
+      let totalWords = 0;
+      let untagged = 0;
+      const tagSet = new Set<string>();
+      let mostRecent: { path: string; mtimeMs: number } | null = null;
+      for (const notePath of notes) {
+        const stat = stats.get(notePath);
+        if (stat && (!mostRecent || stat.mtime > mostRecent.mtimeMs)) {
+          mostRecent = { path: notePath, mtimeMs: stat.mtime };
+        }
+        const content = contents.get(notePath);
+        if (content === undefined) continue;
+        totalBytes += Buffer.byteLength(content, "utf-8");
+        const { content: body } = parseFrontmatter(content);
+        const wordMatches = body.match(/\S+/g);
+        totalWords += wordMatches ? wordMatches.length : 0;
+        const tags = extractTags(content);
+        if (tags.length === 0) untagged++;
+        for (const t of tags) tagSet.add(t.toLowerCase());
+      }
+
+      const avgBytes = Math.round(totalBytes / notes.length);
+      const avgWords = Math.round(totalWords / notes.length);
+      const untaggedPct = ((untagged / notes.length) * 100).toFixed(1);
+      return richText("get_vault_stats most recent path", (b) => {
+        b.trusted(
+          `Vault stats${folder ? ` (folder: ${displayReadValue(folder)})` : ""}`
+        );
+        b.trusted("");
+        b.trusted(`  Notes:           ${notes.length}`);
+        b.trusted(`  Total bytes:     ${totalBytes.toLocaleString()}`);
+        b.trusted(`  Total words:     ${totalWords.toLocaleString()}`);
+        b.trusted(`  Avg bytes/note:  ${avgBytes.toLocaleString()}`);
+        b.trusted(`  Avg words/note:  ${avgWords.toLocaleString()}`);
+        b.trusted(`  Unique tags:     ${tagSet.size}`);
+        b.trusted(`  Untagged notes:  ${untagged} (${untaggedPct}%)`);
         if (mostRecent) {
-          lines.push("  Most recent:");
-          lines.push(untrustedReadBlock(
+          b.trusted("  Most recent:");
+          b.untrusted(
             "get_vault_stats most recent path",
             `${displayReadValue(mostRecent.path)} (${new Date(mostRecent.mtimeMs).toISOString()})`,
-            "    ",
-          ));
+            "    "
+          );
         } else {
-          lines.push("  Most recent:     (none)");
+          b.trusted("  Most recent:     (none)");
         }
-        return {
-          content: [{
-            type: "text" as const,
-            text: lines.join("\n"),
-            ...(mostRecent ? { _meta: untrustedVaultContentMeta("get_vault_stats most recent path") } : {}),
-          }],
-        };
-      } catch (err) {
-        log.error("get_vault_stats failed", { tool: "get_vault_stats", err: err as Error });
-        return errorResult(`Error gathering vault stats: ${sanitizeError(err)}`);
-      }
-    },
+      });
+    }
   );
 }

--- a/src/tools/read/list_notes.ts
+++ b/src/tools/read/list_notes.ts
@@ -1,15 +1,18 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { listNotes } from "../../lib/vault.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
-import { untrustedVaultContentMeta } from "../../lib/tool-output.js";
-import { displayReadValue, errorResult, untrustedReadBlock } from "./shared.js";
+import { defineTool, richText } from "../../lib/tool-seam.js";
+import { displayReadValue } from "./shared.js";
 
-export function registerListNotesTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "list_notes",
+export function registerListNotesTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "list_notes",
       title: "List Notes",
       description:
         "Enumerate every markdown note in the vault (or a single folder), returning a sorted list of relative paths along with the total count. Truncates output to `limit` entries but still reports the total. Use to browse vault structure, build a file picker, or enumerate targets for batch processing.",
@@ -23,7 +26,9 @@ export function registerListNotesTool(server: McpServer, vaultPath: string): voi
           .string()
           .max(500)
           .optional()
-          .describe("Folder relative to vault root to restrict the listing (omit to list the entire vault)"),
+          .describe(
+            "Folder relative to vault root to restrict the listing (omit to list the entire vault)"
+          ),
         limit: z
           .number()
           .int()
@@ -31,34 +36,28 @@ export function registerListNotesTool(server: McpServer, vaultPath: string): voi
           .max(10000)
           .optional()
           .default(50)
-          .describe("Maximum number of note paths to return (1-10000, default: 50). The full total count is still reported separately."),
+          .describe(
+            "Maximum number of note paths to return (1-10000, default: 50). The full total count is still reported separately."
+          ),
       },
     },
     async ({ folder, limit }) => {
-      try {
-        const notes = await listNotes(vaultPath, folder);
-        const limited = notes.slice(0, limit);
-        const totalCount = notes.length;
+      const notes = await listNotes(vaultPath, folder);
+      const limited = notes.slice(0, limit);
+      const totalCount = notes.length;
 
-        const lines: string[] = [
-          `Found ${totalCount} note(s)${folder ? ` in "${displayReadValue(folder)}"` : ""}${totalCount > limit ? ` (showing first ${limit})` : ""}:`,
-          "",
-        ];
+      return richText("list_notes paths", (b) => {
+        b.trusted(
+          `Found ${totalCount} note(s)${folder ? ` in "${displayReadValue(folder)}"` : ""}${totalCount > limit ? ` (showing first ${limit})` : ""}:`
+        );
+        b.trusted("");
         if (limited.length > 0) {
-          lines.push(untrustedReadBlock("list_notes paths", limited.map(displayReadValue).join("\n")));
+          b.untrusted(
+            "list_notes paths",
+            limited.map(displayReadValue).join("\n")
+          );
         }
-
-        return {
-          content: [{
-            type: "text" as const,
-            text: lines.join("\n"),
-            ...(limited.length > 0 ? { _meta: untrustedVaultContentMeta("list_notes paths") } : {}),
-          }],
-        };
-      } catch (err) {
-        log.error("list_notes failed", { tool: "list_notes", err: err as Error });
-        return errorResult(`Error listing notes: ${sanitizeError(err)}`);
-      }
-    },
+      });
+    }
   );
 }

--- a/src/tools/read/resolve_alias.ts
+++ b/src/tools/read/resolve_alias.ts
@@ -3,16 +3,20 @@ import { z } from "zod";
 import path from "path";
 import { listNotes } from "../../lib/vault.js";
 import { readAllCached } from "../../lib/index-cache.js";
-import { sanitizeError } from "../../lib/errors.js";
 import { log } from "../../lib/logger.js";
-import { untrustedVaultContentMeta } from "../../lib/tool-output.js";
 import { extractAliases } from "../../lib/markdown.js";
-import { displayReadValue, errorResult, untrustedReadBlock } from "./shared.js";
+import { defineTool, error, richText, text } from "../../lib/tool-seam.js";
+import { displayReadValue } from "./shared.js";
 
-export function registerResolveAliasTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "resolve_alias",
+export function registerResolveAliasTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "resolve_alias",
       title: "Resolve Alias",
       description:
         "Find every note whose frontmatter `aliases:` field contains the given name (case-insensitive). With `includeBasename: true`, also matches notes whose filename (without `.md`) equals the name — Obsidian's resolution fallback when no alias matches. Use to translate a human-friendly title like 'My Project' into the actual note path before calling get_note.",
@@ -31,75 +35,79 @@ export function registerResolveAliasTool(server: McpServer, vaultPath: string): 
           .boolean()
           .optional()
           .default(true)
-          .describe("If true (default), also match notes whose filename (without extension) equals `name`."),
+          .describe(
+            "If true (default), also match notes whose filename (without extension) equals `name`."
+          ),
       },
     },
     async ({ name, includeBasename }) => {
-      try {
-        const target = name.trim().toLowerCase();
-        if (!target) return errorResult("name must not be empty");
-        const notes = await listNotes(vaultPath);
+      const target = name.trim().toLowerCase();
+      if (!target) return error("name must not be empty");
+      const notes = await listNotes(vaultPath);
 
-        // Basename matches are a pure path comparison - no file I/O needed.
-        const basenameMatches: string[] = [];
-        if (includeBasename) {
-          for (const notePath of notes) {
-            const basename = path.basename(notePath, path.extname(notePath)).toLowerCase();
-            if (basename === target) basenameMatches.push(notePath);
-          }
-        }
-
-        // For alias matches, read through the shared content cache so repeat
-        // lookups reuse warm note bodies while preserving per-note path checks.
-        const aliasMatches: string[] = [];
-        const { contents } = await readAllCached(vaultPath, notes, (note, err) => {
-          log.warn("resolve_alias: note read failed", { note, err });
-        });
+      // Basename matches are a pure path comparison - no file I/O needed.
+      const basenameMatches: string[] = [];
+      if (includeBasename) {
         for (const notePath of notes) {
-          const content = contents.get(notePath);
-          if (content === undefined) continue;
-          const aliases = extractAliases(content);
-          if (aliases.some((a) => a.toLowerCase() === target)) {
-            aliasMatches.push(notePath);
+          const basename = path
+            .basename(notePath, path.extname(notePath))
+            .toLowerCase();
+          if (basename === target) basenameMatches.push(notePath);
+        }
+      }
+
+      // For alias matches, read through the shared content cache so repeat
+      // lookups reuse warm note bodies while preserving per-note path checks.
+      const aliasMatches: string[] = [];
+      const { contents } = await readAllCached(
+        vaultPath,
+        notes,
+        (note, err) => {
+          log.warn("resolve_alias: note read failed", { note, err });
+        }
+      );
+      for (const notePath of notes) {
+        const content = contents.get(notePath);
+        if (content === undefined) continue;
+        const aliases = extractAliases(content);
+        if (aliases.some((a) => a.toLowerCase() === target)) {
+          aliasMatches.push(notePath);
+        }
+      }
+
+      const total = aliasMatches.length + basenameMatches.length;
+      if (total === 0) {
+        return text(
+          `No alias or basename match for "${displayReadValue(name)}"`
+        );
+      }
+
+      return richText(
+        aliasMatches.length > 0
+          ? "resolve_alias alias paths"
+          : "resolve_alias basename paths",
+        (b) => {
+          b.trusted(`Matches for "${displayReadValue(name)}":`);
+          b.trusted("");
+          if (aliasMatches.length > 0) {
+            b.trusted(`Alias matches (${aliasMatches.length}):`);
+            b.untrusted(
+              "resolve_alias alias paths",
+              aliasMatches.map((p) => `- ${displayReadValue(p)}`).join("\n"),
+              "  "
+            );
+          }
+          if (basenameMatches.length > 0) {
+            if (aliasMatches.length > 0) b.trusted("");
+            b.trusted(`Basename matches (${basenameMatches.length}):`);
+            b.untrusted(
+              "resolve_alias basename paths",
+              basenameMatches.map((p) => `- ${displayReadValue(p)}`).join("\n"),
+              "  "
+            );
           }
         }
-
-        const total = aliasMatches.length + basenameMatches.length;
-        if (total === 0) {
-          return { content: [{ type: "text" as const, text: `No alias or basename match for "${displayReadValue(name)}"` }] };
-        }
-
-        const lines: string[] = [`Matches for "${displayReadValue(name)}":`, ""];
-        if (aliasMatches.length > 0) {
-          lines.push(`Alias matches (${aliasMatches.length}):`);
-          lines.push(untrustedReadBlock(
-            "resolve_alias alias paths",
-            aliasMatches.map((p) => `- ${displayReadValue(p)}`).join("\n"),
-            "  ",
-          ));
-        }
-        if (basenameMatches.length > 0) {
-          if (aliasMatches.length > 0) lines.push("");
-          lines.push(`Basename matches (${basenameMatches.length}):`);
-          lines.push(untrustedReadBlock(
-            "resolve_alias basename paths",
-            basenameMatches.map((p) => `- ${displayReadValue(p)}`).join("\n"),
-            "  ",
-          ));
-        }
-        return {
-          content: [{
-            type: "text" as const,
-            text: lines.join("\n"),
-            _meta: untrustedVaultContentMeta(
-              aliasMatches.length > 0 ? "resolve_alias alias paths" : "resolve_alias basename paths",
-            ),
-          }],
-        };
-      } catch (err) {
-        log.error("resolve_alias failed", { tool: "resolve_alias", err: err as Error });
-        return errorResult(`Error resolving alias: ${sanitizeError(err)}`);
-      }
-    },
+      );
+    }
   );
 }

--- a/src/tools/read/search_by_frontmatter.ts
+++ b/src/tools/read/search_by_frontmatter.ts
@@ -2,16 +2,24 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { listNotes } from "../../lib/vault.js";
 import { readAllCached } from "../../lib/index-cache.js";
-import { sanitizeError } from "../../lib/errors.js";
 import { log } from "../../lib/logger.js";
-import { formatUntrustedVaultContent, indentBlock, untrustedVaultContentMeta } from "../../lib/tool-output.js";
 import { parseFrontmatter } from "../../lib/markdown.js";
-import { displayReadValue, errorResult, frontmatterValueForProperty, toSearchableString, untrustedReadBlock } from "./shared.js";
+import { defineTool, richText, text } from "../../lib/tool-seam.js";
+import {
+  displayReadValue,
+  frontmatterValueForProperty,
+  toSearchableString,
+} from "./shared.js";
 
-export function registerSearchByFrontmatterTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "search_by_frontmatter",
+export function registerSearchByFrontmatterTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "search_by_frontmatter",
       title: "Search by Frontmatter",
       description:
         "Find notes whose YAML frontmatter contains a given property/value pair. Property names and values are matched case-insensitively; for array-valued properties, a match is declared if any element matches. Returns matching note paths with their full frontmatter. Use to filter notes by metadata like status, type, or tags stored in frontmatter.",
@@ -25,17 +33,23 @@ export function registerSearchByFrontmatterTool(server: McpServer, vaultPath: st
           .string()
           .min(1)
           .max(200)
-          .describe("Frontmatter key to look up, case-insensitively (e.g., 'status', 'type', 'author')"),
+          .describe(
+            "Frontmatter key to look up, case-insensitively (e.g., 'status', 'type', 'author')"
+          ),
         value: z
           .string()
           .min(1)
           .max(1000)
-          .describe("Value to match against the property (case-insensitive; matches any array element)"),
+          .describe(
+            "Value to match against the property (case-insensitive; matches any array element)"
+          ),
         folder: z
           .string()
           .max(500)
           .optional()
-          .describe("Restrict search to this folder relative to the vault root (omit to search entire vault)"),
+          .describe(
+            "Restrict search to this folder relative to the vault root (omit to search entire vault)"
+          ),
         maxResults: z
           .number()
           .int()
@@ -43,88 +57,85 @@ export function registerSearchByFrontmatterTool(server: McpServer, vaultPath: st
           .max(500)
           .optional()
           .default(50)
-          .describe("Maximum number of matching notes to return (1-500, default: 50)"),
+          .describe(
+            "Maximum number of matching notes to return (1-500, default: 50)"
+          ),
       },
     },
     async ({ property, value, folder, maxResults }) => {
-      try {
-        const notes = await listNotes(vaultPath, folder);
-        const valueLower = value.toLowerCase();
+      const notes = await listNotes(vaultPath, folder);
+      const valueLower = value.toLowerCase();
 
-        type Hit = { path: string; frontmatter: Record<string, unknown> };
-        const allMatches: Hit[] = [];
-        const { contents } = await readAllCached(vaultPath, notes, (note, err) => {
+      type Hit = { path: string; frontmatter: Record<string, unknown> };
+      const allMatches: Hit[] = [];
+      const { contents } = await readAllCached(
+        vaultPath,
+        notes,
+        (note, err) => {
           log.warn("search_by_frontmatter: note read failed", { note, err });
-        });
-        for (const notePath of notes) {
-          const content = contents.get(notePath);
-          if (content === undefined) continue;
-          const { data: frontmatterData } = parseFrontmatter(content);
-          const propValue = frontmatterValueForProperty(frontmatterData, property);
-          if (propValue === undefined) continue;
-
-          const stringified = Array.isArray(propValue)
-            ? propValue.map(toSearchableString)
-            : [toSearchableString(propValue)];
-          const isMatch = stringified.some((v) => v.toLowerCase() === valueLower);
-          if (isMatch) allMatches.push({ path: notePath, frontmatter: frontmatterData });
         }
+      );
+      for (const notePath of notes) {
+        const content = contents.get(notePath);
+        if (content === undefined) continue;
+        const { data: frontmatterData } = parseFrontmatter(content);
+        const propValue = frontmatterValueForProperty(
+          frontmatterData,
+          property
+        );
+        if (propValue === undefined) continue;
 
-        if (allMatches.length === 0) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `No notes found with frontmatter "${displayReadValue(property)}" matching "${displayReadValue(value)}"`,
-              },
-            ],
-          };
-        }
+        const stringified = Array.isArray(propValue)
+          ? propValue.map(toSearchableString)
+          : [toSearchableString(propValue)];
+        const isMatch = stringified.some((v) => v.toLowerCase() === valueLower);
+        if (isMatch)
+          allMatches.push({ path: notePath, frontmatter: frontmatterData });
+      }
 
-        const totalMatches = allMatches.length;
-        const truncated = totalMatches > maxResults;
-        const matches = truncated ? allMatches.slice(0, maxResults) : allMatches;
+      if (allMatches.length === 0) {
+        return text(
+          `No notes found with frontmatter "${displayReadValue(property)}" matching "${displayReadValue(value)}"`
+        );
+      }
 
-        const lines: string[] = [
-          `Found ${totalMatches} note(s) where "${displayReadValue(property)}" matches "${displayReadValue(value)}"${truncated ? ` (showing first ${maxResults})` : ""}:`,
-          "",
-        ];
+      const totalMatches = allMatches.length;
+      const truncated = totalMatches > maxResults;
+      const matches = truncated ? allMatches.slice(0, maxResults) : allMatches;
 
+      return richText("search_by_frontmatter paths and values", (b) => {
+        b.trusted(
+          `Found ${totalMatches} note(s) where "${displayReadValue(property)}" matches "${displayReadValue(value)}"${truncated ? ` (showing first ${maxResults})` : ""}:`
+        );
+        b.trusted("");
         for (const match of matches) {
-          lines.push("Result path:");
-          lines.push(untrustedReadBlock(
+          b.trusted("Result path:");
+          b.untrusted(
             "search_by_frontmatter result path",
             displayReadValue(match.path),
-            "  ",
-          ));
+            "  "
+          );
           const frontmatterLines: string[] = [];
           for (const [key, val] of Object.entries(match.frontmatter)) {
-            frontmatterLines.push(`${displayReadValue(key)}: ${displayReadValue(JSON.stringify(val) ?? "")}`);
+            frontmatterLines.push(
+              `${displayReadValue(key)}: ${displayReadValue(JSON.stringify(val) ?? "")}`
+            );
           }
           if (frontmatterLines.length > 0) {
-            lines.push(indentBlock(
-              formatUntrustedVaultContent("search_by_frontmatter values", frontmatterLines.join("\n")),
-              "  ",
-            ));
+            b.untrusted(
+              "search_by_frontmatter values",
+              frontmatterLines.join("\n"),
+              "  "
+            );
           }
-          lines.push("");
+          b.trusted("");
         }
-
         if (truncated) {
-          lines.push(`(${totalMatches - maxResults} more result(s) omitted. Increase maxResults or narrow the search.)`);
+          b.trusted(
+            `(${totalMatches - maxResults} more result(s) omitted. Increase maxResults or narrow the search.)`
+          );
         }
-
-        return {
-          content: [{
-            type: "text" as const,
-            text: lines.join("\n"),
-            _meta: untrustedVaultContentMeta("search_by_frontmatter paths and values"),
-          }],
-        };
-      } catch (err) {
-        log.error("search_by_frontmatter failed", { tool: "search_by_frontmatter", err: err as Error });
-        return errorResult(`Error searching by frontmatter: ${sanitizeError(err)}`);
-      }
-    },
+      });
+    }
   );
 }

--- a/src/tools/read/search_notes.ts
+++ b/src/tools/read/search_notes.ts
@@ -2,15 +2,19 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { searchInContents, listNotes } from "../../lib/vault.js";
 import { readAllCached } from "../../lib/index-cache.js";
-import { sanitizeError } from "../../lib/errors.js";
 import { log } from "../../lib/logger.js";
-import { formatUntrustedVaultContent, indentBlock, untrustedVaultContentMeta } from "../../lib/tool-output.js";
-import { displayReadValue, errorResult, untrustedReadBlock } from "./shared.js";
+import { defineTool, richText, text } from "../../lib/tool-seam.js";
+import { displayReadValue } from "./shared.js";
 
-export function registerSearchNotesTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "search_notes",
+export function registerSearchNotesTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "search_notes",
       title: "Search Notes",
       description:
         "Full-text search across all notes in the vault. Ranks literal matches with title/path focus and repeated-line dampening, then returns matching note paths grouped with the line numbers and query-centered snippet content of each matching line. Use to locate notes containing a phrase, keyword, or code fragment; pair with get_note to retrieve full bodies.",
@@ -24,12 +28,16 @@ export function registerSearchNotesTool(server: McpServer, vaultPath: string): v
           .string()
           .min(1)
           .max(1000)
-          .describe("Literal search string matched against note body text (not regex)"),
+          .describe(
+            "Literal search string matched against note body text (not regex)"
+          ),
         caseSensitive: z
           .boolean()
           .optional()
           .default(false)
-          .describe("If true, match case exactly; otherwise case-insensitive (default: false)"),
+          .describe(
+            "If true, match case exactly; otherwise case-insensitive (default: false)"
+          ),
         maxResults: z
           .number()
           .int()
@@ -37,75 +45,62 @@ export function registerSearchNotesTool(server: McpServer, vaultPath: string): v
           .max(500)
           .optional()
           .default(20)
-          .describe("Maximum number of matching notes to return (1-500, default: 20)"),
+          .describe(
+            "Maximum number of matching notes to return (1-500, default: 20)"
+          ),
         folder: z
           .string()
           .max(500)
           .optional()
-          .describe("Restrict search to this folder relative to the vault root (omit to search entire vault)"),
+          .describe(
+            "Restrict search to this folder relative to the vault root (omit to search entire vault)"
+          ),
       },
     },
     async ({ query, caseSensitive, maxResults, folder }) => {
-      try {
-        // Pull notes via the mtime cache so repeat searches with hot files
-        // skip re-reads. The pure matcher (`searchInContents`) does the
-        // line-level scan on the in-memory map.
-        const notes = await listNotes(vaultPath, folder);
-        const { contents } = await readAllCached(vaultPath, notes, (note, err) => {
+      // Pull notes via the mtime cache so repeat searches with hot files
+      // skip re-reads. The pure matcher (`searchInContents`) does the
+      // line-level scan on the in-memory map.
+      const notes = await listNotes(vaultPath, folder);
+      const { contents } = await readAllCached(
+        vaultPath,
+        notes,
+        (note, err) => {
           log.warn("search_notes: note read failed", { note, err });
-        });
-        const results = searchInContents(notes, contents, query, {
-          caseSensitive,
-          maxResults,
-        });
-
-        if (results.length === 0) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `No results found for "${displayReadValue(query)}"`,
-              },
-            ],
-          };
         }
+      );
+      const results = searchInContents(notes, contents, query, {
+        caseSensitive,
+        maxResults,
+      });
 
-        const lines: string[] = [
-          `Found ${results.length} result(s) for "${displayReadValue(query)}":`,
-          "",
-        ];
+      if (results.length === 0) {
+        return text(`No results found for "${displayReadValue(query)}"`);
+      }
 
+      return richText("search_notes paths and snippets", (b) => {
+        b.trusted(
+          `Found ${results.length} result(s) for "${displayReadValue(query)}":`
+        );
+        b.trusted("");
         for (const result of results) {
-          lines.push("Result path:");
-          lines.push(untrustedReadBlock(
+          b.trusted("Result path:");
+          b.untrusted(
             "search_notes result path",
             displayReadValue(result.relativePath),
-            "  ",
-          ));
+            "  "
+          );
           for (const match of result.matches) {
-            lines.push(`  Line ${match.line}:`);
-            lines.push(indentBlock(
-              formatUntrustedVaultContent(
-                "search_notes snippet",
-                displayReadValue(match.content),
-              ),
-              "    ",
-            ));
+            b.trusted(`  Line ${match.line}:`);
+            b.untrusted(
+              "search_notes snippet",
+              displayReadValue(match.content),
+              "    "
+            );
           }
-          lines.push("");
+          b.trusted("");
         }
-
-        return {
-          content: [{
-            type: "text" as const,
-            text: lines.join("\n"),
-            _meta: untrustedVaultContentMeta("search_notes paths and snippets"),
-          }],
-        };
-      } catch (err) {
-        log.error("search_notes failed", { tool: "search_notes", err: err as Error });
-        return errorResult(`Error searching notes: ${sanitizeError(err)}`);
-      }
-    },
+      });
+    }
   );
 }

--- a/src/tools/read/shared.ts
+++ b/src/tools/read/shared.ts
@@ -1,29 +1,13 @@
-import {
-  formatUntrustedVaultContent,
-  indentBlock,
-  untrustedTextContent,
-} from "../../lib/tool-output.js";
 import { escapeControlChars } from "../../lib/errors.js";
+
+// The error/result/trust-wrapping recipe (errorResult, untrustedReadBlock,
+// untrustedTextContent) now lives in the tool seam (../../lib/tool-seam.ts):
+// handlers return a ToolResult built via `text` / `untrustedText` / `richText`
+// / `error`, and the seam owns error sanitization. What remains here are the
+// read group's own parsing/escaping helpers.
 
 export function displayReadValue(value: string): string {
   return escapeControlChars(value);
-}
-
-export function errorResult(text: string, meta?: Record<string, unknown>) {
-  return {
-    content: [
-      { type: "text" as const, text, ...(meta ? { _meta: meta } : {}) },
-    ],
-    isError: true as const,
-  };
-}
-
-export function untrustedReadBlock(
-  label: string,
-  text: string,
-  indent = ""
-): string {
-  return indentBlock(formatUntrustedVaultContent(label, text), indent);
 }
 
 export function frontmatterValueForProperty(
@@ -98,5 +82,3 @@ export function parseSince(input: string): number | null {
   if (!Number.isNaN(parsed)) return parsed;
   return null;
 }
-
-export { untrustedTextContent };


### PR DESCRIPTION
## What

Introduces the **tool seam** (`src/lib/tool-seam.ts`) — one deep module every
MCP tool is registered through — and migrates the `read` group (8 tools) through
it as the pattern-setter.

Before, all 41 tools re-implemented the same recipe inline: a terminal
`try/catch` that logged and sanitized thrown errors, plus manual
untrusted-content wrapping of vault-derived text. Two security concerns had no
single choke point:

- **Error-response sanitization** was smeared — `errorResult` takes
  pre-formatted text and does not sanitize, so a handler could leak raw
  paths/secrets. `add_canvas_edge` already leaked raw `err.message`.
- **Untrusted-content trust-wrapping** was smeared across ~45 call sites and
  applied per-handler; a new handler returning plain `{ type: "text", text }`
  would compile and silently emit vault text as trusted.

The log channel already sanitizes at `emit()` as a choke point; the
error-response and trust-wrapping channels were the outliers this closes.

## How

`defineTool(server, vaultPath, spec, handler)` owns registration, `ctx`
assembly, the error boundary (log + `sanitizeError`), and result rendering +
trust-wrapping. Handlers return a **branded `ToolResult`** built via `text` /
`untrustedText` / `richText` / `error` — a raw `{ content }` literal does not
type-check, so trust-wrapping is enforced by construction. Each tool's
`title`/`description`/`annotations`/`inputSchema` surface is unchanged.

## Safety

- **Byte-preserving.** The seam reuses the existing `tool-output.ts` primitives,
  so every `regression-tools-*` and `handlers/*` interface test stays green
  unchanged.
- Two intentional behaviour changes (see ADR 0001):
  1. Thrown errors now use a single generic `Error:` prefix (no test pins it).
  2. `add_canvas_edge` inner catches will be sanitized when that group migrates.
- Arg-type inference verified to survive the generic `defineTool` (a wrong-type
  probe was rejected by `tsc`).

## Gates

`typecheck` · `lint` · `build` all clean; **978 tests pass** (15 skipped).

## Scope / follow-up

Read group only. The other 8 groups are the file-disjoint fan-out from here,
each adding its block constructors (`image`/`audio`/`blobResource`/
`untrustedResource` for attachments) and deleting its recipe helpers. See
`docs/adr/0001-tool-seam.md` and `CONTEXT.md`.
