### PR TITLE
refactor(tools): migrate canvas group through the tool seam

### DIFF
--- a/docs/adr/0001-tool-seam.md
+++ b/docs/adr/0001-tool-seam.md
@@ -1,6 +1,6 @@
 # ADR 0001: One deep tool seam behind every MCP tool
 
-- Status: Accepted (read group migrated as the pattern-setter; other 8 groups to follow)
+- Status: Accepted (read group migrated as the pattern-setter, canvas group migrated next; 7 groups to follow)
 - Date: 2026-07-18
 
 ## Context
@@ -24,8 +24,10 @@ The consequences:
 paths or secrets. Untrusted-content wrapping was smeared across ~45 call
 sites and applied inconsistently; a new handler returning a plain`{ type: "text", text }` would compile and silently emit vault text as if it
   were trusted.
-- One real instance already leaked: `add_canvas_edge`'s inner catches returned
-  `err.message` raw, bypassing `sanitizeError`.
+- One tool bypassed the choke point: `add_canvas_edge`'s inner catches returned
+  `err.message` directly — locally escaped via `displayCanvasValue`, but never
+  routed through `sanitizeError`, so the pattern (not those specific messages)
+  was one edit away from surfacing an unsanitized host path or secret.
 
 By contrast, the **log** channel already sanitizes inside `emit()` (a choke
 point), and permissions enforce at a single point in the vault layer. The
@@ -80,10 +82,15 @@ Non-text blocks (to be added when the attachments/canvas groups migrate;
 
 ## Consequences
 
-- Trust-wrapping and error sanitization become choke points. The seam is where
-  `add_canvas_edge`'s raw-`err.message` leak gets fixed once — when the canvas
-  group migrates through it. This change migrates only the read group, so that
-  leak is still open (see Migration).
+- Trust-wrapping and error sanitization become choke points. With the canvas
+  group migrated, `add_canvas_edge`'s **unexpected**-error path now routes
+  through the seam's single `sanitizeError` boundary (it was returned
+  unsanitized before). Its **expected** validation messages (missing/duplicate
+  node, self-loop) stay handler-authored and verbatim per the error model —
+  control-char escaped via `displayCanvasValue`, not re-sanitized. So the
+  closure is structural: no tool-layer terminal catch emits an unsanitized
+  message anymore. Pinned by a `handlers/canvas.test.ts` case that drives an
+  unexpected failure and asserts the generic sanitized result.
 - Output is **byte-preserving**. The seam reuses the existing `tool-output.ts`
   primitives, so every `regression-tools-*` and `handlers/*` interface test
   stays green unchanged. One intentional exception is recorded: the generic
@@ -122,10 +129,13 @@ compiler will not catch mis-threaded `extra`. Verify that plumbing at runtime
 
 ## Migration
 
-Read group first (this change). Remaining 8 groups are file-disjoint and convert
+Read group first (pattern-setter), canvas group next. The canvas group is all
+text, so it migrated using only the existing `text`/`richText`/`error`
+constructors and needed no seam changes; its conversion routes
+`add_canvas_edge`'s unexpected-error path through the seam's sanitize boundary
+(see Consequences). Remaining 7 groups are file-disjoint and convert
 independently, deleting each group's duplicated recipe helpers as it goes and
-extending the seam with the non-text block constructors when
-attachments/canvas migrate. Routing `add_canvas_edge` through the seam closes
-its raw-`err.message` leak as part of the canvas group's conversion. Collapsing the 9 `display*Value` aliases to a single
+extending the seam with the non-text block constructors when the attachments
+group migrates. Collapsing the 9 `display*Value` aliases to a single
 `escapeControlChars` import is a follow-up sweep. `TOOL_AUTHORING.md §4` is
 rewritten last, once the pattern is proven across all groups.

--- a/src/__tests__/handlers/canvas.test.ts
+++ b/src/__tests__/handlers/canvas.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
-import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
+import {
+  createTestEnv,
+  textContent,
+  isError,
+  type TestEnv,
+} from "./harness.js";
 import { MAX_CANVAS_FILE_BYTES } from "../../lib/vault.js";
 
 let env: TestEnv;
@@ -22,10 +27,14 @@ describe("canvas handlers — list_canvases", () => {
     });
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     const text = textContent(result);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: list_canvases paths]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: list_canvases paths]"
+    );
     expect(text).toContain("boards/test.canvas");
     expect(text).toMatch(/Found 1 canvas/);
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
   });
 });
 
@@ -47,13 +56,25 @@ describe("canvas handlers — read_canvas", () => {
     expect(text).toContain("[n2] type=file");
     expect(text).toContain("note-a.md");
     expect(text).toContain("n1 -> n2");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas edge label]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas edge label: boards/test.canvas#e1]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: read_canvas edge label]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: canvas edge label: boards/test.canvas#e1]"
+    );
     expect(text).toContain("refs");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas node content]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas node content: boards/test.canvas#n1]");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
-    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("read_canvas summary");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: read_canvas node content]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: canvas node content: boards/test.canvas#n1]"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "read_canvas summary"
+    );
   });
 
   it("serves repeated reads without changing the rendered summary", async () => {
@@ -83,13 +104,37 @@ describe("canvas handlers — read_canvas", () => {
       canvasPath,
       JSON.stringify({
         nodes: [
-          { id: "n1", type: "text", x: 0, y: 0, width: 200, height: 100, text: "Hello canvas" },
-          { id: "n2", type: "file", x: 300, y: 0, width: 200, height: 100, file: "note-a.md" },
-          { id: "n3", type: "text", x: 500, y: 0, width: 200, height: 100, text: "Fresh edit" },
+          {
+            id: "n1",
+            type: "text",
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 100,
+            text: "Hello canvas",
+          },
+          {
+            id: "n2",
+            type: "file",
+            x: 300,
+            y: 0,
+            width: 200,
+            height: 100,
+            file: "note-a.md",
+          },
+          {
+            id: "n3",
+            type: "text",
+            x: 500,
+            y: 0,
+            width: 200,
+            height: 100,
+            text: "Fresh edit",
+          },
         ],
         edges: [{ id: "e1", fromNode: "n1", toNode: "n2", label: "refs" }],
       }),
-      "utf-8",
+      "utf-8"
     );
     const future = new Date(Date.now() + 5_000);
     await fs.utimes(canvasPath, future, future);
@@ -133,7 +178,7 @@ describe("canvas handlers — read_canvas", () => {
     await fs.writeFile(
       path.join(env.vaultDir, "bad.canvas"),
       "{ this is not, valid json",
-      "utf-8",
+      "utf-8"
     );
     const result = await env.client.callTool({
       name: "read_canvas",
@@ -147,7 +192,7 @@ describe("canvas handlers — read_canvas", () => {
     await fs.writeFile(
       path.join(env.vaultDir, "huge.canvas"),
       "x".repeat(MAX_CANVAS_FILE_BYTES + 1),
-      "utf-8",
+      "utf-8"
     );
 
     const result = await env.client.callTool({
@@ -180,7 +225,7 @@ describe("canvas handlers — read_canvas", () => {
     await fs.writeFile(
       path.join(env.vaultDir, "crowded.canvas"),
       JSON.stringify({ nodes, edges }),
-      "utf-8",
+      "utf-8"
     );
 
     const result = await env.client.callTool({
@@ -235,7 +280,7 @@ describe("canvas handlers — read_canvas", () => {
           },
         ],
       }),
-      "utf-8",
+      "utf-8"
     );
 
     const result = await env.client.callTool({
@@ -244,21 +289,43 @@ describe("canvas handlers — read_canvas", () => {
     });
     expect(isError(result)).toBe(false);
     const text = textContent(result);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas node identity]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas node identity: dirty.canvas#bad\\nnode]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: read_canvas node identity]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: canvas node identity: dirty.canvas#bad\\nnode]"
+    );
     expect(text).toContain("[bad\\nnode] type=text");
     expect(text).toContain("content:");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas node content]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas node content: dirty.canvas#bad\\nnode]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: read_canvas node content]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: canvas node content: dirty.canvas#bad\\nnode]"
+    );
     expect(text).toContain("first\\nsecond");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas node color]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas node color: dirty.canvas#bad\\nnode]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: read_canvas node color]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: canvas node color: dirty.canvas#bad\\nnode]"
+    );
     expect(text).toContain("red\\nblue");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas edge endpoints]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas edge endpoints: dirty.canvas#edge-1]");
-    expect(text).toContain("bad\\nnode -> clean (from-side=left\\nside to-side=right)");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: read_canvas edge label]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: canvas edge label: dirty.canvas#edge-1]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: read_canvas edge endpoints]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: canvas edge endpoints: dirty.canvas#edge-1]"
+    );
+    expect(text).toContain(
+      "bad\\nnode -> clean (from-side=left\\nside to-side=right)"
+    );
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: read_canvas edge label]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: canvas edge label: dirty.canvas#edge-1]"
+    );
     expect(text).toContain("label\\nspoof");
     expect(text).not.toContain("bad\nnode");
     expect(text).not.toContain("red\nblue");
@@ -287,9 +354,11 @@ describe("canvas handlers — add_canvas_node", () => {
 
     const canvasRaw = await fs.readFile(
       path.join(env.vaultDir, "boards/test.canvas"),
-      "utf-8",
+      "utf-8"
     );
-    const canvas = JSON.parse(canvasRaw) as { nodes: Array<{ id: string; text?: string }> };
+    const canvas = JSON.parse(canvasRaw) as {
+      nodes: Array<{ id: string; text?: string }>;
+    };
     expect(canvas.nodes).toHaveLength(3);
     const added = canvas.nodes.find((n) => n.id === idMatch![1]);
     expect(added?.text).toBe("A new thought");
@@ -391,17 +460,22 @@ describe("canvas handlers — add_canvas_node", () => {
     expect(isError(result)).toBe(false);
     const canvasRaw = await fs.readFile(
       path.join(env.vaultDir, "boards/test.canvas"),
-      "utf-8",
+      "utf-8"
     );
     const canvas = JSON.parse(canvasRaw) as { nodes: Array<{ url?: string }> };
-    expect(canvas.nodes.some((n) => n.url === "https://example.com/deep/path?q=1")).toBe(true);
+    expect(
+      canvas.nodes.some((n) => n.url === "https://example.com/deep/path?q=1")
+    ).toBe(true);
   });
 
   it("rejects non-web link URL schemes before persisting", async () => {
     const canvasPath = path.join(env.vaultDir, "boards/test.canvas");
     const before = await fs.readFile(canvasPath, "utf-8");
 
-    for (const content of ["file:///C:/Users/me/secret.txt", "obsidian://open?vault=main"]) {
+    for (const content of [
+      "file:///C:/Users/me/secret.txt",
+      "obsidian://open?vault=main",
+    ]) {
       const result = await env.client.callTool({
         name: "add_canvas_node",
         arguments: {
@@ -471,7 +545,7 @@ describe("canvas handlers — add_canvas_edge", () => {
 
     const canvasRaw = await fs.readFile(
       path.join(env.vaultDir, "boards/test.canvas"),
-      "utf-8",
+      "utf-8"
     );
     const canvas = JSON.parse(canvasRaw) as {
       edges: Array<{ fromNode: string; toNode: string; label?: string }>;
@@ -535,5 +609,30 @@ describe("canvas handlers — add_canvas_edge", () => {
     const text = textContent(result);
     expect(text).toContain("Label: safe\\nlabel");
     expect(text).not.toContain("safe\nlabel");
+  });
+
+  it("routes an unexpected failure through the seam's sanitize boundary", async () => {
+    // A malformed canvas throws during parse — before any node check — so the
+    // error is unexpected (not MissingNode/DuplicateEdge) and propagates to the
+    // seam. The seam applies the generic "Error:" prefix and sanitizeError,
+    // which strips the absolute file path. This pins the leak closure that
+    // routing add_canvas_edge through the seam provides.
+    await fs.writeFile(
+      path.join(env.vaultDir, "corrupt.canvas"),
+      "{ not valid json",
+      "utf-8"
+    );
+    const result = await env.client.callTool({
+      name: "add_canvas_edge",
+      arguments: {
+        canvasPath: "corrupt.canvas",
+        fromNode: "a",
+        toNode: "b",
+      },
+    });
+    expect(isError(result)).toBe(true);
+    const text = textContent(result);
+    expect(text.startsWith("Error: ")).toBe(true);
+    expect(text).not.toContain(env.vaultDir);
   });
 });

--- a/src/tools/canvas/add-canvas-edge.ts
+++ b/src/tools/canvas/add-canvas-edge.ts
@@ -65,10 +65,7 @@ export function registerAddCanvasEdge(
           ),
       },
     },
-    async (
-      { canvasPath, fromNode, toNode, label, fromSide, toSide },
-      { vaultPath }
-    ) => {
+    async ({ canvasPath, fromNode, toNode, label, fromSide, toSide }) => {
       // BUG-15: Reject self-loops early before touching the canvas file.
       if (fromNode === toNode) {
         return error(
@@ -125,10 +122,10 @@ export function registerAddCanvasEdge(
         // Expected validation failures carry handler-authored (control-char
         // escaped) messages and pass through verbatim. Anything else is
         // unexpected and re-thrown to the seam's single sanitize point.
-        if (err instanceof MissingNodeError) {
-          return error(`Error: ${err.message}`);
-        }
-        if (err instanceof DuplicateEdgeError) {
+        if (
+          err instanceof MissingNodeError ||
+          err instanceof DuplicateEdgeError
+        ) {
           return error(`Error: ${err.message}`);
         }
         throw err;

--- a/src/tools/canvas/add-canvas-edge.ts
+++ b/src/tools/canvas/add-canvas-edge.ts
@@ -1,22 +1,21 @@
 import { randomUUID } from "crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import {
-  updateCanvasFile,
-} from "../../lib/vault.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
+import { updateCanvasFile } from "../../lib/vault.js";
+import { defineTool, text, error } from "../../lib/tool-seam.js";
 import type { CanvasData } from "../../types.js";
-import {
-  errorResult,
-  displayCanvasValue,
-} from "./shared.js";
+import { displayCanvasValue } from "./shared.js";
 import { invalidateCanvasReadCache } from "./read-canvas.js";
 
-export function registerAddCanvasEdge(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "add_canvas_edge",
+export function registerAddCanvasEdge(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "add_canvas_edge",
       title: "Add Canvas Edge",
       description:
         "Create a directed edge connecting two existing canvas nodes. Both fromNode and toNode must already exist on the canvas (use read_canvas to list node ids, or capture the id returned by add_canvas_node). Optional fromSide/toSide control which face of each node the edge anchors to. Returns the generated edge UUID.",
@@ -37,12 +36,16 @@ export function registerAddCanvasEdge(server: McpServer, vaultPath: string): voi
           .string()
           .min(1)
           .max(200)
-          .describe("UUID of the source (origin) node - must already exist on the canvas"),
+          .describe(
+            "UUID of the source (origin) node - must already exist on the canvas"
+          ),
         toNode: z
           .string()
           .min(1)
           .max(200)
-          .describe("UUID of the target (destination) node - must already exist on the canvas"),
+          .describe(
+            "UUID of the target (destination) node - must already exist on the canvas"
+          ),
         label: z
           .string()
           .max(1000)
@@ -51,80 +54,90 @@ export function registerAddCanvasEdge(server: McpServer, vaultPath: string): voi
         fromSide: z
           .enum(["top", "right", "bottom", "left"])
           .optional()
-          .describe("Face of the source node the edge leaves from (default: auto-chosen by Obsidian)"),
+          .describe(
+            "Face of the source node the edge leaves from (default: auto-chosen by Obsidian)"
+          ),
         toSide: z
           .enum(["top", "right", "bottom", "left"])
           .optional()
-          .describe("Face of the target node the edge arrives at (default: auto-chosen by Obsidian)"),
+          .describe(
+            "Face of the target node the edge arrives at (default: auto-chosen by Obsidian)"
+          ),
       },
     },
-    async ({ canvasPath, fromNode, toNode, label, fromSide, toSide }) => {
-      try {
-        // BUG-15: Reject self-loops early before touching the canvas file.
-        if (fromNode === toNode) {
-          return errorResult(
-            `Self-loop rejected: fromNode and toNode are the same ('${displayCanvasValue(fromNode)}'). Edges must connect two different nodes.`,
+    async (
+      { canvasPath, fromNode, toNode, label, fromSide, toSide },
+      { vaultPath }
+    ) => {
+      // BUG-15: Reject self-loops early before touching the canvas file.
+      if (fromNode === toNode) {
+        return error(
+          `Self-loop rejected: fromNode and toNode are the same ('${displayCanvasValue(fromNode)}'). Edges must connect two different nodes.`
+        );
+      }
+
+      const id = randomUUID();
+      // Node-existence validated inside the lock to prevent a concurrent
+      // deletion from sneaking in between the check and the write.
+      class MissingNodeError extends Error {
+        constructor(
+          public side: "source" | "target",
+          public nodeId: string
+        ) {
+          super(
+            `${side} node '${displayCanvasValue(nodeId)}' not found in canvas.`
           );
         }
-
-        const id = randomUUID();
-        // Node-existence validated inside the lock to prevent a concurrent
-        // deletion from sneaking in between the check and the write.
-        class MissingNodeError extends Error {
-          constructor(public side: "source" | "target", public nodeId: string) {
-            super(`${side} node '${displayCanvasValue(nodeId)}' not found in canvas.`);
-          }
-        }
-        class DuplicateEdgeError extends Error {
-          constructor(public from: string, public to: string) {
-            super(
-              `An edge from '${displayCanvasValue(from)}' to '${displayCanvasValue(to)}' already exists on the canvas.`,
-            );
-          }
-        }
-        try {
-          await updateCanvasFile(vaultPath, canvasPath, (data) => {
-            if (!data.nodes.some((n) => n.id === fromNode)) {
-              throw new MissingNodeError("source", fromNode);
-            }
-            if (!data.nodes.some((n) => n.id === toNode)) {
-              throw new MissingNodeError("target", toNode);
-            }
-            // BUG-15: Reject duplicate edges between the same node pair.
-            const isDuplicate = data.edges.some(
-              (e) => e.fromNode === fromNode && e.toNode === toNode,
-            );
-            if (isDuplicate) {
-              throw new DuplicateEdgeError(fromNode, toNode);
-            }
-            const edge: CanvasData["edges"][number] = { id, fromNode, toNode };
-            if (label) edge.label = label;
-            if (fromSide) edge.fromSide = fromSide;
-            if (toSide) edge.toSide = toSide;
-            data.edges.push(edge);
-            return data;
-          });
-        } catch (err) {
-          if (err instanceof MissingNodeError) {
-            return errorResult(`Error: ${err.message}`);
-          }
-          if (err instanceof DuplicateEdgeError) {
-            return errorResult(`Error: ${err.message}`);
-          }
-          throw err;
-        }
-        invalidateCanvasReadCache(vaultPath, canvasPath);
-
-        return {
-          content: [{
-            type: "text" as const,
-            text: `Edge added successfully.\nID: ${id}\nFrom: ${displayCanvasValue(fromNode)} -> To: ${displayCanvasValue(toNode)}${label ? `\nLabel: ${displayCanvasValue(label)}` : ""}`,
-          }],
-        };
-      } catch (err) {
-        log.error("add_canvas_edge failed", { tool: "add_canvas_edge", err: err as Error });
-        return errorResult(`Error adding edge: ${sanitizeError(err)}`);
       }
-    },
+      class DuplicateEdgeError extends Error {
+        constructor(
+          public from: string,
+          public to: string
+        ) {
+          super(
+            `An edge from '${displayCanvasValue(from)}' to '${displayCanvasValue(to)}' already exists on the canvas.`
+          );
+        }
+      }
+      try {
+        await updateCanvasFile(vaultPath, canvasPath, (data) => {
+          if (!data.nodes.some((n) => n.id === fromNode)) {
+            throw new MissingNodeError("source", fromNode);
+          }
+          if (!data.nodes.some((n) => n.id === toNode)) {
+            throw new MissingNodeError("target", toNode);
+          }
+          // BUG-15: Reject duplicate edges between the same node pair.
+          const isDuplicate = data.edges.some(
+            (e) => e.fromNode === fromNode && e.toNode === toNode
+          );
+          if (isDuplicate) {
+            throw new DuplicateEdgeError(fromNode, toNode);
+          }
+          const edge: CanvasData["edges"][number] = { id, fromNode, toNode };
+          if (label) edge.label = label;
+          if (fromSide) edge.fromSide = fromSide;
+          if (toSide) edge.toSide = toSide;
+          data.edges.push(edge);
+          return data;
+        });
+      } catch (err) {
+        // Expected validation failures carry handler-authored (control-char
+        // escaped) messages and pass through verbatim. Anything else is
+        // unexpected and re-thrown to the seam's single sanitize point.
+        if (err instanceof MissingNodeError) {
+          return error(`Error: ${err.message}`);
+        }
+        if (err instanceof DuplicateEdgeError) {
+          return error(`Error: ${err.message}`);
+        }
+        throw err;
+      }
+      invalidateCanvasReadCache(vaultPath, canvasPath);
+
+      return text(
+        `Edge added successfully.\nID: ${id}\nFrom: ${displayCanvasValue(fromNode)} -> To: ${displayCanvasValue(toNode)}${label ? `\nLabel: ${displayCanvasValue(label)}` : ""}`
+      );
+    }
   );
 }

--- a/src/tools/canvas/add-canvas-node.ts
+++ b/src/tools/canvas/add-canvas-node.ts
@@ -1,17 +1,10 @@
 import { randomUUID } from "crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import {
-  resolveVaultPathSafe,
-  updateCanvasFile,
-} from "../../lib/vault.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
+import { resolveVaultPathSafe, updateCanvasFile } from "../../lib/vault.js";
+import { defineTool, text, error } from "../../lib/tool-seam.js";
 import type { CanvasNode } from "../../types.js";
-import {
-  errorResult,
-  displayCanvasValue,
-} from "./shared.js";
+import { displayCanvasValue } from "./shared.js";
 import { invalidateCanvasReadCache } from "./read-canvas.js";
 
 const ALLOWED_CANVAS_LINK_PROTOCOLS = new Set(["http:", "https:"]);
@@ -40,10 +33,15 @@ function hasUrlControlChars(value: string): boolean {
   return false;
 }
 
-export function registerAddCanvasNode(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "add_canvas_node",
+export function registerAddCanvasNode(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "add_canvas_node",
       title: "Add Canvas Node",
       description:
         "Add a new node to an Obsidian canvas and persist the updated file. Supports four node types: 'text' (markdown block), 'file' (embedded vault note reference), 'link' (external URL), and 'group' (labeled container). Returns the generated node UUID, needed to connect nodes via add_canvas_edge. When neither x nor y is supplied, the new node is auto-positioned at (50 * existing_count, 50 * existing_count) to avoid stacking multiple defaulted nodes at the origin. Supplying an explicit x or y always overrides this stagger.",
@@ -62,26 +60,34 @@ export function registerAddCanvasNode(server: McpServer, vaultPath: string): voi
           .describe("Relative path from vault root to the target .canvas file"),
         type: z
           .enum(["text", "file", "link", "group"])
-          .describe("Node kind: 'text' = markdown block, 'file' = vault note reference, 'link' = external URL, 'group' = labeled container"),
+          .describe(
+            "Node kind: 'text' = markdown block, 'file' = vault note reference, 'link' = external URL, 'group' = labeled container"
+          ),
         content: z
           .string()
           .min(1)
           .max(100000)
-          .describe("Interpretation depends on type: text body for 'text', relative note path for 'file', URL for 'link', display label for 'group'"),
+          .describe(
+            "Interpretation depends on type: text body for 'text', relative note path for 'file', URL for 'link', display label for 'group'"
+          ),
         x: z
           .number()
           .finite()
           .min(-100000)
           .max(100000)
           .optional()
-          .describe("X coordinate on the canvas. When omitted (and y is also omitted) the node is auto-staggered to avoid origin pile-up; an explicit value always wins."),
+          .describe(
+            "X coordinate on the canvas. When omitted (and y is also omitted) the node is auto-staggered to avoid origin pile-up; an explicit value always wins."
+          ),
         y: z
           .number()
           .finite()
           .min(-100000)
           .max(100000)
           .optional()
-          .describe("Y coordinate on the canvas. When omitted (and x is also omitted) the node is auto-staggered to avoid origin pile-up; an explicit value always wins."),
+          .describe(
+            "Y coordinate on the canvas. When omitted (and x is also omitted) the node is auto-staggered to avoid origin pile-up; an explicit value always wins."
+          ),
         width: z
           .number()
           .int()
@@ -100,97 +106,100 @@ export function registerAddCanvasNode(server: McpServer, vaultPath: string): voi
           .describe("Node height in pixels (default: 60, max: 10000)"),
         color: z
           .string()
-          .regex(/^([1-6]|#[0-9a-fA-F]{3,8})$/, "color must be '1'-'6' or a hex code like '#ff5555'")
+          .regex(
+            /^([1-6]|#[0-9a-fA-F]{3,8})$/,
+            "color must be '1'-'6' or a hex code like '#ff5555'"
+          )
           .optional()
-          .describe("Color: '1'-'6' for Obsidian's preset palette (red/orange/yellow/green/cyan/purple), or a hex code like '#ff5555'"),
+          .describe(
+            "Color: '1'-'6' for Obsidian's preset palette (red/orange/yellow/green/cyan/purple), or a hex code like '#ff5555'"
+          ),
       },
     },
-    async ({ canvasPath, type, content, x, y, width, height, color }) => {
-      try {
-        const id = randomUUID();
-        // Coordinate defaulting happens inside the file lock so that the
-        // "existing node count" used for stagger reflects the exact state we
-        // are about to mutate (no race with a parallel add_canvas_node).
-        const autoStaggerX = x === undefined;
-        const autoStaggerY = y === undefined;
-        const resolvedWidth = width ?? 250;
-        const resolvedHeight = height ?? 60;
+    async (
+      { canvasPath, type, content, x, y, width, height, color },
+      { vaultPath }
+    ) => {
+      const id = randomUUID();
+      // Coordinate defaulting happens inside the file lock so that the
+      // "existing node count" used for stagger reflects the exact state we
+      // are about to mutate (no race with a parallel add_canvas_node).
+      const autoStaggerX = x === undefined;
+      const autoStaggerY = y === undefined;
+      const resolvedWidth = width ?? 250;
+      const resolvedHeight = height ?? 60;
 
-        if (type === "file") {
-          // Validate the file reference stays inside the vault. Without this
-          // check, arbitrary paths (e.g. "../../etc/passwd") would be
-          // persisted in the canvas JSON and surfaced back to clients.
-          // Use the async variant so symlinked paths that escape the vault
-          // (via realpath) are also rejected, matches the defense-in-depth
-          // used by every other path-accepting tool. The referenced file
-          // need not exist yet; `resolveVaultPathSafe` walks up to the
-          // deepest existing ancestor and realpath-checks that.
-          try {
-            await resolveVaultPathSafe(vaultPath, content);
-          } catch {
-            return errorResult(
-              `Invalid file reference: "${displayCanvasValue(content)}" must be a relative path inside the vault.`,
-            );
-          }
+      if (type === "file") {
+        // Validate the file reference stays inside the vault. Without this
+        // check, arbitrary paths (e.g. "../../etc/passwd") would be
+        // persisted in the canvas JSON and surfaced back to clients.
+        // Use the async variant so symlinked paths that escape the vault
+        // (via realpath) are also rejected, matches the defense-in-depth
+        // used by every other path-accepting tool. The referenced file
+        // need not exist yet; `resolveVaultPathSafe` walks up to the
+        // deepest existing ancestor and realpath-checks that.
+        try {
+          await resolveVaultPathSafe(vaultPath, content);
+        } catch {
+          return error(
+            `Invalid file reference: "${displayCanvasValue(content)}" must be a relative path inside the vault.`
+          );
         }
-
-        if (type === "link") {
-          // WHATWG URL parsing normalizes leading spaces and C0 whitespace
-          // inside schemes, so check the parsed protocol instead of raw text.
-          const invalidUrl = validateCanvasLinkUrl(content);
-          if (invalidUrl) return errorResult(invalidUrl);
-        }
-
-        let finalX = 0;
-        let finalY = 0;
-
-        await updateCanvasFile(vaultPath, canvasPath, (data) => {
-          // Auto-stagger only when BOTH coordinates are omitted; any explicit
-          // value disables the stagger so callers can pin to (0, 0) on purpose.
-          if (autoStaggerX && autoStaggerY) {
-            const count = data.nodes.length;
-            finalX = 50 * count;
-            finalY = 50 * count;
-          } else {
-            finalX = autoStaggerX ? 0 : (x);
-            finalY = autoStaggerY ? 0 : (y);
-          }
-
-          const node: CanvasNode = {
-            id,
-            type,
-            x: finalX,
-            y: finalY,
-            width: resolvedWidth,
-            height: resolvedHeight,
-          };
-
-          if (type === "text") {
-            node.text = content;
-          } else if (type === "file") {
-            node.file = content;
-          } else if (type === "link") {
-            node.url = content;
-          } else if (type === "group") {
-            node.label = content;
-          }
-
-          if (color) {
-            node.color = color;
-          }
-
-          data.nodes.push(node);
-          return data;
-        });
-        invalidateCanvasReadCache(vaultPath, canvasPath);
-
-        return {
-          content: [{ type: "text" as const, text: `Node added successfully.\nID: ${id}\nType: ${type}\nPosition: (${finalX}, ${finalY})` }],
-        };
-      } catch (err) {
-        log.error("add_canvas_node failed", { tool: "add_canvas_node", err: err as Error });
-        return errorResult(`Error adding node: ${sanitizeError(err)}`);
       }
-    },
+
+      if (type === "link") {
+        // WHATWG URL parsing normalizes leading spaces and C0 whitespace
+        // inside schemes, so check the parsed protocol instead of raw text.
+        const invalidUrl = validateCanvasLinkUrl(content);
+        if (invalidUrl) return error(invalidUrl);
+      }
+
+      let finalX = 0;
+      let finalY = 0;
+
+      await updateCanvasFile(vaultPath, canvasPath, (data) => {
+        // Auto-stagger only when BOTH coordinates are omitted; any explicit
+        // value disables the stagger so callers can pin to (0, 0) on purpose.
+        if (autoStaggerX && autoStaggerY) {
+          const count = data.nodes.length;
+          finalX = 50 * count;
+          finalY = 50 * count;
+        } else {
+          finalX = autoStaggerX ? 0 : x;
+          finalY = autoStaggerY ? 0 : y;
+        }
+
+        const node: CanvasNode = {
+          id,
+          type,
+          x: finalX,
+          y: finalY,
+          width: resolvedWidth,
+          height: resolvedHeight,
+        };
+
+        if (type === "text") {
+          node.text = content;
+        } else if (type === "file") {
+          node.file = content;
+        } else if (type === "link") {
+          node.url = content;
+        } else if (type === "group") {
+          node.label = content;
+        }
+
+        if (color) {
+          node.color = color;
+        }
+
+        data.nodes.push(node);
+        return data;
+      });
+      invalidateCanvasReadCache(vaultPath, canvasPath);
+
+      return text(
+        `Node added successfully.\nID: ${id}\nType: ${type}\nPosition: (${finalX}, ${finalY})`
+      );
+    }
   );
 }

--- a/src/tools/canvas/add-canvas-node.ts
+++ b/src/tools/canvas/add-canvas-node.ts
@@ -116,10 +116,7 @@ export function registerAddCanvasNode(
           ),
       },
     },
-    async (
-      { canvasPath, type, content, x, y, width, height, color },
-      { vaultPath }
-    ) => {
+    async ({ canvasPath, type, content, x, y, width, height, color }) => {
       const id = randomUUID();
       // Coordinate defaulting happens inside the file lock so that the
       // "existing node count" used for stagger reflects the exact state we

--- a/src/tools/canvas/list-canvases.ts
+++ b/src/tools/canvas/list-canvases.ts
@@ -1,18 +1,17 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { listCanvasFiles } from "../../lib/vault.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
-import {
-  errorResult,
-  displayCanvasValue,
-  untrustedCanvasTextResult,
-  untrustedCanvasBlock,
-} from "./shared.js";
+import { defineTool, text, richText } from "../../lib/tool-seam.js";
+import { displayCanvasValue } from "./shared.js";
 
-export function registerListCanvases(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "list_canvases",
+export function registerListCanvases(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "list_canvases",
       title: "List Canvases",
       description:
         "Enumerate every Obsidian canvas file (.canvas) anywhere in the vault, returning a numbered list of relative paths and the total count. Takes no parameters — scans the entire vault. Use to discover available canvases before calling read_canvas, add_canvas_node, or add_canvas_edge.",
@@ -24,22 +23,20 @@ export function registerListCanvases(server: McpServer, vaultPath: string): void
       inputSchema: {},
     },
     async () => {
-      try {
-        const files = await listCanvasFiles(vaultPath);
+      const files = await listCanvasFiles(vaultPath);
 
-        if (files.length === 0) {
-          return { content: [{ type: "text" as const, text: "No canvas files found in the vault." }] };
-        }
-
-        const formatted = files.map((f, i) => `${i + 1}. ${displayCanvasValue(f)}`).join("\n");
-        return untrustedCanvasTextResult(
-          "list_canvases paths",
-          `Found ${files.length} canvas file(s):\n\n${untrustedCanvasBlock("list_canvases paths", formatted)}`,
-        );
-      } catch (err) {
-        log.error("list_canvases failed", { tool: "list_canvases", err: err as Error });
-        return errorResult(`Error listing canvas files: ${sanitizeError(err)}`);
+      if (files.length === 0) {
+        return text("No canvas files found in the vault.");
       }
-    },
+
+      const formatted = files
+        .map((f, i) => `${i + 1}. ${displayCanvasValue(f)}`)
+        .join("\n");
+      return richText("list_canvases paths", (b) => {
+        b.trusted(`Found ${files.length} canvas file(s):`);
+        b.trusted("");
+        b.untrusted("list_canvases paths", formatted);
+      });
+    }
   );
 }

--- a/src/tools/canvas/read-canvas.ts
+++ b/src/tools/canvas/read-canvas.ts
@@ -1,20 +1,14 @@
 import path from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { openVaultFileForRead, readCanvasFile } from "../../lib/vault.js";
 import {
-  openVaultFileForRead,
-  readCanvasFile,
-} from "../../lib/vault.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { untrustedVaultContentMeta } from "../../lib/tool-output.js";
-import { log } from "../../lib/logger.js";
+  defineTool,
+  richText,
+  type RichTextBuilder,
+} from "../../lib/tool-seam.js";
 import type { CanvasData } from "../../types.js";
-import {
-  errorResult,
-  displayCanvasValue,
-  untrustedCanvasBlock,
-} from "./shared.js";
-import { indentBlock, formatUntrustedVaultContent } from "../../lib/tool-output.js";
+import { displayCanvasValue } from "./shared.js";
 
 const CANVAS_READ_CACHE_LIMIT = 16;
 const CANVAS_SUMMARY_NODE_LIMIT = 200;
@@ -24,7 +18,7 @@ interface CanvasReadCacheEntry {
   fullPath: string;
   size: number;
   mtimeMs: number;
-  text: string;
+  data: CanvasData;
 }
 
 const canvasReadCache = new Map<string, CanvasReadCacheEntry>();
@@ -35,12 +29,16 @@ function canvasReadCacheKey(vaultPath: string, canvasPath: string): string {
 
 async function getCanvasReadSignature(
   vaultPath: string,
-  canvasPath: string,
+  canvasPath: string
 ): Promise<{ fullPath: string; size: number; mtimeMs: number }> {
   let opened: Awaited<ReturnType<typeof openVaultFileForRead>> | undefined;
   try {
     opened = await openVaultFileForRead(vaultPath, canvasPath);
-    return { fullPath: opened.fullPath, size: opened.stats.size, mtimeMs: opened.stats.mtimeMs };
+    return {
+      fullPath: opened.fullPath,
+      size: opened.stats.size,
+      mtimeMs: opened.stats.mtimeMs,
+    };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       // Preserve the existing read_canvas missing-file error shape, which
@@ -53,16 +51,24 @@ async function getCanvasReadSignature(
   }
 }
 
-function renderCanvasSummary(canvasPath: string, data: CanvasData): string {
-  const lines: string[] = [];
-
-  lines.push("Canvas:");
-  lines.push(untrustedCanvasBlock("read_canvas path", displayCanvasValue(canvasPath), "  "));
-  lines.push(`Nodes: ${data.nodes.length} | Edges: ${data.edges.length}`);
-  lines.push("");
+// Emit the bounded canvas summary through the seam's richText builder. Trusted
+// framing goes through `b.trusted`; every vault-derived value (path, node/edge
+// identity, content, labels) goes through `b.untrusted`, which BEGIN/END-wraps
+// and indents it. Building through the builder is what attaches the block-level
+// `read_canvas summary` trust `_meta` — the path section below is unconditional,
+// so an untrusted section is always present.
+function renderCanvasSummary(
+  b: RichTextBuilder,
+  canvasPath: string,
+  data: CanvasData
+): void {
+  b.trusted("Canvas:");
+  b.untrusted("read_canvas path", displayCanvasValue(canvasPath), "  ");
+  b.trusted(`Nodes: ${data.nodes.length} | Edges: ${data.edges.length}`);
+  b.trusted("");
 
   if (data.nodes.length > 0) {
-    lines.push("--- Nodes ---");
+    b.trusted("--- Nodes ---");
     const visibleNodes = data.nodes.slice(0, CANVAS_SUMMARY_NODE_LIMIT);
     for (const node of visibleNodes) {
       const pos = `(${node.x}, ${node.y})`;
@@ -70,9 +76,8 @@ function renderCanvasSummary(canvasPath: string, data: CanvasData): string {
       let preview = "";
 
       if (node.type === "text" && node.text) {
-        preview = node.text.length > 100
-          ? node.text.slice(0, 100) + "..."
-          : node.text;
+        preview =
+          node.text.length > 100 ? node.text.slice(0, 100) + "..." : node.text;
       } else if (node.type === "file" && node.file) {
         preview = node.file;
       } else if (node.type === "link" && node.url) {
@@ -81,75 +86,83 @@ function renderCanvasSummary(canvasPath: string, data: CanvasData): string {
         preview = `Group: ${node.label}`;
       }
 
-      lines.push("  Node:");
-      lines.push(untrustedCanvasBlock(
+      b.trusted("  Node:");
+      b.untrusted(
         "read_canvas node identity",
         `[${displayCanvasValue(node.id)}] type=${displayCanvasValue(node.type)}`,
-        "    ",
-      ));
-      lines.push(`    pos=${pos} size=${size}`);
+        "    "
+      );
+      b.trusted(`    pos=${pos} size=${size}`);
       if (preview) {
-        lines.push("    content:");
-        lines.push(indentBlock(
-          formatUntrustedVaultContent(
-            "read_canvas node content",
-            displayCanvasValue(preview),
-          ),
-          "      ",
-        ));
+        b.trusted("    content:");
+        b.untrusted(
+          "read_canvas node content",
+          displayCanvasValue(preview),
+          "      "
+        );
       }
       if (node.color) {
-        lines.push("    color:");
-        lines.push(untrustedCanvasBlock(
+        b.trusted("    color:");
+        b.untrusted(
           "read_canvas node color",
           displayCanvasValue(node.color),
-          "      ",
-        ));
+          "      "
+        );
       }
     }
     const omittedNodes = data.nodes.length - visibleNodes.length;
     if (omittedNodes > 0) {
-      lines.push(`  ... ${omittedNodes} more node(s) omitted by read_canvas output cap.`);
+      b.trusted(
+        `  ... ${omittedNodes} more node(s) omitted by read_canvas output cap.`
+      );
     }
-    lines.push("");
+    b.trusted("");
   }
 
   if (data.edges.length > 0) {
-    lines.push("--- Edges ---");
+    b.trusted("--- Edges ---");
     const visibleEdges = data.edges.slice(0, CANVAS_SUMMARY_EDGE_LIMIT);
     for (const edge of visibleEdges) {
       const sides = [
         edge.fromSide ? `from-side=${displayCanvasValue(edge.fromSide)}` : "",
         edge.toSide ? `to-side=${displayCanvasValue(edge.toSide)}` : "",
-      ].filter(Boolean).join(" ");
+      ]
+        .filter(Boolean)
+        .join(" ");
       const sideInfo = sides ? ` (${sides})` : "";
-      lines.push("  Edge:");
-      lines.push(untrustedCanvasBlock(
+      b.trusted("  Edge:");
+      b.untrusted(
         "read_canvas edge endpoints",
         `${displayCanvasValue(edge.fromNode)} -> ${displayCanvasValue(edge.toNode)}${sideInfo}`,
-        "    ",
-      ));
+        "    "
+      );
       if (edge.label) {
-        lines.push("    label:");
-        lines.push(indentBlock(
-          formatUntrustedVaultContent(
-            "read_canvas edge label",
-            displayCanvasValue(edge.label),
-          ),
-          "      ",
-        ));
+        b.trusted("    label:");
+        b.untrusted(
+          "read_canvas edge label",
+          displayCanvasValue(edge.label),
+          "      "
+        );
       }
     }
     const omittedEdges = data.edges.length - visibleEdges.length;
     if (omittedEdges > 0) {
-      lines.push(`  ... ${omittedEdges} more edge(s) omitted by read_canvas output cap.`);
+      b.trusted(
+        `  ... ${omittedEdges} more edge(s) omitted by read_canvas output cap.`
+      );
     }
   }
-
-  return lines.join("\n");
 }
 
-async function readCanvasSummaryCached(vaultPath: string, canvasPath: string): Promise<string> {
+// Read-through cache of parsed canvas data, keyed by (vault, path) and validated
+// against the file's size+mtime signature. Caching the structured `CanvasData`
+// (rather than a rendered string) preserves the file-read/JSON-parse savings
+// while letting the summary re-render through the seam each call — the seam is
+// the only place that can attach the untrusted-content `_meta`.
+async function readCanvasDataCached(
+  vaultPath: string,
+  canvasPath: string
+): Promise<CanvasData> {
   const signature = await getCanvasReadSignature(vaultPath, canvasPath);
   const key = canvasReadCacheKey(vaultPath, canvasPath);
   const cached = canvasReadCache.get(key);
@@ -161,28 +174,32 @@ async function readCanvasSummaryCached(vaultPath: string, canvasPath: string): P
   ) {
     canvasReadCache.delete(key);
     canvasReadCache.set(key, cached);
-    return cached.text;
+    return cached.data;
   }
 
   const data = await readCanvasFile(vaultPath, canvasPath);
-  const text = renderCanvasSummary(canvasPath, data);
-  canvasReadCache.set(key, { ...signature, text });
+  canvasReadCache.set(key, { ...signature, data });
   while (canvasReadCache.size > CANVAS_READ_CACHE_LIMIT) {
     const oldestKey = canvasReadCache.keys().next().value;
     if (oldestKey === undefined) break;
     canvasReadCache.delete(oldestKey);
   }
-  return text;
+  return data;
 }
 
-export function invalidateCanvasReadCache(vaultPath: string, canvasPath: string): void {
+export function invalidateCanvasReadCache(
+  vaultPath: string,
+  canvasPath: string
+): void {
   canvasReadCache.delete(canvasReadCacheKey(vaultPath, canvasPath));
 }
 
 export function registerReadCanvas(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "read_canvas",
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "read_canvas",
       title: "Read Canvas",
       description:
         "Read an Obsidian canvas file (.canvas, JSON format) and return a bounded human-readable summary of its structure: total node/edge counts, up to 200 nodes with id/type/position/size/content preview, and up to 200 edges with source/target node ids plus optional label. Use to inspect or navigate a canvas before calling add_canvas_node or add_canvas_edge.",
@@ -197,23 +214,16 @@ export function registerReadCanvas(server: McpServer, vaultPath: string): void {
           .min(1)
           .max(500)
           .regex(/\.canvas$/i, "Path must end in .canvas")
-          .describe("Relative path from vault root to the .canvas file (e.g., 'boards/roadmap.canvas')"),
+          .describe(
+            "Relative path from vault root to the .canvas file (e.g., 'boards/roadmap.canvas')"
+          ),
       },
     },
-    async ({ path: canvasPath }) => {
-      try {
-        const text = await readCanvasSummaryCached(vaultPath, canvasPath);
-        return {
-          content: [{
-            type: "text" as const,
-            text,
-            _meta: untrustedVaultContentMeta("read_canvas summary"),
-          }],
-        };
-      } catch (err) {
-        log.error("read_canvas failed", { tool: "read_canvas", err: err as Error });
-        return errorResult(`Error reading canvas: ${sanitizeError(err)}`);
-      }
-    },
+    async ({ path: canvasPath }, { vaultPath }) => {
+      const data = await readCanvasDataCached(vaultPath, canvasPath);
+      return richText("read_canvas summary", (b) =>
+        renderCanvasSummary(b, canvasPath, data)
+      );
+    }
   );
 }

--- a/src/tools/canvas/read-canvas.ts
+++ b/src/tools/canvas/read-canvas.ts
@@ -219,7 +219,7 @@ export function registerReadCanvas(server: McpServer, vaultPath: string): void {
           ),
       },
     },
-    async ({ path: canvasPath }, { vaultPath }) => {
+    async ({ path: canvasPath }) => {
       const data = await readCanvasDataCached(vaultPath, canvasPath);
       return richText("read_canvas summary", (b) =>
         renderCanvasSummary(b, canvasPath, data)

--- a/src/tools/canvas/shared.ts
+++ b/src/tools/canvas/shared.ts
@@ -1,35 +1,11 @@
 import { escapeControlChars } from "../../lib/errors.js";
-import {
-  formatUntrustedVaultContent,
-  indentBlock,
-  untrustedVaultContentMeta,
-} from "../../lib/tool-output.js";
 
-function errorResult(text: string) {
-  return { content: [{ type: "text" as const, text }], isError: true as const };
-}
+// The error/result/trust-wrapping recipe (errorResult, untrustedCanvasTextResult,
+// untrustedCanvasBlock) now lives in the tool seam (../../lib/tool-seam.ts):
+// handlers return a ToolResult built via `text` / `richText` / `error`, and the
+// seam owns error sanitization. What remains here is the canvas group's own
+// escaping helper.
 
-function displayCanvasValue(value: string): string {
+export function displayCanvasValue(value: string): string {
   return escapeControlChars(value);
 }
-
-function untrustedCanvasTextResult(label: string, text: string) {
-  return {
-    content: [{
-      type: "text" as const,
-      text,
-      _meta: untrustedVaultContentMeta(label),
-    }],
-  };
-}
-
-function untrustedCanvasBlock(label: string, text: string, indent = ""): string {
-  return indentBlock(formatUntrustedVaultContent(label, text), indent);
-}
-
-export {
-  errorResult,
-  displayCanvasValue,
-  untrustedCanvasTextResult,
-  untrustedCanvasBlock,
-};


### PR DESCRIPTION
## What

Second fan-out step after the read group ([ADR 0001](docs/adr/0001-tool-seam.md)). Routes all four canvas tools (`list_canvases`, `read_canvas`, `add_canvas_node`, `add_canvas_edge`) through `defineTool` + the branded `ToolResult` vocabulary, deleting the group's per-file recipe (terminal `try/catch` + `errorResult` + manual untrusted-content wrapping).

## How

The canvas group is all text, so it migrated using only the existing `text`/`richText`/`error` constructors — **no seam changes**. Mappings:

- `list_canvases` / `read_canvas` summaries → `richText` (`b.trusted` framing + `b.untrusted` vault sections); the block-level trust `_meta` is attached by construction.
- `add_canvas_node` / `add_canvas_edge` success → `text`; expected validation failures → `error` (verbatim, `displayCanvasValue`-escaped).
- `shared.ts` reduces to the `displayCanvasValue` escaping helper (mirrors `read/shared.ts`).

`read_canvas`'s cache now stores parsed `CanvasData` instead of the rendered string, so the summary re-renders through the seam each call (the only place that can attach untrusted `_meta`). File-read/JSON-parse savings are preserved; a summary is 200/200-capped so re-rendering is free. Covered by the existing repeated-read / external-edit / tool-write cache tests.

## Safety

- **Byte-preserving.** Every existing `regression-tools-canvas` and `handlers/canvas` test stays green **unchanged**. The `_meta`/BEGIN-marker assertions and domain-error fragments all still hold.
- One intentional change (per ADR 0001): thrown errors now use the generic `Error:` prefix instead of per-tool verbs (`Error adding edge`, etc.). No test pinned the old wording.

## add_canvas_edge leak closure (structural, unexpected-path only)

Routing through the seam means `add_canvas_edge`'s **unexpected**-error path now hits the seam's single `sanitizeError` boundary (it was returned unsanitized before). Its **expected** validation messages (missing/duplicate node, self-loop) stay handler-authored and verbatim per the error model — control-char escaped, not re-sanitized. So the closure is structural: no tool-layer terminal catch emits an unsanitized message anymore.

Pinned by a new `handlers/canvas.test.ts` case that drives an unexpected failure (malformed canvas) through `add_canvas_edge` and asserts the generic sanitized result with the absolute path stripped. ADR 0001 updated (Context, Consequences, Migration, Status) to state this precisely.

## Gates

`typecheck` · `lint` · `build` all clean; **979 tests pass** (15 skipped) — 978 unchanged + the new leak-closure test.

## Scope / follow-up

Canvas group only. 7 groups remain (write, tags, links, sections, bases, attachments, semantic). The attachments group is where the non-text block constructors (`image`/`audio`/`blobResource`/`untrustedResource`) get added; the semantic/progress group carries the `extra`-boundary type-cast caveat (verify progress plumbing at runtime).
