### PR TITLE
refactor(tools): migrate links group through the tool seam

### DIFF
--- a/docs/adr/0001-tool-seam.md
+++ b/docs/adr/0001-tool-seam.md
@@ -1,6 +1,6 @@
 # ADR 0001: One deep tool seam behind every MCP tool
 
-- Status: Accepted (read group migrated as the pattern-setter, canvas group migrated next; 7 groups to follow)
+- Status: Accepted (read group migrated as the pattern-setter, then canvas and links; 6 groups to follow)
 - Date: 2026-07-18
 
 ## Context
@@ -93,9 +93,17 @@ Non-text blocks (to be added when the attachments/canvas groups migrate;
   unexpected failure and asserts the generic sanitized result.
 - Output is **byte-preserving**. The seam reuses the existing `tool-output.ts`
   primitives, so every `regression-tools-*` and `handlers/*` interface test
-  stays green unchanged. One intentional exception is recorded: the generic
-  thrown-error prefix replaces per-tool verbs (thrown path only; no test pins
-  the wording).
+  stays green unchanged. Two intentional exceptions are recorded:
+  1. The generic thrown-error prefix replaces per-tool verbs (thrown path only;
+     no test pins the wording).
+  2. `get_backlinks` (links group) no longer prefixes each context block with a
+     decorative `→ ` on the BEGIN line. The seam wraps untrusted content as
+     whole indented blocks, and a trusted lead-in on the same line as a BEGIN
+     marker is not expressible without widening the frozen `richText`
+     vocabulary — not worth it for one caller's arrow. The context stays
+     BEGIN/END-wrapped with the same `get_backlinks context` label and the
+     block-level trust `_meta` is unchanged, so the delta is purely visual with
+     no trust impact. No test pins the arrow.
 - `docs/TOOL_AUTHORING.md §4` is superseded: handlers no longer write the recipe.
   The per-tool `title`/`description`/`annotations`/`inputSchema` surface is
   unchanged.
@@ -129,13 +137,19 @@ compiler will not catch mis-threaded `extra`. Verify that plumbing at runtime
 
 ## Migration
 
-Read group first (pattern-setter), canvas group next. The canvas group is all
-text, so it migrated using only the existing `text`/`richText`/`error`
+Read group first (pattern-setter), then canvas, then links. The canvas group is
+all text, so it migrated using only the existing `text`/`richText`/`error`
 constructors and needed no seam changes; its conversion routes
 `add_canvas_edge`'s unexpected-error path through the seam's sanitize boundary
-(see Consequences). Remaining 7 groups are file-disjoint and convert
-independently, deleting each group's duplicated recipe helpers as it goes and
-extending the seam with the non-text block constructors when the attachments
+(see Consequences). The links group is also all text; its shared multi-tool
+render helpers (`untrustedLinkTarget`, `untrustedLinkPathRows`) were rewritten to
+emit through the `richText` builder rather than a `lines[]` array — the same
+builder-passing idiom as canvas's `renderCanvasSummary(b, …)`. `find_orphans`'
+conditional block-level `_meta` now falls out of `richText`'s `hasUntrusted` for
+free, deleting its bookkeeping; the one output delta is `get_backlinks`' dropped
+context arrow (see Consequences). Remaining 6 groups are file-disjoint and
+convert independently, deleting each group's duplicated recipe helpers as it goes
+and extending the seam with the non-text block constructors when the attachments
 group migrates. Collapsing the 9 `display*Value` aliases to a single
 `escapeControlChars` import is a follow-up sweep. `TOOL_AUTHORING.md §4` is
 rewritten last, once the pattern is proven across all groups.

--- a/src/__tests__/handlers/links.test.ts
+++ b/src/__tests__/handlers/links.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
+import {
+  createTestEnv,
+  textContent,
+  isError,
+  type TestEnv,
+} from "./harness.js";
 
 let env: TestEnv;
 
@@ -23,9 +28,18 @@ describe("link handlers — get_backlinks", () => {
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     expect(text).toContain("nested/note-d.md");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_backlinks target path]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_backlinks source path]");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_backlinks target path]"
+    );
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_backlinks source path]"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "get_backlinks paths and context"
+    );
   });
 
   it("reports 'No backlinks' for a note nothing links to", async () => {
@@ -108,11 +122,22 @@ describe("link handlers — get_backlinks", () => {
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     expect(text).toContain("Links to [[note-a]]\\twith tab.");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_backlinks source path]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_backlinks context]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: backlink context: tab-backlink.md:");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_backlinks source path]"
+    );
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_backlinks context]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: backlink context: tab-backlink.md:"
+    );
     expect(text).not.toContain("note-a]]\twith tab");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "get_backlinks paths and context"
+    );
   });
 });
 
@@ -135,8 +160,12 @@ describe("link handlers — get_outlinks", () => {
     const text = textContent(result);
     expect(text).toMatch(/1 valid, 0 broken/);
     expect(text).toContain("note-b.md");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks source path]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks resolved path]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks source path]"
+    );
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks resolved path]"
+    );
   });
 
   it("canonicalizes source path dot segments before basename fallback", async () => {
@@ -209,9 +238,15 @@ describe("link handlers — get_outlinks", () => {
     const text = textContent(result);
     expect(isError(result)).toBe(false);
     expect(text).toContain("Outgoing links from:");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks source path]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks target]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: outlink target: warm-new-source.md]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks source path]"
+    );
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks target]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: outlink target: warm-new-source.md]"
+    );
     expect(text).toContain("note-a");
     expect(text).toContain("note-a.md");
   });
@@ -251,11 +286,20 @@ describe("link handlers — get_outlinks", () => {
     });
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks broken target]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_outlinks broken target]"
+    );
     expect(text).toContain("bad\\ttarget");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: broken outlink target: tab-outlink.md]");
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: broken outlink target: tab-outlink.md]"
+    );
     expect(text).not.toContain("bad\ttarget");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "get_outlinks paths and targets"
+    );
   });
 });
 
@@ -271,10 +315,19 @@ describe("link handlers — find_orphans", () => {
     expect(text).toContain("orphan.md");
     // note-c has backlinks (from note-b) but no outlinks → no-outlinks bucket.
     expect(text).toContain("note-c.md");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_orphans fully isolated paths]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_orphans no-outlink paths]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_orphans fully isolated paths]"
+    );
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_orphans no-outlink paths]"
+    );
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "find_orphans paths"
+    );
   });
 
   it("hides the no-outlinks bucket when includeOutlinksCheck=false", async () => {
@@ -304,10 +357,17 @@ describe("link handlers — find_orphans", () => {
 
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_orphans fully isolated paths]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_orphans fully isolated paths]"
+    );
     expect(text).toContain("orphan\\x7fpath.md");
     expect(text).not.toContain(dirtyPath);
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "find_orphans paths"
+    );
   });
 });
 
@@ -319,7 +379,9 @@ describe("link handlers — find_broken_links", () => {
     });
     const text = textContent(result);
     expect(text).toContain("broken.md");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_broken_links source path]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_broken_links source path]"
+    );
     expect(text).toContain("does-not-exist");
     expect(text).toMatch(/Total: 1 broken/);
   });
@@ -348,12 +410,23 @@ describe("link handlers — find_broken_links", () => {
     });
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_broken_links source path]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_broken_links target]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_broken_links source path]"
+    );
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_broken_links target]"
+    );
     expect(text).toContain("bad\\ttarget");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: broken link target: tab-broken-report.md:");
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: broken link target: tab-broken-report.md:"
+    );
     expect(text).not.toContain("bad\ttarget");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "find_broken_links paths and targets"
+    );
   });
 });
 
@@ -365,9 +438,18 @@ describe("link handlers — get_graph_neighbors", () => {
     });
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_graph_neighbors start path]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_graph_neighbors path tree]");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_graph_neighbors start path]"
+    );
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_graph_neighbors path tree]"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "get_graph_neighbors paths"
+    );
     // note-a links to note-b (outbound) and is linked from note-d (inbound).
     expect(text).toContain("note-b.md");
     expect(text).toContain("nested/note-d.md");
@@ -432,9 +514,13 @@ describe("link handlers — get_graph_neighbors", () => {
 
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: get_graph_neighbors path tree]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_graph_neighbors path tree]"
+    );
     expect(text).toContain("dirty\\x7fneighbor.md");
     expect(text).not.toContain(dirtyPath);
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
   });
 });

--- a/src/tools/links/find_broken_links.ts
+++ b/src/tools/links/find_broken_links.ts
@@ -1,22 +1,23 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { listNotes } from "../../lib/vault.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
+import { defineTool, text, richText } from "../../lib/tool-seam.js";
 import type { BrokenLink } from "../../types.js";
 import {
   buildLinkGraph,
   displayLinkValue,
-  untrustedLinkBlock,
-  pushUntrustedLinkTarget,
-  textWithUntrustedMeta,
-  errorResult,
+  untrustedLinkTarget,
 } from "./shared.js";
 
-export function registerFindBrokenLinks(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "find_broken_links",
+export function registerFindBrokenLinks(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "find_broken_links",
       title: "Find Broken Links",
       description:
         "Scan notes for wikilinks ([[target]]) whose target does not resolve to any existing note in the vault. Returns a per-source report grouping each note with its broken link text and line numbers, plus a total count. Use after renaming, moving, or deleting notes to catch dangling references. Resolution uses the whole vault even when scanning a single folder, so only truly unresolvable links are reported.",
@@ -30,7 +31,9 @@ export function registerFindBrokenLinks(server: McpServer, vaultPath: string): v
           .string()
           .max(500)
           .optional()
-          .describe("Restrict the scan to notes within this folder (resolution still uses the entire vault). Omit to scan every note."),
+          .describe(
+            "Restrict the scan to notes within this folder (resolution still uses the entire vault). Omit to scan every note."
+          ),
         maxResults: z
           .number()
           .int()
@@ -38,71 +41,76 @@ export function registerFindBrokenLinks(server: McpServer, vaultPath: string): v
           .max(1000)
           .optional()
           .default(200)
-          .describe("Maximum broken link entries to show (1-1000, default: 200). Grouped by source note. Remaining matches are summarized."),
+          .describe(
+            "Maximum broken link entries to show (1-1000, default: 200). Grouped by source note. Remaining matches are summarized."
+          ),
       },
     },
     async ({ folder, maxResults }) => {
-      try {
-        // Validate and capture folder scope before the whole-vault graph work
-        // so a missing folder fails fast. Resolution still uses the full graph.
-        const scanNotes = folder ? await listNotes(vaultPath, folder) : null;
-        const graph = await buildLinkGraph(vaultPath);
-        const notesToScan = scanNotes ?? graph.allNotes;
+      // Validate and capture folder scope before the whole-vault graph work
+      // so a missing folder fails fast. Resolution still uses the full graph.
+      const scanNotes = folder ? await listNotes(vaultPath, folder) : null;
+      const graph = await buildLinkGraph(vaultPath);
+      const notesToScan = scanNotes ?? graph.allNotes;
 
-        const brokenBySource = new Map<string, BrokenLink[]>();
+      const brokenBySource = new Map<string, BrokenLink[]>();
 
-        for (const notePath of notesToScan) {
-          const brokenLinks = graph.brokenLinks.get(notePath);
-          if (!brokenLinks || brokenLinks.length === 0) continue;
-          brokenBySource.set(notePath, brokenLinks);
-        }
+      for (const notePath of notesToScan) {
+        const brokenLinks = graph.brokenLinks.get(notePath);
+        if (!brokenLinks || brokenLinks.length === 0) continue;
+        brokenBySource.set(notePath, brokenLinks);
+      }
 
-        if (brokenBySource.size === 0) {
-          const scopeStr = folder ? ` in folder: ${displayLinkValue(folder)}` : "";
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `No broken links found${scopeStr}`,
-              },
-            ],
-          };
-        }
+      if (brokenBySource.size === 0) {
+        const scopeStr = folder
+          ? ` in folder: ${displayLinkValue(folder)}`
+          : "";
+        return text(`No broken links found${scopeStr}`);
+      }
 
-        let totalBroken = 0;
-        for (const brokenLinks of brokenBySource.values()) {
-          totalBroken += brokenLinks.length;
-        }
+      let totalBroken = 0;
+      for (const brokenLinks of brokenBySource.values()) {
+        totalBroken += brokenLinks.length;
+      }
 
-        const lines: string[] = [];
-        const scopeStr = folder ? ` (folder: ${displayLinkValue(folder)})` : "";
-        lines.push(`Broken links report${scopeStr}\n`);
+      const scopeStr = folder ? ` (folder: ${displayLinkValue(folder)})` : "";
+
+      return richText("find_broken_links paths and targets", (b) => {
+        b.trusted(`Broken links report${scopeStr}\n`);
 
         let shown = 0;
         for (const [sourcePath, brokenLinks] of brokenBySource) {
           if (shown >= maxResults) break;
-          lines.push("Source:");
-          lines.push(untrustedLinkBlock("find_broken_links source path", displayLinkValue(sourcePath), "  "));
+          b.trusted("Source:");
+          b.untrusted(
+            "find_broken_links source path",
+            displayLinkValue(sourcePath),
+            "  "
+          );
           for (const bl of brokenLinks) {
             if (shown >= maxResults) break;
             const lineStr = bl.line > 0 ? ` (line ${bl.line})` : "";
-            lines.push(`  - broken link${lineStr}`);
-            pushUntrustedLinkTarget(lines, "find_broken_links target", bl.targetLink, "    ");
+            b.trusted(`  - broken link${lineStr}`);
+            untrustedLinkTarget(
+              b,
+              "find_broken_links target",
+              bl.targetLink,
+              "    "
+            );
             shown++;
           }
-          lines.push("");
+          b.trusted("");
         }
 
         if (shown < totalBroken) {
-          lines.push(`... and ${totalBroken - shown} more broken link(s) not shown`);
+          b.trusted(
+            `... and ${totalBroken - shown} more broken link(s) not shown`
+          );
         }
-        lines.push(`Total: ${totalBroken} broken link(s) across ${brokenBySource.size} file(s)`);
-
-        return textWithUntrustedMeta(lines.join("\n"), "find_broken_links paths and targets");
-      } catch (err) {
-        log.error("find_broken_links failed", { tool: "find_broken_links", err: err as Error });
-        return errorResult(`Error finding broken links: ${sanitizeError(err)}`);
-      }
-    },
+        b.trusted(
+          `Total: ${totalBroken} broken link(s) across ${brokenBySource.size} file(s)`
+        );
+      });
+    }
   );
 }

--- a/src/tools/links/find_orphans.ts
+++ b/src/tools/links/find_orphans.ts
@@ -1,19 +1,18 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
 import type { OrphanNote } from "../../types.js";
-import {
-  buildLinkGraph,
-  pushUntrustedLinkPathRows,
-  textWithUntrustedMeta,
-  errorResult,
-} from "./shared.js";
+import { defineTool, richText } from "../../lib/tool-seam.js";
+import { buildLinkGraph, untrustedLinkPathRows } from "./shared.js";
 
-export function registerFindOrphans(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "find_orphans",
+export function registerFindOrphans(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "find_orphans",
       title: "Find Orphan Notes",
       description:
         "Identify disconnected notes in the vault's link graph, classified into three groups: fully isolated (no links in or out), no-backlinks (nothing links to them), and no-outlinks (they link to nothing). Returns counts per category and an example list per category, capped by maxResults. Use to surface abandoned notes, missing hub pages, or candidates for archiving.",
@@ -27,7 +26,9 @@ export function registerFindOrphans(server: McpServer, vaultPath: string): void 
           .boolean()
           .optional()
           .default(true)
-          .describe("If true (default), also report notes with no outgoing links; if false, only report fully-isolated notes and notes with no backlinks."),
+          .describe(
+            "If true (default), also report notes with no outgoing links; if false, only report fully-isolated notes and notes with no backlinks."
+          ),
         maxResults: z
           .number()
           .int()
@@ -35,90 +36,112 @@ export function registerFindOrphans(server: McpServer, vaultPath: string): void 
           .max(1000)
           .optional()
           .default(200)
-          .describe("Maximum total note paths to list across all categories (1-1000, default: 200). Full counts are always reported regardless."),
+          .describe(
+            "Maximum total note paths to list across all categories (1-1000, default: 200). Full counts are always reported regardless."
+          ),
       },
     },
     async ({ includeOutlinksCheck, maxResults }) => {
-      try {
-        const graph = await buildLinkGraph(vaultPath);
+      const graph = await buildLinkGraph(vaultPath);
 
-        const noBacklinks: OrphanNote[] = [];
-        const noOutlinks: OrphanNote[] = [];
-        const fullyIsolated: OrphanNote[] = [];
+      const noBacklinks: OrphanNote[] = [];
+      const noOutlinks: OrphanNote[] = [];
+      const fullyIsolated: OrphanNote[] = [];
 
-        for (const notePath of graph.allNotes) {
-          const hasBacklinks = (graph.backlinks.get(notePath)?.size ?? 0) > 0;
-          const hasOutlinks = (graph.outlinks.get(notePath)?.size ?? 0) > 0;
+      for (const notePath of graph.allNotes) {
+        const hasBacklinks = (graph.backlinks.get(notePath)?.size ?? 0) > 0;
+        const hasOutlinks = (graph.outlinks.get(notePath)?.size ?? 0) > 0;
 
-          if (!hasBacklinks && !hasOutlinks) {
-            fullyIsolated.push({ path: notePath, hasOutlinks: false, hasBacklinks: false });
-          } else if (!hasBacklinks) {
-            noBacklinks.push({ path: notePath, hasOutlinks, hasBacklinks: false });
-          } else if (!hasOutlinks && includeOutlinksCheck) {
-            noOutlinks.push({ path: notePath, hasOutlinks: false, hasBacklinks });
-          }
+        if (!hasBacklinks && !hasOutlinks) {
+          fullyIsolated.push({
+            path: notePath,
+            hasOutlinks: false,
+            hasBacklinks: false,
+          });
+        } else if (!hasBacklinks) {
+          noBacklinks.push({
+            path: notePath,
+            hasOutlinks,
+            hasBacklinks: false,
+          });
+        } else if (!hasOutlinks && includeOutlinksCheck) {
+          noOutlinks.push({ path: notePath, hasOutlinks: false, hasBacklinks });
         }
+      }
 
-        // Apply maxResults cap across all categories
-        let remaining = maxResults;
+      // Apply maxResults cap across all categories
+      let remaining = maxResults;
 
-        const cappedIsolated = fullyIsolated.slice(0, remaining);
-        remaining -= cappedIsolated.length;
-        const cappedNoBacklinks = noBacklinks.slice(0, Math.max(0, remaining));
-        remaining -= cappedNoBacklinks.length;
-        const cappedNoOutlinks = includeOutlinksCheck ? noOutlinks.slice(0, Math.max(0, remaining)) : [];
+      const cappedIsolated = fullyIsolated.slice(0, remaining);
+      remaining -= cappedIsolated.length;
+      const cappedNoBacklinks = noBacklinks.slice(0, Math.max(0, remaining));
+      remaining -= cappedNoBacklinks.length;
+      const cappedNoOutlinks = includeOutlinksCheck
+        ? noOutlinks.slice(0, Math.max(0, remaining))
+        : [];
 
-        const lines: string[] = [
-          `Orphan analysis for vault (${graph.allNotes.length} notes total)\n`,
-        ];
+      const totalOrphans =
+        fullyIsolated.length +
+        noBacklinks.length +
+        (includeOutlinksCheck ? noOutlinks.length : 0);
 
-        let hasDisplayedPathRows = false;
+      // richText attaches the block-level `_meta` only if at least one
+      // untrustedLinkPathRows section is emitted — so an all-empty analysis
+      // stays untagged, exactly as the prior hasDisplayedPathRows branch did.
+      return richText("find_orphans paths", (b) => {
+        b.trusted(
+          `Orphan analysis for vault (${graph.allNotes.length} notes total)\n`
+        );
 
-        lines.push(`Fully isolated (no links in or out): ${fullyIsolated.length}`);
-        hasDisplayedPathRows = pushUntrustedLinkPathRows(
-          lines,
+        b.trusted(
+          `Fully isolated (no links in or out): ${fullyIsolated.length}`
+        );
+        untrustedLinkPathRows(
+          b,
           "find_orphans fully isolated paths",
           cappedIsolated.map((note) => `- ${note.path}`),
-          "  ",
-        ) || hasDisplayedPathRows;
+          "  "
+        );
         if (cappedIsolated.length < fullyIsolated.length) {
-          lines.push(`  ... and ${fullyIsolated.length - cappedIsolated.length} more`);
+          b.trusted(
+            `  ... and ${fullyIsolated.length - cappedIsolated.length} more`
+          );
         }
 
-        lines.push(`\nNo backlinks (not linked by any note): ${noBacklinks.length}`);
-        hasDisplayedPathRows = pushUntrustedLinkPathRows(
-          lines,
+        b.trusted(
+          `\nNo backlinks (not linked by any note): ${noBacklinks.length}`
+        );
+        untrustedLinkPathRows(
+          b,
           "find_orphans no-backlink paths",
           cappedNoBacklinks.map((note) => `- ${note.path}`),
-          "  ",
-        ) || hasDisplayedPathRows;
+          "  "
+        );
         if (cappedNoBacklinks.length < noBacklinks.length) {
-          lines.push(`  ... and ${noBacklinks.length - cappedNoBacklinks.length} more`);
+          b.trusted(
+            `  ... and ${noBacklinks.length - cappedNoBacklinks.length} more`
+          );
         }
 
         if (includeOutlinksCheck) {
-          lines.push(`\nNo outlinks (links to no other notes): ${noOutlinks.length}`);
-          hasDisplayedPathRows = pushUntrustedLinkPathRows(
-            lines,
+          b.trusted(
+            `\nNo outlinks (links to no other notes): ${noOutlinks.length}`
+          );
+          untrustedLinkPathRows(
+            b,
             "find_orphans no-outlink paths",
             cappedNoOutlinks.map((note) => `- ${note.path}`),
-            "  ",
-          ) || hasDisplayedPathRows;
+            "  "
+          );
           if (cappedNoOutlinks.length < noOutlinks.length) {
-            lines.push(`  ... and ${noOutlinks.length - cappedNoOutlinks.length} more`);
+            b.trusted(
+              `  ... and ${noOutlinks.length - cappedNoOutlinks.length} more`
+            );
           }
         }
 
-        const totalOrphans = fullyIsolated.length + noBacklinks.length + (includeOutlinksCheck ? noOutlinks.length : 0);
-        lines.push(`\nTotal orphan entries: ${totalOrphans}`);
-
-        return hasDisplayedPathRows
-          ? textWithUntrustedMeta(lines.join("\n"), "find_orphans paths")
-          : { content: [{ type: "text" as const, text: lines.join("\n") }] };
-      } catch (err) {
-        log.error("find_orphans failed", { tool: "find_orphans", err: err as Error });
-        return errorResult(`Error finding orphans: ${sanitizeError(err)}`);
-      }
-    },
+        b.trusted(`\nTotal orphan entries: ${totalOrphans}`);
+      });
+    }
   );
 }

--- a/src/tools/links/get_backlinks.ts
+++ b/src/tools/links/get_backlinks.ts
@@ -1,23 +1,23 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { indentBlock, formatUntrustedVaultContent, untrustedVaultContentMeta } from "../../lib/tool-output.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
+import { defineTool, richText, error } from "../../lib/tool-seam.js";
 import {
   buildLinkGraph,
   resolveGraphInputPath,
   findLineWithLink,
   displayLinkValue,
-  untrustedLinkBlock,
-  textWithUntrustedMeta,
-  errorResult,
   resolveWikilinkWithIndex,
 } from "./shared.js";
 
-export function registerGetBacklinks(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "get_backlinks",
+export function registerGetBacklinks(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "get_backlinks",
       title: "Get Backlinks",
       description:
         "List all notes that contain a wikilink pointing to the target note. Each result includes the source note path, line number, and the surrounding line text for context. Use to understand which notes reference a topic, or to assess the impact of renaming or deleting a note. Accepts paths with or without .md extension; falls back to basename matching if exact match fails.",
@@ -31,110 +31,111 @@ export function registerGetBacklinks(server: McpServer, vaultPath: string): void
           .string()
           .min(1)
           .max(500)
-          .describe("Target note path relative to vault root (e.g., 'folder/note.md' or 'note'). Extension optional."),
+          .describe(
+            "Target note path relative to vault root (e.g., 'folder/note.md' or 'note'). Extension optional."
+          ),
       },
     },
     async ({ path: targetPath }) => {
-      try {
-        const graph = await buildLinkGraph(vaultPath);
+      const graph = await buildLinkGraph(vaultPath);
 
-        const resolvedTarget = resolveGraphInputPath(graph, targetPath);
+      const resolvedTarget = resolveGraphInputPath(graph, targetPath);
 
-        if (!resolvedTarget) {
-          return errorResult(`No note found matching path: ${displayLinkValue(targetPath)}`);
-        }
+      if (!resolvedTarget) {
+        return error(
+          `No note found matching path: ${displayLinkValue(targetPath)}`
+        );
+      }
 
-        const backlinkSources = graph.backlinks.get(resolvedTarget);
-        if (!backlinkSources || backlinkSources.size === 0) {
-          const text = [
-            "No backlinks found for:",
-            untrustedLinkBlock("get_backlinks target path", displayLinkValue(resolvedTarget), "  "),
-          ].join("\n");
-          return textWithUntrustedMeta(text, "get_backlinks target path");
-        }
+      const backlinkSources = graph.backlinks.get(resolvedTarget);
+      if (!backlinkSources || backlinkSources.size === 0) {
+        return richText("get_backlinks target path", (b) => {
+          b.trusted("No backlinks found for:");
+          b.untrusted(
+            "get_backlinks target path",
+            displayLinkValue(resolvedTarget),
+            "  "
+          );
+        });
+      }
 
-        const results: { source: string; line: number; context: string }[] = [];
+      const results: { source: string; line: number; context: string }[] = [];
 
-        for (const sourcePath of backlinkSources) {
-          const lines = graph.noteLines.get(sourcePath) ?? [];
-          // Find the line(s) that contain the link to the target
-          const links = graph.rawLinks.get(sourcePath) ?? [];
-          const relevantLinks = links.filter((l) => {
-            const base = l.target.split("#")[0]!.trim();
-            // Pass aliasMap so alias-only matches (e.g. `[[My Project]]`
-            // pointing at a note whose frontmatter declares that alias)
-            // resolve here exactly as they did during graph build. Without
-            // it, the source slipped into the backlink set during build but
-            // produced an empty line/context in this display pass.
-            const resolved = resolveWikilinkWithIndex(
-              base,
-              sourcePath,
-              graph.allNotes,
-              graph.pathIndex,
-              graph.aliasMap,
-            );
-            return resolved === resolvedTarget;
-          });
-
-          if (relevantLinks.length > 0) {
-            for (const link of relevantLinks) {
-              const lineInfo = findLineWithLink(lines, link.target);
-              results.push({
-                source: sourcePath,
-                line: lineInfo.line,
-                context: lineInfo.content,
-              });
-            }
-          } else {
-            results.push({ source: sourcePath, line: 0, context: "" });
-          }
-        }
-
-        // Deduplicate by source+line
-        const seen = new Set<string>();
-        const deduped = results.filter((r) => {
-          const key = `${r.source}:${r.line}`;
-          if (seen.has(key)) return false;
-          seen.add(key);
-          return true;
+      for (const sourcePath of backlinkSources) {
+        const lines = graph.noteLines.get(sourcePath) ?? [];
+        // Find the line(s) that contain the link to the target
+        const links = graph.rawLinks.get(sourcePath) ?? [];
+        const relevantLinks = links.filter((l) => {
+          const base = l.target.split("#")[0]!.trim();
+          // Pass aliasMap so alias-only matches (e.g. `[[My Project]]`
+          // pointing at a note whose frontmatter declares that alias)
+          // resolve here exactly as they did during graph build. Without
+          // it, the source slipped into the backlink set during build but
+          // produced an empty line/context in this display pass.
+          const resolved = resolveWikilinkWithIndex(
+            base,
+            sourcePath,
+            graph.allNotes,
+            graph.pathIndex,
+            graph.aliasMap
+          );
+          return resolved === resolvedTarget;
         });
 
-        const outputLines = [
-          "Backlinks to:",
-          untrustedLinkBlock("get_backlinks target path", displayLinkValue(resolvedTarget), "  "),
-          `Found: ${deduped.length} backlink(s)\n`,
-        ];
+        if (relevantLinks.length > 0) {
+          for (const link of relevantLinks) {
+            const lineInfo = findLineWithLink(lines, link.target);
+            results.push({
+              source: sourcePath,
+              line: lineInfo.line,
+              context: lineInfo.content,
+            });
+          }
+        } else {
+          results.push({ source: sourcePath, line: 0, context: "" });
+        }
+      }
+
+      // Deduplicate by source+line
+      const seen = new Set<string>();
+      const deduped = results.filter((r) => {
+        const key = `${r.source}:${r.line}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+
+      return richText("get_backlinks paths and context", (b) => {
+        b.trusted("Backlinks to:");
+        b.untrusted(
+          "get_backlinks target path",
+          displayLinkValue(resolvedTarget),
+          "  "
+        );
+        b.trusted(`Found: ${deduped.length} backlink(s)\n`);
         for (const r of deduped) {
           const lineStr = r.line > 0 ? `:${r.line}` : "";
-          outputLines.push("Source:");
-          outputLines.push(untrustedLinkBlock(
+          b.trusted("Source:");
+          b.untrusted(
             "get_backlinks source path",
             `${displayLinkValue(r.source)}${lineStr}`,
-            "  ",
-          ));
+            "  "
+          );
           if (r.context) {
-            outputLines.push(indentBlock(
-              `→ ${formatUntrustedVaultContent(
-                "get_backlinks context",
-                displayLinkValue(r.context),
-              )}`,
-              "  ",
-            ));
+            // Intentional migration delta: the pre-seam renderer prefixed this
+            // block with a decorative "→ " on the BEGIN line. The seam wraps
+            // untrusted content as whole indented blocks, so the arrow is
+            // dropped. The context is still BEGIN/END-wrapped with the same
+            // "get_backlinks context" label and the block-level trust `_meta`
+            // is unchanged — a purely visual delta, no trust impact.
+            b.untrusted(
+              "get_backlinks context",
+              displayLinkValue(r.context),
+              "  "
+            );
           }
         }
-        const output = outputLines.join("\n");
-
-        return {
-          content: [{
-            type: "text" as const,
-            text: output,
-            _meta: untrustedVaultContentMeta("get_backlinks paths and context"),
-          }],
-        };
-      } catch (err) {
-        log.error("get_backlinks failed", { tool: "get_backlinks", err: err as Error });
-        return errorResult(`Error finding backlinks: ${sanitizeError(err)}`);
-      }
-    },
+      });
+    }
   );
 }

--- a/src/tools/links/get_graph_neighbors.ts
+++ b/src/tools/links/get_graph_neighbors.ts
@@ -1,21 +1,22 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
 import type { GraphNeighbor } from "../../types.js";
+import { defineTool, richText, error } from "../../lib/tool-seam.js";
 import {
   buildLinkGraph,
   resolveGraphInputPath,
   displayLinkValue,
-  untrustedLinkBlock,
-  textWithUntrustedMeta,
-  errorResult,
 } from "./shared.js";
 
-export function registerGetGraphNeighbors(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "get_graph_neighbors",
+export function registerGetGraphNeighbors(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "get_graph_neighbors",
       title: "Get Graph Neighbors",
       description:
         "Traverse the wikilink graph outward from a starting note and return every note reachable within N hops, grouped by depth level with an indented tree visualization. Each neighbor is tagged with its hop distance and direction (inbound = reached via backlink, outbound = reached via outlink). Use to explore a topic cluster, map a note's local neighborhood, or find related notes beyond direct links. Accepts paths with or without .md extension.",
@@ -29,7 +30,9 @@ export function registerGetGraphNeighbors(server: McpServer, vaultPath: string):
           .string()
           .min(1)
           .max(500)
-          .describe("Starting note path relative to vault root (e.g., 'projects/alpha.md'). Extension optional; falls back to basename match."),
+          .describe(
+            "Starting note path relative to vault root (e.g., 'projects/alpha.md'). Extension optional; falls back to basename match."
+          ),
         depth: z
           .number()
           .int()
@@ -37,12 +40,16 @@ export function registerGetGraphNeighbors(server: McpServer, vaultPath: string):
           .max(3)
           .optional()
           .default(1)
-          .describe("Maximum link-hops to traverse from the start note (1-3, default: 1). Higher values explore exponentially more notes."),
+          .describe(
+            "Maximum link-hops to traverse from the start note (1-3, default: 1). Higher values explore exponentially more notes."
+          ),
         direction: z
           .enum(["both", "inbound", "outbound"])
           .optional()
           .default("both")
-          .describe("Traversal direction: 'outbound' follows outlinks the start note points to, 'inbound' follows backlinks pointing at the start note, 'both' follows either (default)"),
+          .describe(
+            "Traversal direction: 'outbound' follows outlinks the start note points to, 'inbound' follows backlinks pointing at the start note, 'both' follows either (default)"
+          ),
         maxResults: z
           .number()
           .int()
@@ -50,133 +57,144 @@ export function registerGetGraphNeighbors(server: McpServer, vaultPath: string):
           .max(1000)
           .optional()
           .default(200)
-          .describe("Maximum neighbor notes to return (1-1000, default: 200). Traversal stops early when this cap is reached and a truncation notice is appended."),
+          .describe(
+            "Maximum neighbor notes to return (1-1000, default: 200). Traversal stops early when this cap is reached and a truncation notice is appended."
+          ),
       },
     },
     async ({ path: startPath, depth, direction, maxResults }) => {
-      try {
-        const graph = await buildLinkGraph(vaultPath);
+      const graph = await buildLinkGraph(vaultPath);
 
-        const resolvedStart = resolveGraphInputPath(graph, startPath);
+      const resolvedStart = resolveGraphInputPath(graph, startPath);
 
-        if (!resolvedStart) {
-          return errorResult(`No note found matching path: ${displayLinkValue(startPath)}`);
+      if (!resolvedStart) {
+        return error(
+          `No note found matching path: ${displayLinkValue(startPath)}`
+        );
+      }
+
+      // BFS traversal with maxResults cap to prevent explosion at higher depths
+      const visited = new Map<string, GraphNeighbor>();
+      const queue: { path: string; currentDepth: number }[] = [
+        { path: resolvedStart, currentDepth: 0 },
+      ];
+      visited.set(resolvedStart, {
+        path: resolvedStart,
+        depth: 0,
+        direction: "both",
+      });
+      // Track neighbor count separately (visited includes the start node)
+      let neighborCount = 0;
+      let truncated = false;
+
+      while (queue.length > 0) {
+        const { path: currentPath, currentDepth } = queue.shift()!;
+        if (currentDepth >= depth) continue;
+        if (truncated) break;
+
+        const neighbors: { path: string; dir: "inbound" | "outbound" }[] = [];
+
+        if (direction === "outbound" || direction === "both") {
+          const outs = graph.outlinks.get(currentPath);
+          if (outs) {
+            for (const target of outs) {
+              neighbors.push({ path: target, dir: "outbound" });
+            }
+          }
         }
 
-        // BFS traversal with maxResults cap to prevent explosion at higher depths
-        const visited = new Map<string, GraphNeighbor>();
-        const queue: { path: string; currentDepth: number }[] = [
-          { path: resolvedStart, currentDepth: 0 },
-        ];
-        visited.set(resolvedStart, {
-          path: resolvedStart,
-          depth: 0,
-          direction: "both",
+        if (direction === "inbound" || direction === "both") {
+          const ins = graph.backlinks.get(currentPath);
+          if (ins) {
+            for (const source of ins) {
+              neighbors.push({ path: source, dir: "inbound" });
+            }
+          }
+        }
+
+        for (const neighbor of neighbors) {
+          if (!visited.has(neighbor.path)) {
+            if (neighborCount >= maxResults) {
+              truncated = true;
+              break;
+            }
+            const neighborInfo: GraphNeighbor = {
+              path: neighbor.path,
+              depth: currentDepth + 1,
+              direction: neighbor.dir,
+            };
+            visited.set(neighbor.path, neighborInfo);
+            neighborCount++;
+            queue.push({ path: neighbor.path, currentDepth: currentDepth + 1 });
+          }
+        }
+      }
+
+      // Remove the start node from results
+      visited.delete(resolvedStart);
+
+      if (visited.size === 0) {
+        return richText("get_graph_neighbors start path", (b) => {
+          b.trusted("No neighbors found for:");
+          b.untrusted(
+            "get_graph_neighbors start path",
+            displayLinkValue(resolvedStart),
+            "  "
+          );
+          b.trusted(`(depth: ${depth}, direction: ${direction})`);
         });
-        // Track neighbor count separately (visited includes the start node)
-        let neighborCount = 0;
-        let truncated = false;
+      }
 
-        while (queue.length > 0) {
-          const { path: currentPath, currentDepth } = queue.shift()!;
-          if (currentDepth >= depth) continue;
-          if (truncated) break;
-
-          const neighbors: { path: string; dir: "inbound" | "outbound" }[] = [];
-
-          if (direction === "outbound" || direction === "both") {
-            const outs = graph.outlinks.get(currentPath);
-            if (outs) {
-              for (const target of outs) {
-                neighbors.push({ path: target, dir: "outbound" });
-              }
-            }
-          }
-
-          if (direction === "inbound" || direction === "both") {
-            const ins = graph.backlinks.get(currentPath);
-            if (ins) {
-              for (const source of ins) {
-                neighbors.push({ path: source, dir: "inbound" });
-              }
-            }
-          }
-
-          for (const neighbor of neighbors) {
-            if (!visited.has(neighbor.path)) {
-              if (neighborCount >= maxResults) {
-                truncated = true;
-                break;
-              }
-              const neighborInfo: GraphNeighbor = {
-                path: neighbor.path,
-                depth: currentDepth + 1,
-                direction: neighbor.dir,
-              };
-              visited.set(neighbor.path, neighborInfo);
-              neighborCount++;
-              queue.push({ path: neighbor.path, currentDepth: currentDepth + 1 });
-            }
-          }
+      // Group by depth level for tree-like output
+      const byDepth = new Map<number, GraphNeighbor[]>();
+      for (const neighbor of visited.values()) {
+        if (!byDepth.has(neighbor.depth)) {
+          byDepth.set(neighbor.depth, []);
         }
+        byDepth.get(neighbor.depth)!.push(neighbor);
+      }
 
-        // Remove the start node from results
-        visited.delete(resolvedStart);
+      const truncatedStr = truncated ? " (TRUNCATED)" : "";
+      const pathTreeLines = [displayLinkValue(resolvedStart)];
 
-        if (visited.size === 0) {
-          const text = [
-            "No neighbors found for:",
-            untrustedLinkBlock("get_graph_neighbors start path", displayLinkValue(resolvedStart), "  "),
-            `(depth: ${depth}, direction: ${direction})`,
-          ].join("\n");
-          return textWithUntrustedMeta(text, "get_graph_neighbors start path");
+      const sortedDepths = [...byDepth.keys()].sort((a, b) => a - b);
+      for (const d of sortedDepths) {
+        const neighbors = byDepth.get(d)!;
+        neighbors.sort((a, b) => a.path.localeCompare(b.path));
+
+        for (const neighbor of neighbors) {
+          const indent = "  ".repeat(d);
+          const arrow =
+            neighbor.direction === "inbound"
+              ? "←"
+              : neighbor.direction === "outbound"
+                ? "→"
+                : "↔";
+          pathTreeLines.push(
+            `${indent}${arrow} ${displayLinkValue(neighbor.path)} (depth ${d})`
+          );
         }
+      }
 
-        // Group by depth level for tree-like output
-        const byDepth = new Map<number, GraphNeighbor[]>();
-        for (const neighbor of visited.values()) {
-          if (!byDepth.has(neighbor.depth)) {
-            byDepth.set(neighbor.depth, []);
-          }
-          byDepth.get(neighbor.depth)!.push(neighbor);
-        }
-
-        const truncatedStr = truncated ? " (TRUNCATED)" : "";
-        const lines: string[] = [
-          "Graph neighbors of:",
-          untrustedLinkBlock("get_graph_neighbors start path", displayLinkValue(resolvedStart), "  "),
-          `Direction: ${direction} | Max depth: ${depth} | Found: ${visited.size} note(s)${truncatedStr}\n`,
-          "Path tree:",
-        ];
-        const pathTreeLines = [displayLinkValue(resolvedStart)];
-
-        const sortedDepths = [...byDepth.keys()].sort((a, b) => a - b);
-        for (const d of sortedDepths) {
-          const neighbors = byDepth.get(d)!;
-          neighbors.sort((a, b) => a.path.localeCompare(b.path));
-
-          for (const neighbor of neighbors) {
-            const indent = "  ".repeat(d);
-            const arrow =
-              neighbor.direction === "inbound"
-                ? "←"
-                : neighbor.direction === "outbound"
-                  ? "→"
-                  : "↔";
-            pathTreeLines.push(`${indent}${arrow} ${displayLinkValue(neighbor.path)} (depth ${d})`);
-          }
-        }
-        lines.push(untrustedLinkBlock("get_graph_neighbors path tree", pathTreeLines.join("\n")));
+      return richText("get_graph_neighbors paths", (b) => {
+        b.trusted("Graph neighbors of:");
+        b.untrusted(
+          "get_graph_neighbors start path",
+          displayLinkValue(resolvedStart),
+          "  "
+        );
+        b.trusted(
+          `Direction: ${direction} | Max depth: ${depth} | Found: ${visited.size} note(s)${truncatedStr}\n`
+        );
+        b.trusted("Path tree:");
+        b.untrusted("get_graph_neighbors path tree", pathTreeLines.join("\n"));
 
         if (truncated) {
-          lines.push(`\nResults truncated at ${maxResults} neighbors. Reduce depth or narrow direction to see the full graph.`);
+          b.trusted(
+            `\nResults truncated at ${maxResults} neighbors. Reduce depth or narrow direction to see the full graph.`
+          );
         }
-
-        return textWithUntrustedMeta(lines.join("\n"), "get_graph_neighbors paths");
-      } catch (err) {
-        log.error("get_graph_neighbors failed", { tool: "get_graph_neighbors", err: err as Error });
-        return errorResult(`Error getting graph neighbors: ${sanitizeError(err)}`);
-      }
-    },
+      });
+    }
   );
 }

--- a/src/tools/links/get_outlinks.ts
+++ b/src/tools/links/get_outlinks.ts
@@ -1,21 +1,22 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
+import { defineTool, richText, error } from "../../lib/tool-seam.js";
 import {
   buildLinkGraph,
   resolveGraphInputPath,
   displayLinkValue,
-  untrustedLinkBlock,
-  pushUntrustedLinkTarget,
-  textWithUntrustedMeta,
-  errorResult,
+  untrustedLinkTarget,
 } from "./shared.js";
 
-export function registerGetOutlinks(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "get_outlinks",
+export function registerGetOutlinks(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "get_outlinks",
       title: "Get Outlinks",
       description:
         "List every outgoing wikilink from a note, partitioned into valid links (resolve to an existing note), broken links (target not found), and file embeds (![[...]]). Returns the raw link text and resolved paths. Use to audit a note's references, detect broken links, or follow downstream dependencies.",
@@ -29,67 +30,78 @@ export function registerGetOutlinks(server: McpServer, vaultPath: string): void 
           .string()
           .min(1)
           .max(500)
-          .describe("Source note path relative to vault root (e.g., 'folder/note.md'). Extension optional."),
+          .describe(
+            "Source note path relative to vault root (e.g., 'folder/note.md'). Extension optional."
+          ),
       },
     },
     async ({ path: notePath }) => {
-      try {
-        // Route through the shared link graph so resolution uses the same
-        // alias map the rest of the link tools rely on, and so the heavy
-        // read/parse work is shared with backlinks/orphans/broken-links
-        // calls. The graph already indexes raw links per source.
-        const graph = await buildLinkGraph(vaultPath);
+      // Route through the shared link graph so resolution uses the same
+      // alias map the rest of the link tools rely on, and so the heavy
+      // read/parse work is shared with backlinks/orphans/broken-links
+      // calls. The graph already indexes raw links per source.
+      const graph = await buildLinkGraph(vaultPath);
 
-        const resolvedSource = resolveGraphInputPath(graph, notePath);
-        if (!resolvedSource) {
-          return errorResult(`No note found matching path: ${displayLinkValue(notePath)}`);
-        }
+      const resolvedSource = resolveGraphInputPath(graph, notePath);
+      if (!resolvedSource) {
+        return error(
+          `No note found matching path: ${displayLinkValue(notePath)}`
+        );
+      }
 
-        const results = graph.outlinkDetails.get(resolvedSource) ?? [];
+      const results = graph.outlinkDetails.get(resolvedSource) ?? [];
 
-        if (results.length === 0) {
-          const text = [
-            "No outgoing links found in:",
-            untrustedLinkBlock("get_outlinks source path", displayLinkValue(resolvedSource), "  "),
-          ].join("\n");
-          return textWithUntrustedMeta(text, "get_outlinks source path");
-        }
+      if (results.length === 0) {
+        return richText("get_outlinks source path", (b) => {
+          b.trusted("No outgoing links found in:");
+          b.untrusted(
+            "get_outlinks source path",
+            displayLinkValue(resolvedSource),
+            "  "
+          );
+        });
+      }
 
-        const valid = results.filter((r) => r.isValid);
-        const broken = results.filter((r) => !r.isValid);
+      const valid = results.filter((r) => r.isValid);
+      const broken = results.filter((r) => !r.isValid);
 
-        const lines: string[] = [
-          "Outgoing links from:",
-          untrustedLinkBlock("get_outlinks source path", displayLinkValue(resolvedSource), "  "),
-          `Total: ${results.length} (${valid.length} valid, ${broken.length} broken)\n`,
-        ];
+      return richText("get_outlinks paths and targets", (b) => {
+        b.trusted("Outgoing links from:");
+        b.untrusted(
+          "get_outlinks source path",
+          displayLinkValue(resolvedSource),
+          "  "
+        );
+        b.trusted(
+          `Total: ${results.length} (${valid.length} valid, ${broken.length} broken)\n`
+        );
 
         if (valid.length > 0) {
-          lines.push("Valid links:");
+          b.trusted("Valid links:");
           for (const r of valid) {
-            lines.push("  Resolved path:");
-            lines.push(untrustedLinkBlock(
+            b.trusted("  Resolved path:");
+            b.untrusted(
               "get_outlinks resolved path",
               `${displayLinkValue(r.resolvedPath ?? "")}${r.isEmbed ? " (embed)" : ""}`,
-              "    ",
-            ));
-            pushUntrustedLinkTarget(lines, "get_outlinks target", r.target, "    ");
+              "    "
+            );
+            untrustedLinkTarget(b, "get_outlinks target", r.target, "    ");
           }
         }
 
         if (broken.length > 0) {
-          lines.push("\nBroken links:");
+          b.trusted("\nBroken links:");
           for (const r of broken) {
-            lines.push(`  - unresolved${r.isEmbed ? " (embed)" : ""}`);
-            pushUntrustedLinkTarget(lines, "get_outlinks broken target", r.target, "    ");
+            b.trusted(`  - unresolved${r.isEmbed ? " (embed)" : ""}`);
+            untrustedLinkTarget(
+              b,
+              "get_outlinks broken target",
+              r.target,
+              "    "
+            );
           }
         }
-
-        return textWithUntrustedMeta(lines.join("\n"), "get_outlinks paths and targets");
-      } catch (err) {
-        log.error("get_outlinks failed", { tool: "get_outlinks", err: err as Error });
-        return errorResult(`Error getting outlinks: ${sanitizeError(err)}`);
-      }
-    },
+      });
+    }
   );
 }

--- a/src/tools/links/shared.ts
+++ b/src/tools/links/shared.ts
@@ -1,9 +1,17 @@
-import { indentBlock, formatUntrustedVaultContent, untrustedVaultContentMeta } from "../../lib/tool-output.js";
+import type { RichTextBuilder } from "../../lib/tool-seam.js";
 import { escapeControlChars } from "../../lib/errors.js";
 import path from "path";
-import { getNoteStats, getVaultRootRealPath, listNotes } from "../../lib/vault.js";
+import {
+  getNoteStats,
+  getVaultRootRealPath,
+  listNotes,
+} from "../../lib/vault.js";
 import { readAllCached } from "../../lib/index-cache.js";
-import { extractWikilinks, extractAliases, normalizeWikilinkTargetPath } from "../../lib/markdown.js";
+import {
+  extractWikilinks,
+  extractAliases,
+  normalizeWikilinkTargetPath,
+} from "../../lib/markdown.js";
 import { log } from "../../lib/logger.js";
 import type { LinkInfo, BrokenLink } from "../../types.js";
 
@@ -70,7 +78,7 @@ function setGraphCache(key: string, entry: CachedGraph): void {
 
 function fingerprintFromMtimes(
   notes: string[],
-  mtimes: ReadonlyMap<string, number>,
+  mtimes: ReadonlyMap<string, number>
 ): string {
   // Accumulate a 32-bit FNV-1a hash over "<sortedPath>|<mtimeMs>;" per note.
   // Catches add+delete churn and mtime-restoring edits that count+max-mtime
@@ -90,7 +98,7 @@ function fingerprintFromMtimes(
 
 async function fingerprintVault(
   vaultPath: string,
-  notes: string[],
+  notes: string[]
 ): Promise<string> {
   const mtimes = new Map<string, number>();
   const sorted = [...notes].sort();
@@ -98,7 +106,9 @@ async function fingerprintVault(
   for (let i = 0; i < sorted.length; i += GRAPH_FINGERPRINT_CONCURRENCY) {
     const slice = sorted.slice(i, i + GRAPH_FINGERPRINT_CONCURRENCY);
     const stats = await Promise.all(
-      slice.map((n) => getNoteStats(vaultPath, n, { realVaultRoot }).catch(() => null)),
+      slice.map((n) =>
+        getNoteStats(vaultPath, n, { realVaultRoot }).catch(() => null)
+      )
     );
     for (let j = 0; j < slice.length; j++) {
       const mtime = stats[j]?.modified?.getTime() ?? 0;
@@ -137,12 +147,17 @@ function normalizeGraphInputPath(input: string): string {
   return normalized.replace(/\/+$/g, "").toLowerCase();
 }
 
-export function resolveGraphInputPath(graph: LinkGraphData, input: string): string | null {
+export function resolveGraphInputPath(
+  graph: LinkGraphData,
+  input: string
+): string | null {
   const normalized = normalizeGraphInputPath(input);
   const basename = normalized.split("/").pop() ?? normalized;
-  return graph.sourceLookup.get(`exact:${normalized}`) ??
+  return (
+    graph.sourceLookup.get(`exact:${normalized}`) ??
     graph.sourceLookup.get(`base:${basename}`) ??
-    null;
+    null
+  );
 }
 
 function sharedPathDepth(a: string, b: string): number {
@@ -179,7 +194,7 @@ function resolveWikilinkWithIndex(
   currentNotePath: string,
   allNotePaths: string[],
   index: NotePathIndex,
-  aliasMap: Map<string, string>,
+  aliasMap: Map<string, string>
 ): string | null {
   const cleanLink = link.split("#")[0]!.split("^")[0]!.trim();
   if (!cleanLink) return null;
@@ -195,8 +210,12 @@ function resolveWikilinkWithIndex(
     for (const notePath of allNotePaths) {
       const withoutExt = notePath.replace(/\.md$/i, "").toLowerCase();
       if (withoutExt.endsWith(normalizedLinkLower)) {
-        const prefix = withoutExt.slice(0, withoutExt.length - normalizedLinkLower.length);
-        if (prefix === "" || prefix.endsWith("/")) suffixCandidates.push(notePath);
+        const prefix = withoutExt.slice(
+          0,
+          withoutExt.length - normalizedLinkLower.length
+        );
+        if (prefix === "" || prefix.endsWith("/"))
+          suffixCandidates.push(notePath);
       }
     }
     if (suffixCandidates.length === 1) return suffixCandidates[0]!;
@@ -215,7 +234,10 @@ function resolveWikilinkWithIndex(
   return aliasMap.get(normalizedLinkLower) ?? null;
 }
 
-function nearestNotePath(currentNotePath: string, candidates: readonly string[]): string {
+function nearestNotePath(
+  currentNotePath: string,
+  candidates: readonly string[]
+): string {
   const sourceDir = path.dirname(currentNotePath).replace(/\\/g, "/");
   return [...candidates].sort((a, b) => {
     const da = sharedPathDepth(sourceDir, path.dirname(a).replace(/\\/g, "/"));
@@ -227,7 +249,7 @@ function nearestNotePath(currentNotePath: string, candidates: readonly string[])
 
 export async function buildLinkGraph(
   vaultPath: string,
-  folder?: string,
+  folder?: string
 ): Promise<LinkGraphData> {
   const cacheKey = `${vaultPath}::${folder ?? ""}`;
   const cached = graphCache.get(cacheKey);
@@ -262,7 +284,7 @@ export async function buildLinkGraph(
     allNotes,
     (note, err) => {
       log.warn("link graph: note read failed", { note, err });
-    },
+    }
   );
 
   // Build alias map first so any note can link to any other by alias
@@ -278,7 +300,10 @@ export async function buildLinkGraph(
       if (!key) continue;
       const prior = aliasMap.get(key);
       if (prior && prior !== notePath) {
-        log.warn("Duplicate alias", { alias: REDACTED_ALIAS_LABEL, notes: [prior, notePath] });
+        log.warn("Duplicate alias", {
+          alias: REDACTED_ALIAS_LABEL,
+          notes: [prior, notePath],
+        });
       }
       aliasMap.set(key, notePath);
     }
@@ -307,7 +332,13 @@ export async function buildLinkGraph(
       const targetBase = link.target.split("#")[0]!.trim();
       if (!targetBase) continue;
 
-      const resolved = resolveWikilinkWithIndex(targetBase, notePath, allNotes, pathIndex, aliasMap);
+      const resolved = resolveWikilinkWithIndex(
+        targetBase,
+        notePath,
+        allNotes,
+        pathIndex,
+        aliasMap
+      );
       details.push({
         target: link.target,
         resolvedPath: resolved,
@@ -359,12 +390,12 @@ export async function buildLinkGraph(
 
 export function findLineWithLink(
   lines: string[],
-  linkTarget: string,
+  linkTarget: string
 ): { line: number; content: string } {
   const targetLower = linkTarget.toLowerCase();
   // Exact match: the character after the link name must be ]], |, or #
   // to avoid prefix false positives (e.g. [[note]] matching [[notebook]]).
-  const exactSuffixes = ["]]" , "|", "#"];
+  const exactSuffixes = ["]]", "|", "#"];
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (line === undefined) continue;
@@ -372,7 +403,10 @@ export function findLineWithLink(
     const idx = lineLower.indexOf(`[[${targetLower}`);
     if (idx !== -1) {
       const afterPos = idx + 2 + targetLower.length;
-      if (afterPos <= lineLower.length && exactSuffixes.some((s) => lineLower.startsWith(s, afterPos))) {
+      if (
+        afterPos <= lineLower.length &&
+        exactSuffixes.some((s) => lineLower.startsWith(s, afterPos))
+      ) {
         return { line: i + 1, content: line.trim() };
       }
     }
@@ -386,7 +420,10 @@ export function findLineWithLink(
     const idx = lineLower.indexOf(`[[${basename}`);
     if (idx !== -1) {
       const afterPos = idx + 2 + basename.length;
-      if (afterPos <= lineLower.length && exactSuffixes.some((s) => lineLower.startsWith(s, afterPos))) {
+      if (
+        afterPos <= lineLower.length &&
+        exactSuffixes.some((s) => lineLower.startsWith(s, afterPos))
+      ) {
         return { line: i + 1, content: line.trim() };
       }
     }
@@ -398,43 +435,32 @@ export function displayLinkValue(value: string): string {
   return escapeControlChars(value);
 }
 
-export function untrustedLinkBlock(label: string, text: string, indent = ""): string {
-  return indentBlock(formatUntrustedVaultContent(label, text), indent);
-}
+// Group render helpers that emit through the seam's richText builder — the seam
+// owns the actual BEGIN/END wrapping and the block-level trust `_meta`. These
+// factor the "Target:" and path-rows shapes shared across the link tools.
 
-export function pushUntrustedLinkPathRows(
-  lines: string[],
-  label: string,
-  rows: readonly string[],
-  indent = "",
-): boolean {
-  if (rows.length === 0) return false;
-  lines.push(untrustedLinkBlock(label, rows.map(displayLinkValue).join("\n"), indent));
-  return true;
-}
-
-export function pushUntrustedLinkTarget(
-  lines: string[],
+/** Append a "Target:" label line plus the target as a wrapped untrusted block. */
+export function untrustedLinkTarget(
+  b: RichTextBuilder,
   label: string,
   target: string,
-  indent: string,
+  indent: string
 ): void {
-  lines.push(`${indent}Target:`);
-  lines.push(untrustedLinkBlock(label, displayLinkValue(target), `${indent}  `));
+  b.trusted(`${indent}Target:`);
+  b.untrusted(label, displayLinkValue(target), `${indent}  `);
 }
 
-export function textWithUntrustedMeta(text: string, label: string) {
-  return {
-    content: [{
-      type: "text" as const,
-      text,
-      _meta: untrustedVaultContentMeta(label),
-    }],
-  };
-}
-
-export function errorResult(text: string) {
-  return { content: [{ type: "text" as const, text }], isError: true as const };
+/** Append `rows` as one wrapped untrusted block, or nothing when empty. Emitting
+ *  no untrusted section is what keeps richText from attaching the block-level
+ *  `_meta`, so an all-empty result stays untagged. */
+export function untrustedLinkPathRows(
+  b: RichTextBuilder,
+  label: string,
+  rows: readonly string[],
+  indent = ""
+): void {
+  if (rows.length === 0) return;
+  b.untrusted(label, rows.map(displayLinkValue).join("\n"), indent);
 }
 
 export { resolveWikilinkWithIndex };


### PR DESCRIPTION
## What

Third fan-out step after read and canvas ([ADR 0001](docs/adr/0001-tool-seam.md)). Routes all five link tools (`get_backlinks`, `get_outlinks`, `find_orphans`, `find_broken_links`, `get_graph_neighbors`) through `defineTool` + the branded `ToolResult` vocabulary, deleting the per-tool recipe (terminal `try/catch` + `errorResult` + manual untrusted-content wrapping).

## How

The links group is all text but, unlike canvas, had **shared multi-tool render helpers**. Those move from `lines[]`-array mutation to the `richText` builder — the same builder-passing idiom as canvas's `renderCanvasSummary(b, …)`:

- `shared.ts` keeps `displayLinkValue` and all graph logic (`buildLinkGraph`, `resolveGraphInputPath`, `findLineWithLink`, `resolveWikilinkWithIndex`, the graph cache). The recipe helpers (`untrustedLinkBlock`, `textWithUntrustedMeta`, `errorResult`, `pushUntrusted*`) are replaced by builder-based `untrustedLinkTarget(b, …)` and `untrustedLinkPathRows(b, …)`.
- `find_orphans`' conditional block-level `_meta` now falls out of `richText`'s `hasUntrusted` **for free** — the `hasDisplayedPathRows` bookkeeping deletes entirely.
- Errors: domain "no note found" / invalid-folder → `error()` (verbatim, `displayLinkValue`-escaped); success → `text`/`richText`; unexpected throws → the seam's single `sanitizeError` boundary.

The seam module itself is **not touched** — all five tools map to existing `text`/`richText`/`error` constructors.

## Safety

- **Byte-preserving** with one documented exception. Every existing `regression-tools-links` and `handlers/links` test stays green **unchanged**.
- **Intentional delta (2nd overall, after the generic `Error:` prefix):** `get_backlinks` no longer prefixes each context block with a decorative `→ ` on the BEGIN line. The seam wraps untrusted content as whole indented blocks, and a trusted lead-in sharing the BEGIN line isn't expressible without widening the frozen `richText` vocabulary — not worth it for one caller's arrow. The context stays BEGIN/END-wrapped with the same `get_backlinks context` label and identical block-level `_meta`, so the delta is **purely visual, no trust impact**. No test pins the arrow. ADR 0001 records it.

## Gates

`typecheck` · `lint` · `build` all clean; **979 tests pass** (15 skipped), zero test edits. Net −70 lines.

## Scope / follow-up

Links group only. 6 groups remain (write, tags, sections, bases, attachments, semantic). Attachments is where the non-text block constructors get added to the seam; the semantic/progress group needs a runtime progress-notification test (the `extra`-boundary type-cast caveat).
