### PR TITLE
chore(deps): migrate js-yaml v4 to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^5.2.1",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -18,7 +18,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.12.4",
         "eslint": "^10.4.1",
         "fallow": "^2.101.0",
@@ -790,13 +789,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2399,9 +2391,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "funding": [
         {
           "type": "github",
@@ -2417,7 +2409,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-buffer": {

--- a/package.json
+++ b/package.json
@@ -59,12 +59,11 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^5.2.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.12.4",
     "eslint": "^10.4.1",
     "fallow": "^2.101.0",

--- a/src/__tests__/bases.test.ts
+++ b/src/__tests__/bases.test.ts
@@ -8,7 +8,10 @@ import {
 
 const noteWithFrontmatter = (data: Record<string, unknown>, body = "") => {
   const fm = Object.entries(data)
-    .map(([k, v]) => `${k}: ${typeof v === "string" ? `"${v}"` : JSON.stringify(v)}`)
+    .map(
+      ([k, v]) =>
+        `${k}: ${typeof v === "string" ? `"${v}"` : JSON.stringify(v)}`
+    )
     .join("\n");
   return `---\n${fm}\n---\n${body}`;
 };
@@ -23,7 +26,11 @@ describe("parseBaseFile", () => {
   });
 
   it("emits a warning for invalid YAML", () => {
-    const { warnings } = parseBaseFile(":\n  - broken\n");
+    // js-yaml v5's parser is more lenient than v4: it accepts `:\n  - broken`
+    // as `{ "": ["broken"] }` (empty-string key) where v4 threw. Use input
+    // that is malformed under both (a mapping value that is itself a mapping
+    // entry) so this still exercises the parse-error warning path.
+    const { warnings } = parseBaseFile("key: value: extra\n");
     expect(warnings.length).toBeGreaterThan(0);
   });
 
@@ -57,9 +64,18 @@ describe("parseBaseFile", () => {
 
 describe("evaluateFilter / queryBase", () => {
   const rows = [
-    buildRow("a.md", noteWithFrontmatter({ status: "active" }, "Body #project text")),
-    buildRow("b.md", noteWithFrontmatter({ status: "done" }, "Body #other text")),
-    buildRow("c.md", noteWithFrontmatter({ status: "active", priority: 5 }, "#project/alpha")),
+    buildRow(
+      "a.md",
+      noteWithFrontmatter({ status: "active" }, "Body #project text")
+    ),
+    buildRow(
+      "b.md",
+      noteWithFrontmatter({ status: "done" }, "Body #other text")
+    ),
+    buildRow(
+      "c.md",
+      noteWithFrontmatter({ status: "active", priority: 5 }, "#project/alpha")
+    ),
   ];
 
   it("supports taggedWith()", () => {
@@ -95,14 +111,18 @@ describe("evaluateFilter / queryBase", () => {
 
   it("warns on unknown filter functions and treats as no-match", () => {
     const ctx = { warnings: [] };
-    expect(evaluateFilter(rows[0], "mysteryFn(\"x\")", ctx)).toBe(false);
+    expect(evaluateFilter(rows[0], 'mysteryFn("x")', ctx)).toBe(false);
     expect(ctx.warnings.length).toBe(1);
   });
 
   it("warns on unknown filter shapes and treats as no-match", () => {
     const ctx = { warnings: [] };
-    expect(evaluateFilter(rows[0], { custom: ["status"] } as never, ctx)).toBe(false);
-    expect(ctx.warnings.some((w) => w.includes("Unknown filter shape"))).toBe(true);
+    expect(evaluateFilter(rows[0], { custom: ["status"] } as never, ctx)).toBe(
+      false
+    );
+    expect(ctx.warnings.some((w) => w.includes("Unknown filter shape"))).toBe(
+      true
+    );
   });
 
   it("fails closed when filter recursion exceeds the cap", () => {
@@ -113,7 +133,9 @@ describe("evaluateFilter / queryBase", () => {
 
     const result = queryBase(rows, { filters: filter as never });
     expect(result.rows).toHaveLength(0);
-    expect(result.warnings.some((w) => w.includes("recursion exceeded"))).toBe(true);
+    expect(result.warnings.some((w) => w.includes("recursion exceeded"))).toBe(
+      true
+    );
   });
 
   it("supports numeric > comparison", () => {
@@ -122,16 +144,20 @@ describe("evaluateFilter / queryBase", () => {
   });
 
   it("supports view-level filters layered on top of base filters", () => {
-    const result = queryBase(rows, {
-      filters: ['status == "active"'],
-      views: [
-        {
-          type: "table",
-          name: "high-priority",
-          filters: ["priority > 3"],
-        },
-      ],
-    }, "high-priority");
+    const result = queryBase(
+      rows,
+      {
+        filters: ['status == "active"'],
+        views: [
+          {
+            type: "table",
+            name: "high-priority",
+            filters: ["priority > 3"],
+          },
+        ],
+      },
+      "high-priority"
+    );
     expect(result.rows.map((r) => r.path)).toEqual(["c.md"]);
   });
 });

--- a/src/__tests__/markdown.test.ts
+++ b/src/__tests__/markdown.test.ts
@@ -121,7 +121,7 @@ The body.`;
     const content = [
       "---",
       "title: R&D notes",
-      "pattern: \"*.md\"",
+      'pattern: "*.md"',
       "plain: look * here and R & D",
       "emphasis: note *emphasis*",
       "---",
@@ -186,7 +186,7 @@ ${body}`;
 
   it("refuses to update oversized frontmatter", () => {
     expect(() =>
-      updateFrontmatter(oversizedFrontmatter(), { status: "safe" }),
+      updateFrontmatter(oversizedFrontmatter(), { status: "safe" })
     ).toThrow(/Frontmatter block exceeds size cap/);
   });
 
@@ -200,8 +200,32 @@ ${body}`;
       "Body.",
     ].join("\n");
     expect(() => updateFrontmatter(content, { status: "safe" })).toThrow(
-      /anchors and aliases/i,
+      /anchors and aliases/i
     );
+  });
+
+  // Pins the js-yaml v4 -> v5 migration risk: v5's dump defaults changed
+  // (YAML-1.1-based schema), but it still emits single-quoted scalars by
+  // default, so quoteWikilinksInFrontmatter must still normalize wikilink
+  // values to Obsidian's required double-quoted form on round-trip.
+  it("double-quotes wikilink values after a v5 dump round-trip", () => {
+    const updated = updateFrontmatter("Body.", {
+      link: "[[Episode IV]]",
+      related: ["[[A]]", "[[B]]"],
+      plain: "no link here",
+    });
+    // Emitted frontmatter uses the double-quoted wikilink form Obsidian needs,
+    // never the bare or single-quoted form.
+    expect(updated).toContain('link: "[[Episode IV]]"');
+    expect(updated).toContain('"[[A]]"');
+    expect(updated).toContain('"[[B]]"');
+    expect(updated).not.toMatch(/link:\s*\[\[/); // not bare
+    expect(updated).not.toMatch(/'\[\[/); // not single-quoted
+    // And it parses back to the original values.
+    const parsed = parseFrontmatter(updated);
+    expect(parsed.data.link).toBe("[[Episode IV]]");
+    expect(parsed.data.related).toEqual(["[[A]]", "[[B]]"]);
+    expect(parsed.data.plain).toBe("no link here");
   });
 });
 
@@ -254,7 +278,9 @@ describe("extractWikilinks", () => {
     // ``code with ` inside`` is a CommonMark code span; the wikilink within
     // must not be extracted. The single-backtick regex used previously
     // missed this and rewrote into the code span.
-    const links = extractWikilinks("Use ``with ` and [[skip]]`` outside [[hit]].");
+    const links = extractWikilinks(
+      "Use ``with ` and [[skip]]`` outside [[hit]]."
+    );
     expect(links.map((l) => l.target)).toEqual(["hit"]);
   });
 
@@ -525,7 +551,7 @@ describe("resolveWikilink", () => {
     const result = resolveWikilink(
       "unique-note#some-heading",
       "any.md",
-      allPaths,
+      allPaths
     );
     expect(result).toBe("zettelkasten/unique-note.md");
   });
@@ -547,10 +573,12 @@ describe("resolveWikilink", () => {
 
   it("normalizes path dot segments before basename fallback", () => {
     const paths = ["archive/idea.md", "projects/idea.md"];
-    expect(resolveWikilink("./projects/idea", "ref.md", paths)).toBe("projects/idea.md");
-    expect(resolveWikilink("archive/../projects/idea#Heading", "ref.md", paths)).toBe(
-      "projects/idea.md",
+    expect(resolveWikilink("./projects/idea", "ref.md", paths)).toBe(
+      "projects/idea.md"
     );
+    expect(
+      resolveWikilink("archive/../projects/idea#Heading", "ref.md", paths)
+    ).toBe("projects/idea.md");
   });
 });
 
@@ -573,12 +601,7 @@ aliases:
 ---
 Some body #inline-tag with [[link]].`;
 
-    const meta = buildNoteMetadata(
-      "/vault",
-      "notes/test.md",
-      content,
-      stats,
-    );
+    const meta = buildNoteMetadata("/vault", "notes/test.md", content, stats);
 
     expect(meta.relativePath).toBe("notes/test.md");
     expect(meta.size).toBe(1024);
@@ -601,7 +624,12 @@ Body.`;
 
   it("should fall back to filename for title", () => {
     const content = "No frontmatter, plain body.";
-    const meta = buildNoteMetadata("/vault", "notes/my-note.md", content, stats);
+    const meta = buildNoteMetadata(
+      "/vault",
+      "notes/my-note.md",
+      content,
+      stats
+    );
     expect(meta.title).toBe("my-note");
   });
 });
@@ -643,7 +671,9 @@ describe("extractWikilinkSpans", () => {
   });
 
   it("skips wikilinks inside fenced code blocks", () => {
-    const c = ["before [[real]]", "```", "[[notreal]]", "```", "after"].join("\n");
+    const c = ["before [[real]]", "```", "[[notreal]]", "```", "after"].join(
+      "\n"
+    );
     const spans = extractWikilinkSpans(c);
     expect(spans).toHaveLength(1);
     expect(spans[0].target).toBe("real");
@@ -670,7 +700,9 @@ describe("extractWikilinkSpans", () => {
   });
 
   it("skips wikilinks inside 4-space indented code blocks", () => {
-    const c = ["before [[real]]", "", "    [[skip-me]]", "", "after"].join("\n");
+    const c = ["before [[real]]", "", "    [[skip-me]]", "", "after"].join(
+      "\n"
+    );
     const spans = extractWikilinkSpans(c);
     expect(spans.map((s) => s.target)).toEqual(["real"]);
   });

--- a/src/lib/bases.ts
+++ b/src/lib/bases.ts
@@ -1,4 +1,4 @@
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import path from "path";
 import { parseFrontmatter, extractTags } from "./markdown.js";
 import {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,4 +1,4 @@
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import path from "path";
 import type { NoteMetadata, LinkInfo } from "../types.js";
 import { hasYamlAnchorOrAliasToken } from "./yaml.js";
@@ -36,21 +36,24 @@ function scanYamlFrontmatter(content: string): FrontmatterScan {
     }
 
     const lineEnd = content.indexOf("\n", lineStart);
-    const rawLine = lineEnd === -1
-      ? content.slice(lineStart)
-      : content.slice(lineStart, lineEnd);
+    const rawLine =
+      lineEnd === -1
+        ? content.slice(lineStart)
+        : content.slice(lineStart, lineEnd);
     const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
 
     if (line === "---") {
       const yaml = content.slice(yamlStart, lineStart);
-      const bytes = Buffer.byteLength(
-        yaml,
-        "utf8",
-      );
+      const bytes = Buffer.byteLength(yaml, "utf8");
       if (bytes > MAX_FRONTMATTER_BYTES) {
         return { kind: "oversized", bytes };
       }
-      return { kind: "found", bytes, yaml, contentStart: lineEnd === -1 ? content.length : lineEnd + 1 };
+      return {
+        kind: "found",
+        bytes,
+        yaml,
+        contentStart: lineEnd === -1 ? content.length : lineEnd + 1,
+      };
     }
 
     if (lineEnd === -1) return { kind: "none" };
@@ -93,13 +96,21 @@ export function parseStrictYamlFrontmatter(content: string): ParsedFrontmatter {
       data: {},
       content,
       hasFrontmatter: true,
-      error: new Error("YAML frontmatter anchors and aliases are not supported."),
+      error: new Error(
+        "YAML frontmatter anchors and aliases are not supported."
+      ),
       bytes: scan.bytes,
     };
   }
 
   try {
-    const data = scan.yaml.trim() === "" ? {} : yaml.load(scan.yaml, { json: true });
+    // js-yaml v5 removed the `{ json: true }` load option (which made
+    // duplicate mapping keys last-wins instead of throwing). v5 throws on
+    // duplicate keys; the catch below turns that into tolerant empty-data,
+    // so a note with duplicate frontmatter keys now yields {} + error rather
+    // than silently keeping the last value. Empty input is guarded here
+    // because v5 `load('')` throws instead of returning undefined.
+    const data = scan.yaml.trim() === "" ? {} : yaml.load(scan.yaml);
     return {
       data: asFrontmatterObject(data),
       content: content.slice(scan.contentStart),
@@ -135,7 +146,7 @@ function parseFrontmatterForMutation(content: string): ParsedFrontmatter {
 
 export function stringifyYamlFrontmatter(
   content: string,
-  data: Record<string, unknown>,
+  data: Record<string, unknown>
 ): string {
   const yamlBlock = yaml.dump(data, {
     lineWidth: -1,
@@ -253,7 +264,7 @@ function quoteForYaml(value: string): string {
  */
 export function updateFrontmatter(
   content: string,
-  updates: Record<string, unknown>,
+  updates: Record<string, unknown>
 ): string {
   const parsed = parseFrontmatterForMutation(content);
   const merged = { ...parsed.data, ...updates };
@@ -287,7 +298,7 @@ function createCodeBlockTracker(): (line: string) => boolean {
       // backticks inside a code block would prematurely end the fence and
       // expose subsequent content to wikilink/markdown-link rewriting.
       const closePattern = new RegExp(
-        `^ {0,3}${fenceChar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}{${fenceLength},}\\s*$`,
+        `^ {0,3}${fenceChar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}{${fenceLength},}\\s*$`
       );
       if (closePattern.test(line)) {
         insideFence = false;
@@ -413,7 +424,8 @@ function findInlineCodeRanges(line: string): Array<[number, number]> {
         continue;
       }
       let closeLen = 0;
-      while (j + closeLen < line.length && line[j + closeLen] === "`") closeLen++;
+      while (j + closeLen < line.length && line[j + closeLen] === "`")
+        closeLen++;
       if (closeLen === openLen) {
         ranges.push([i, j + closeLen]);
         i = j + closeLen;
@@ -481,9 +493,12 @@ export function extractWikilinkSpans(content: string): WikilinkSpan[] {
         const inner = m[2]!;
         const pipeIndex = inner.indexOf("|");
         const before = pipeIndex >= 0 ? inner.slice(0, pipeIndex) : inner;
-        const alias = pipeIndex >= 0 ? inner.slice(pipeIndex + 1).trim() : undefined;
+        const alias =
+          pipeIndex >= 0 ? inner.slice(pipeIndex + 1).trim() : undefined;
         const hashIndex = before.indexOf("#");
-        const target = (hashIndex >= 0 ? before.slice(0, hashIndex) : before).trim();
+        const target = (
+          hashIndex >= 0 ? before.slice(0, hashIndex) : before
+        ).trim();
         const fragment = hashIndex >= 0 ? before.slice(hashIndex) : "";
 
         out.push({
@@ -584,7 +599,7 @@ export function extractMarkdownLinkSpans(content: string): MarkdownLinkSpan[] {
 export function formatWikilinkTarget(
   newPath: string,
   originalForm: string,
-  allNotes: readonly string[],
+  allNotes: readonly string[]
 ): string {
   const newWithoutExt = newPath.replace(/\.md$/i, "");
   const originalUsedPath = originalForm.includes("/");
@@ -642,7 +657,8 @@ export function extractTags(content: string): string[] {
   // Extract inline tags from body
   const lines = body.split("\n");
   const isInsideCodeBlock = createCodeBlockTracker();
-  const tagRegex = /(?:^|\s)#([a-zA-Z0-9\u00C0-\u024F\u0400-\u04FF\u4E00-\u9FFF\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF_][a-zA-Z0-9\u00C0-\u024F\u0400-\u04FF\u4E00-\u9FFF\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF_/-]*)/g;
+  const tagRegex =
+    /(?:^|\s)#([a-zA-Z0-9\u00C0-\u024F\u0400-\u04FF\u4E00-\u9FFF\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF_][a-zA-Z0-9\u00C0-\u024F\u0400-\u04FF\u4E00-\u9FFF\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF_/-]*)/g;
 
   for (const line of lines) {
     if (isInsideCodeBlock(line)) continue;
@@ -677,7 +693,10 @@ export function extractAliases(content: string): string[] {
   }
 
   if (typeof aliasField === "string") {
-    return aliasField.split(",").map((a: string) => a.trim()).filter(Boolean);
+    return aliasField
+      .split(",")
+      .map((a: string) => a.trim())
+      .filter(Boolean);
   }
 
   return [];
@@ -690,7 +709,7 @@ export function buildNoteMetadata(
   _vaultPath: string,
   relativePath: string,
   content: string,
-  stats: { size: number; created: Date | null; modified: Date | null },
+  stats: { size: number; created: Date | null; modified: Date | null }
 ): NoteMetadata {
   const { data } = parseFrontmatter(content);
   const tags = extractTags(content);
@@ -753,7 +772,7 @@ export function resolveWikilink(
   link: string,
   currentNotePath: string,
   allNotePaths: string[],
-  options: ResolveWikilinkOptions = {},
+  options: ResolveWikilinkOptions = {}
 ): string | null {
   // Strip heading anchors (`#...`) AND bare block refs (`^...`). Obsidian's
   // own block-ref syntax is `note#^id`, so `#` splits first and `^` is dead
@@ -781,16 +800,26 @@ export function resolveWikilink(
     for (const notePath of allNotePaths) {
       const withoutExt = notePath.replace(/\.md$/i, "").toLowerCase();
       if (withoutExt.endsWith(normalizedLinkLower)) {
-        const prefix = withoutExt.slice(0, withoutExt.length - normalizedLinkLower.length);
-        if (prefix === "" || prefix.endsWith("/")) suffixCandidates.push(notePath);
+        const prefix = withoutExt.slice(
+          0,
+          withoutExt.length - normalizedLinkLower.length
+        );
+        if (prefix === "" || prefix.endsWith("/"))
+          suffixCandidates.push(notePath);
       }
     }
     if (suffixCandidates.length === 1) return suffixCandidates[0]!;
     if (suffixCandidates.length > 1) {
       const sourceDir = path.dirname(currentNotePath).replace(/\\/g, "/");
       suffixCandidates.sort((a, b) => {
-        const da = sharedPathDepth(sourceDir, path.dirname(a).replace(/\\/g, "/"));
-        const db = sharedPathDepth(sourceDir, path.dirname(b).replace(/\\/g, "/"));
+        const da = sharedPathDepth(
+          sourceDir,
+          path.dirname(a).replace(/\\/g, "/")
+        );
+        const db = sharedPathDepth(
+          sourceDir,
+          path.dirname(b).replace(/\\/g, "/")
+        );
         if (da !== db) return db - da;
         return a.length - b.length;
       });
@@ -814,8 +843,14 @@ export function resolveWikilink(
     // Ties break on shortest overall path (closer to vault root).
     const sourceDir = path.dirname(currentNotePath).replace(/\\/g, "/");
     candidates.sort((a, b) => {
-      const da = sharedPathDepth(sourceDir, path.dirname(a).replace(/\\/g, "/"));
-      const db = sharedPathDepth(sourceDir, path.dirname(b).replace(/\\/g, "/"));
+      const da = sharedPathDepth(
+        sourceDir,
+        path.dirname(a).replace(/\\/g, "/")
+      );
+      const db = sharedPathDepth(
+        sourceDir,
+        path.dirname(b).replace(/\\/g, "/")
+      );
       if (da !== db) return db - da;
       return a.length - b.length;
     });


### PR DESCRIPTION
## Summary

Migrates `js-yaml` from `^4.2.0` to `^5.2.1`. v5 is a rewritten, ESM-only implementation with a new API. The repo's entire js-yaml surface is 4 call sites across two files, so the code change is small; the substance is the behavior deltas below.

- Swap the two default imports for namespace imports (`load`/`dump`/`JSON_SCHEMA` are now named exports; the migration guide sanctions `import * as yaml`).
- Drop the removed `{ json: true }` load option in `markdown.ts`.
- Remove `@types/js-yaml` (v5 ships its own types).

## Behavior deltas (none break existing coverage)

1. **Duplicate mapping keys** — v4 + `{ json: true }` was last-wins; v5 throws. The existing frontmatter `try/catch` turns that into tolerant empty-data, so a note with duplicate frontmatter keys now yields `{}` + error instead of silently keeping the last value. No v5 option restores the old behavior.
2. **Empty input** — v4 `load('')` returned `undefined`; v5 throws. Both call sites already guard this, so only an unasserted warning string differs.
3. **Parser leniency** — v5 accepts `:\n  - broken` as `{ "": ["broken"] }` (empty-string key) where v4 threw. This means some previously-rejected `.base`/frontmatter inputs now parse instead of warning. Repointed the one bases fixture that relied on the old rejection to input malformed under both versions.

## Wikilink-quoting risk: cleared

`stringifyYamlFrontmatter` depends on js-yaml emitting single-quoted scalars so `quoteWikilinksInFrontmatter` can normalize them to Obsidian's required double-quoted form. v5's dump schema changed (YAML-1.1-based) but it still defaults to single-quoted scalars, so the behavior is preserved. Added a frontmatter round-trip test pinning this directly.

## Gates

- `lint`, `typecheck`, `build`, `check:licenses` (v5 is MIT) all clean.
- `test`: **971 passed**, 15 skipped, 0 failed.

## Note

There is no forcing reason to leave `^4` — v4.2.0 works today. This is ready if we *want* v5's new AST/events API, not something required.
