### PR TITLE
refactor(tools): migrate tags group through the tool seam

### DIFF
--- a/src/__tests__/handlers/tags.test.ts
+++ b/src/__tests__/handlers/tags.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
-import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
+import {
+  createTestEnv,
+  textContent,
+  isError,
+  type TestEnv,
+} from "./harness.js";
 import { setMaxNoteFileBytesForTests } from "../../lib/vault.js";
 
 let env: TestEnv;
@@ -17,7 +22,10 @@ afterEach(async () => {
 
 describe("tag handlers — list_tags", () => {
   it("enumerates unique tags across the vault with counts", async () => {
-    const result = await env.client.callTool({ name: "list_tags", arguments: {} });
+    const result = await env.client.callTool({
+      name: "list_tags",
+      arguments: {},
+    });
     expect(isError(result)).toBe(false);
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
@@ -27,7 +35,12 @@ describe("tag handlers — list_tags", () => {
     expect(text).toMatch(/#review/);
     expect(text).toMatch(/#lonely/);
     expect(text).toMatch(/#nested\/archive/);
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "list_tags values"
+    );
   });
 
   it("escapes frontmatter tag labels in list output", async () => {
@@ -52,7 +65,12 @@ describe("tag handlers — list_tags", () => {
     expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: list_tags values]");
     expect(text).toContain("#dirty\\x7ftag (1 note)");
     expect(text).not.toContain(dirtyTag);
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "list_tags values"
+    );
   });
 
   it("ignores numeric-only frontmatter tags in list and search", async () => {
@@ -93,7 +111,9 @@ describe("tag handlers — list_tags", () => {
       arguments: {
         path: "whitespace-frontmatter-tag.md",
         content: "Body.",
-        frontmatter: JSON.stringify({ tags: ["project alpha", "project-alpha"] }),
+        frontmatter: JSON.stringify({
+          tags: ["project alpha", "project-alpha"],
+        }),
       },
     });
 
@@ -120,7 +140,10 @@ describe("tag handlers — list_tags", () => {
   });
 
   it("sorts by count desc by default (review appears in 2 notes)", async () => {
-    const result = await env.client.callTool({ name: "list_tags", arguments: {} });
+    const result = await env.client.callTool({
+      name: "list_tags",
+      arguments: {},
+    });
     const text = textContent(result);
     // `#review` appears in note-a AND note-b → 2 notes
     expect(text).toMatch(/#review \(2 notes\)/);
@@ -154,14 +177,27 @@ describe("tag handlers — search_by_tag", () => {
     });
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    const pathMarkers = [...text.matchAll(/\[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path\]/g)];
+    const pathMarkers = [
+      ...text.matchAll(
+        /\[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path\]/g
+      ),
+    ];
     expect(pathMarkers).toHaveLength(2);
     expect(text).toContain("note-a.md");
     expect(text).toContain("note-b.md");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: note-a.md]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: note-b.md]");
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: note-a.md]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: note-b.md]"
+    );
     expect(text).not.toContain("orphan.md");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "search_by_tag paths"
+    );
   });
 
   it("accepts tags with or without a leading '#'", async () => {
@@ -241,17 +277,30 @@ describe("tag handlers — search_by_tag", () => {
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     // The body of note-b starts with its frontmatter delimiter in a preview.
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path]"
+    );
     expect(text).toContain("note-a.md");
     expect(text).toContain("note-b.md");
     // Frontmatter is now stripped from previews, so verify body content appears instead.
     expect(text).toMatch(/Note A|Note B/);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag preview]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag preview]"
+    );
     expect(text).toContain("# Note A\\n\\nLinks to [[note-b]]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: note-a.md]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: tag preview: note-a.md]");
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: note-a.md]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: tag preview: note-a.md]"
+    );
     expect(text).not.toContain("# Note A\n\nLinks to [[note-b]]");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "search_by_tag paths and previews"
+    );
   });
 
   it("honors maxResults cap", async () => {
@@ -281,9 +330,13 @@ describe("tag handlers — search_by_tag", () => {
 
     expect(isError(result)).toBe(false);
     const text = textContent(result);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path]"
+    );
     expect(text).toContain("fresh-tag.md");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: fresh-tag.md]");
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: search_by_tag result path: fresh-tag.md]"
+    );
   });
 });
 
@@ -334,7 +387,11 @@ describe("tag handlers — rename_tag", () => {
 
     const result = await env.client.callTool({
       name: "rename_tag",
-      arguments: { oldName: "1a", newName: "2026-goals", confirmTag: "2026-goals" },
+      arguments: {
+        oldName: "1a",
+        newName: "2026-goals",
+        confirmTag: "2026-goals",
+      },
     });
     expect(isError(result)).toBe(false);
     expect(textContent(result)).toMatch(/Rewrote #1a/);
@@ -382,14 +439,24 @@ describe("tag handlers — rename_tag", () => {
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     expect(isError(result)).toBe(false);
     expect(text).toContain("Skipped due to errors: 1");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: rename_tag failed note]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: rename_tag failed note]"
+    );
     expect(text).toContain("dirty\\x7ffailed.md: Note file exceeds size cap");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: rename_tag failed note: dirty\\x7ffailed.md]");
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: rename_tag failed note: dirty\\x7ffailed.md]"
+    );
     expect(text).not.toContain(dirtyPath);
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
-    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("rename_tag failed notes");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "rename_tag failed notes"
+    );
 
-    await expect(fs.readFile(path.join(env.vaultDir, "ok.md"), "utf-8")).resolves.toBe("#draft\n");
+    await expect(
+      fs.readFile(path.join(env.vaultDir, "ok.md"), "utf-8")
+    ).resolves.toBe("#draft\n");
   });
 
   it("aborts rename_tag when elicitation confirms the wrong tag", async () => {
@@ -408,7 +475,9 @@ describe("tag handlers — rename_tag", () => {
     });
 
     expect(isError(result)).toBe(true);
-    expect(textContent(result)).toContain("Confirmation tag did not match #wip");
+    expect(textContent(result)).toContain(
+      "Confirmation tag did not match #wip"
+    );
     const search = await env.client.callTool({
       name: "search_by_tag",
       arguments: { tag: "draft" },

--- a/src/tools/tags/list_tags.ts
+++ b/src/tools/tags/list_tags.ts
@@ -2,17 +2,18 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { listNotes } from "../../lib/vault.js";
 import { readAllCached } from "../../lib/index-cache.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { formatUntrustedVaultContent, untrustedVaultContentMeta } from "../../lib/tool-output.js";
 import { log } from "../../lib/logger.js";
+import { defineTool, richText } from "../../lib/tool-seam.js";
 
 import type { TagInfo } from "../../types.js";
-import { errorResult, displayTagValue, getCachedTagIndex } from "./shared.js";
+import { displayTagValue, getCachedTagIndex } from "./shared.js";
 
 export function registerListTags(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "list_tags",
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "list_tags",
       title: "List All Tags",
       description:
         "Enumerate every unique tag used across the vault along with the number of notes each tag appears in. Detects tags from both inline #hashtags and YAML frontmatter, normalizes them case-insensitively, and returns a sorted list plus the total unique tag count. Use to build a tag cloud, pick categories, audit taxonomy, or discover available tags before calling search_by_tag.",
@@ -26,56 +27,54 @@ export function registerListTags(server: McpServer, vaultPath: string): void {
           .enum(["count", "name"])
           .optional()
           .default("count")
-          .describe("Sort order: 'count' = by usage count descending (most-used first, default), 'name' = alphabetical by tag name"),
+          .describe(
+            "Sort order: 'count' = by usage count descending (most-used first, default), 'name' = alphabetical by tag name"
+          ),
       },
     },
     async ({ sortBy }) => {
-      try {
-        const notes = await listNotes(vaultPath);
+      const notes = await listNotes(vaultPath);
 
-        // Cached batch read: re-uses content for files whose mtime hasn't
-        // moved since the last vault-wide scan. Per-file failures are
-        // logged and dropped so one unreadable note can't abort the index.
-        const { contents, mtimes } = await readAllCached(vaultPath, notes, (note, err) => {
+      // Cached batch read: re-uses content for files whose mtime hasn't
+      // moved since the last vault-wide scan. Per-file failures are
+      // logged and dropped so one unreadable note can't abort the index.
+      const { contents, mtimes } = await readAllCached(
+        vaultPath,
+        notes,
+        (note, err) => {
           log.warn("list_tags: note read failed", { note, err });
-        });
-
-        const tagIndex = getCachedTagIndex(vaultPath, notes, contents, mtimes);
-        const tagInfos: TagInfo[] = tagIndex.tagInfos.map((info) => ({
-          tag: info.tag,
-          count: info.count,
-          files: [...info.files],
-        }));
-
-        if (sortBy === "name") {
-          tagInfos.sort((a, b) => a.tag.localeCompare(b.tag));
-        } else {
-          tagInfos.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
         }
+      );
 
-        const lines: string[] = [];
-        lines.push(`Total unique tags: ${tagInfos.length}`);
-        lines.push("");
+      const tagIndex = getCachedTagIndex(vaultPath, notes, contents, mtimes);
+      const tagInfos: TagInfo[] = tagIndex.tagInfos.map((info) => ({
+        tag: info.tag,
+        count: info.count,
+        files: [...info.files],
+      }));
 
-        const tagLines: string[] = [];
-        for (const info of tagInfos) {
-          tagLines.push(`#${displayTagValue(info.tag)} (${info.count} ${info.count === 1 ? "note" : "notes"})`);
-        }
-        if (tagLines.length > 0) {
-          lines.push(formatUntrustedVaultContent("list_tags values", tagLines.join("\n")));
-        }
-
-        return {
-          content: [{
-            type: "text" as const,
-            text: lines.join("\n"),
-            ...(tagLines.length > 0 ? { _meta: untrustedVaultContentMeta("list_tags values") } : {}),
-          }],
-        };
-      } catch (err) {
-        log.error("list_tags failed", { tool: "list_tags", err: err as Error });
-        return errorResult(`Error listing tags: ${sanitizeError(err)}`);
+      if (sortBy === "name") {
+        tagInfos.sort((a, b) => a.tag.localeCompare(b.tag));
+      } else {
+        tagInfos.sort(
+          (a, b) => b.count - a.count || a.tag.localeCompare(b.tag)
+        );
       }
-    },
+
+      const tagLines: string[] = [];
+      for (const info of tagInfos) {
+        tagLines.push(
+          `#${displayTagValue(info.tag)} (${info.count} ${info.count === 1 ? "note" : "notes"})`
+        );
+      }
+
+      return richText("list_tags values", (b) => {
+        b.trusted(`Total unique tags: ${tagInfos.length}`);
+        b.trusted("");
+        if (tagLines.length > 0) {
+          b.untrusted("list_tags values", tagLines.join("\n"));
+        }
+      });
+    }
   );
 }

--- a/src/tools/tags/rename_tag.ts
+++ b/src/tools/tags/rename_tag.ts
@@ -1,20 +1,28 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { listNotes, readNote, updateNote, withFileLock, vaultRewriteLockKey } from "../../lib/vault.js";
+import {
+  listNotes,
+  readNote,
+  updateNote,
+  withFileLock,
+  vaultRewriteLockKey,
+} from "../../lib/vault.js";
 import { isValidTagName, rewriteAllTags } from "../../lib/tag-rewriter.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { formatUntrustedFailedPath, untrustedVaultContentMeta } from "../../lib/tool-output.js";
+import { sanitizeError, escapeControlChars } from "../../lib/errors.js";
 import { mapConcurrent } from "../../lib/concurrency.js";
 import { elicitTextConfirmation } from "../../lib/confirmation.js";
 import { makeProgressReporter } from "../../lib/progress.js";
 import { log } from "../../lib/logger.js";
+import { defineTool, richText, text, error } from "../../lib/tool-seam.js";
 
-import { errorResult, displayTagValue } from "./shared.js";
+import { displayTagValue } from "./shared.js";
 
 export function registerRenameTag(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "rename_tag",
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "rename_tag",
       title: "Rename Tag",
       description:
         "Rename a tag everywhere it appears across the vault, in both inline #tags and frontmatter `tags:` fields. Non-dry-run rewrites require `confirmTag` to match the new tag name. With `hierarchical: true` (default), nested tags also rebase: renaming `project` to `client` also renames `project/alpha` → `client/alpha`. With `dryRun: true`, returns the planned counts without writing. Strip the leading `#` from oldName/newName — they're tag names, not tag tokens.",
@@ -29,13 +37,19 @@ export function registerRenameTag(server: McpServer, vaultPath: string): void {
           .string()
           .min(1)
           .max(200)
-          .refine(isValidTagName, "Tag name contains characters Obsidian's tag parser will not recognize")
+          .refine(
+            isValidTagName,
+            "Tag name contains characters Obsidian's tag parser will not recognize"
+          )
           .describe("Existing tag name (without leading #), e.g. 'project'."),
         newName: z
           .string()
           .min(1)
           .max(200)
-          .refine(isValidTagName, "Tag name contains characters Obsidian's tag parser will not recognize")
+          .refine(
+            isValidTagName,
+            "Tag name contains characters Obsidian's tag parser will not recognize"
+          )
           .describe("New tag name (without leading #), e.g. 'client'."),
         hierarchical: z
           .boolean()
@@ -51,147 +65,146 @@ export function registerRenameTag(server: McpServer, vaultPath: string): void {
           .string()
           .max(200)
           .optional()
-          .describe("Required when dryRun is false: re-type the new tag name to confirm vault-wide tag rewriting."),
+          .describe(
+            "Required when dryRun is false: re-type the new tag name to confirm vault-wide tag rewriting."
+          ),
       },
     },
-    async ({ oldName, newName, hierarchical, dryRun, confirmTag }, extra) => {
-      try {
-        if (oldName === newName) return errorResult("oldName and newName must differ");
-        if (!dryRun) {
-          if (confirmTag?.trim() !== newName) {
-            return errorResult(
-              `Vault-wide tag rewriting to #${displayTagValue(newName)} requires confirmTag="${displayTagValue(newName)}". ` +
-              "Set dryRun=true to preview without writing.",
-            );
-          }
-          const confirmation = await elicitTextConfirmation(server, {
-            tool: "rename_tag",
-            message:
-              `Rename #${displayTagValue(oldName)} to #${displayTagValue(newName)} across the vault? ` +
-              "This can rewrite many notes. Type the new tag name to confirm.",
-            fieldName: "confirmTag",
-            fieldDescription: "Re-type the new tag name to confirm vault-wide tag rewriting.",
-            expectedValue: newName,
-          });
-          if (confirmation.status === "cancelled") {
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: `Rename of #${displayTagValue(oldName)} to #${displayTagValue(newName)} cancelled.`,
-                },
-              ],
-            };
-          }
-          if (confirmation.status === "mismatch") {
-            return errorResult(
-              `Confirmation tag did not match #${displayTagValue(newName)}; rename aborted.`,
-            );
-          }
-        }
-        const notes = await listNotes(vaultPath);
-        const opts = { oldName, newName, hierarchical };
-        const reportProgress = makeProgressReporter(extra);
-
-        let updatedFiles = 0;
-        let totalInline = 0;
-        let totalFrontmatter = 0;
-        let processed = 0;
-        const failed: Array<{ path: string; error: string }> = [];
-
-        const runScan = async (): Promise<void> => {
-          await mapConcurrent(
-            notes,
-            8,
-            async (notePath) => {
-              try {
-                if (dryRun) {
-                  // No write path — a single read outside any lock is fine
-                  // because we only report counts.
-                  const original = await readNote(vaultPath, notePath);
-                  const result = rewriteAllTags(original, opts);
-                  if (result.inlineCount + result.frontmatterCount > 0) {
-                    updatedFiles++;
-                    totalInline += result.inlineCount;
-                    totalFrontmatter += result.frontmatterCount;
-                  }
-                } else {
-                  // Apply the rewrite inside the per-file lock so a concurrent
-                  // write between read and write can't be silently overwritten.
-                  // `updateNote` re-reads under the lock and feeds `existing`
-                  // into our transform, then atomically renames the result.
-                  let inline = 0;
-                  let frontmatter = 0;
-                  let changed = false;
-                  await updateNote(vaultPath, notePath, (existing) => {
-                    const result = rewriteAllTags(existing, opts);
-                    inline = result.inlineCount;
-                    frontmatter = result.frontmatterCount;
-                    if (inline + frontmatter === 0) return existing;
-                    changed = result.content !== existing;
-                    return result.content;
-                  });
-                  if (inline + frontmatter > 0 && changed) {
-                    updatedFiles++;
-                    totalInline += inline;
-                    totalFrontmatter += frontmatter;
-                  }
-                }
-              } catch (err) {
-                failed.push({ path: notePath, error: (err as Error).message });
-              }
-              processed++;
-              await reportProgress(processed, notes.length, `Scanned ${processed}/${notes.length} notes`);
-              return undefined;
-            },
-            (err, notePath) => {
-              log.warn("rename_tag: note read failed", { note: notePath, err: err as Error });
-            },
+    async (
+      { oldName, newName, hierarchical, dryRun, confirmTag },
+      { extra }
+    ) => {
+      if (oldName === newName) return error("oldName and newName must differ");
+      if (!dryRun) {
+        if (confirmTag?.trim() !== newName) {
+          return error(
+            `Vault-wide tag rewriting to #${displayTagValue(newName)} requires confirmTag="${displayTagValue(newName)}". ` +
+              "Set dryRun=true to preview without writing."
           );
-        };
-
-        // Serialize the bulk-write phase under the same vault-level lock
-        // that move_note / delete_note (with removeReferences) take. Without
-        // this, an in-flight rename_tag could shift bytes mid-plan in a
-        // concurrent move_note, surfacing as "content changed during move"
-        // failures with stale links left behind. Dry-run skips the lock —
-        // it doesn't write — and so can't conflict.
-        if (!dryRun) {
-          await withFileLock(vaultRewriteLockKey(vaultPath), runScan);
-        } else {
-          await runScan();
         }
-
-        const verb = dryRun ? "Would rewrite" : "Rewrote";
-        const lines = [
-          `${verb} #${displayTagValue(oldName)} → #${displayTagValue(newName)}${hierarchical ? " (and nested sub-tags)" : ""}`,
-          `  Files affected: ${updatedFiles}`,
-          `  Inline #tag occurrences: ${totalInline}`,
-          `  Frontmatter occurrences: ${totalFrontmatter}`,
-        ];
-        if (failed.length > 0) {
-          lines.push(`  Skipped due to errors: ${failed.length}`);
-          for (const f of failed.slice(0, 5)) {
-            lines.push(formatUntrustedFailedPath(
-              "rename_tag failed note",
-              f.path,
-              f.error,
-              "    ",
-            ));
-          }
-          if (failed.length > 5) lines.push(`    ...and ${failed.length - 5} more`);
+        const confirmation = await elicitTextConfirmation(server, {
+          tool: "rename_tag",
+          message:
+            `Rename #${displayTagValue(oldName)} to #${displayTagValue(newName)} across the vault? ` +
+            "This can rewrite many notes. Type the new tag name to confirm.",
+          fieldName: "confirmTag",
+          fieldDescription:
+            "Re-type the new tag name to confirm vault-wide tag rewriting.",
+          expectedValue: newName,
+        });
+        if (confirmation.status === "cancelled") {
+          return text(
+            `Rename of #${displayTagValue(oldName)} to #${displayTagValue(newName)} cancelled.`
+          );
         }
-        return {
-          content: [{
-            type: "text" as const,
-            text: lines.join("\n"),
-            ...(failed.length > 0 ? { _meta: untrustedVaultContentMeta("rename_tag failed notes") } : {}),
-          }],
-        };
-      } catch (err) {
-        log.error("rename_tag failed", { tool: "rename_tag", err: err as Error });
-        return errorResult(`Error renaming tag: ${sanitizeError(err)}`);
+        if (confirmation.status === "mismatch") {
+          return error(
+            `Confirmation tag did not match #${displayTagValue(newName)}; rename aborted.`
+          );
+        }
       }
-    },
+      const notes = await listNotes(vaultPath);
+      const opts = { oldName, newName, hierarchical };
+      const reportProgress = makeProgressReporter(extra);
+
+      let updatedFiles = 0;
+      let totalInline = 0;
+      let totalFrontmatter = 0;
+      let processed = 0;
+      const failed: Array<{ path: string; error: string }> = [];
+
+      const runScan = async (): Promise<void> => {
+        await mapConcurrent(
+          notes,
+          8,
+          async (notePath) => {
+            try {
+              if (dryRun) {
+                // No write path — a single read outside any lock is fine
+                // because we only report counts.
+                const original = await readNote(vaultPath, notePath);
+                const result = rewriteAllTags(original, opts);
+                if (result.inlineCount + result.frontmatterCount > 0) {
+                  updatedFiles++;
+                  totalInline += result.inlineCount;
+                  totalFrontmatter += result.frontmatterCount;
+                }
+              } else {
+                // Apply the rewrite inside the per-file lock so a concurrent
+                // write between read and write can't be silently overwritten.
+                // `updateNote` re-reads under the lock and feeds `existing`
+                // into our transform, then atomically renames the result.
+                let inline = 0;
+                let frontmatter = 0;
+                let changed = false;
+                await updateNote(vaultPath, notePath, (existing) => {
+                  const result = rewriteAllTags(existing, opts);
+                  inline = result.inlineCount;
+                  frontmatter = result.frontmatterCount;
+                  if (inline + frontmatter === 0) return existing;
+                  changed = result.content !== existing;
+                  return result.content;
+                });
+                if (inline + frontmatter > 0 && changed) {
+                  updatedFiles++;
+                  totalInline += inline;
+                  totalFrontmatter += frontmatter;
+                }
+              }
+            } catch (err) {
+              failed.push({ path: notePath, error: (err as Error).message });
+            }
+            processed++;
+            await reportProgress(
+              processed,
+              notes.length,
+              `Scanned ${processed}/${notes.length} notes`
+            );
+            return undefined;
+          },
+          (err, notePath) => {
+            log.warn("rename_tag: note read failed", {
+              note: notePath,
+              err: err as Error,
+            });
+          }
+        );
+      };
+
+      // Serialize the bulk-write phase under the same vault-level lock
+      // that move_note / delete_note (with removeReferences) take. Without
+      // this, an in-flight rename_tag could shift bytes mid-plan in a
+      // concurrent move_note, surfacing as "content changed during move"
+      // failures with stale links left behind. Dry-run skips the lock —
+      // it doesn't write — and so can't conflict.
+      if (!dryRun) {
+        await withFileLock(vaultRewriteLockKey(vaultPath), runScan);
+      } else {
+        await runScan();
+      }
+
+      const verb = dryRun ? "Would rewrite" : "Rewrote";
+
+      return richText("rename_tag failed notes", (b) => {
+        b.trusted(
+          `${verb} #${displayTagValue(oldName)} → #${displayTagValue(newName)}${hierarchical ? " (and nested sub-tags)" : ""}`
+        );
+        b.trusted(`  Files affected: ${updatedFiles}`);
+        b.trusted(`  Inline #tag occurrences: ${totalInline}`);
+        b.trusted(`  Frontmatter occurrences: ${totalFrontmatter}`);
+        if (failed.length > 0) {
+          b.trusted(`  Skipped due to errors: ${failed.length}`);
+          for (const f of failed.slice(0, 5)) {
+            b.untrusted(
+              "rename_tag failed note",
+              `- ${escapeControlChars(f.path)}: ${sanitizeError(f.error)}`,
+              "    "
+            );
+          }
+          if (failed.length > 5)
+            b.trusted(`    ...and ${failed.length - 5} more`);
+        }
+      });
+    }
   );
 }

--- a/src/tools/tags/search_by_tag.ts
+++ b/src/tools/tags/search_by_tag.ts
@@ -2,16 +2,20 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { listNotes } from "../../lib/vault.js";
 import { readAllCached } from "../../lib/index-cache.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { formatUntrustedVaultContent, indentBlock, untrustedVaultContentMeta } from "../../lib/tool-output.js";
 import { log } from "../../lib/logger.js";
+import { defineTool, richText, text } from "../../lib/tool-seam.js";
 
-import { errorResult, displayTagValue, getCachedTagIndex, untrustedTagBlock } from "./shared.js";
+import { displayTagValue, getCachedTagIndex } from "./shared.js";
 
-export function registerSearchByTag(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "search_by_tag",
+export function registerSearchByTag(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "search_by_tag",
       title: "Search by Tag",
       description:
         "Find all notes tagged with a specific tag, including nested sub-tags (searching 'project' matches both #project and #project/alpha). Detects tags from both inline #hashtags and YAML frontmatter. Returns matching note paths with optional content previews. Use to collect notes belonging to a topic, area, or workflow stage.",
@@ -25,12 +29,16 @@ export function registerSearchByTag(server: McpServer, vaultPath: string): void 
           .string()
           .min(1)
           .max(200)
-          .describe("Tag to search for, with or without # prefix (e.g., 'project' or '#project'). Matches nested tags like 'project/alpha'."),
+          .describe(
+            "Tag to search for, with or without # prefix (e.g., 'project' or '#project'). Matches nested tags like 'project/alpha'."
+          ),
         includeContent: z
           .boolean()
           .optional()
           .default(false)
-          .describe("If true, include the first 200 characters of each matching note as a preview (default: false)"),
+          .describe(
+            "If true, include the first 200 characters of each matching note as a preview (default: false)"
+          ),
         maxResults: z
           .number()
           .int()
@@ -38,29 +46,41 @@ export function registerSearchByTag(server: McpServer, vaultPath: string): void 
           .max(1000)
           .optional()
           .default(100)
-          .describe("Maximum number of matching notes to return (1-1000, default: 100)"),
+          .describe(
+            "Maximum number of matching notes to return (1-1000, default: 100)"
+          ),
       },
     },
     async ({ tag, includeContent, maxResults }) => {
-      try {
-        const searchTag = tag.replace(/^#/, "").toLowerCase();
-        const notes = await listNotes(vaultPath);
+      const searchTag = tag.replace(/^#/, "").toLowerCase();
+      const notes = await listNotes(vaultPath);
 
-        const { contents, mtimes } = await readAllCached(vaultPath, notes, (note, err) => {
+      const { contents, mtimes } = await readAllCached(
+        vaultPath,
+        notes,
+        (note, err) => {
           log.warn("search_by_tag: note read failed", { note, err });
-        });
-
-        const tagIndex = getCachedTagIndex(vaultPath, notes, contents, mtimes);
-        const matchingPathSet = new Set<string>();
-        for (const [normalizedTag, files] of tagIndex.tagToFiles) {
-          if (normalizedTag === searchTag || normalizedTag.startsWith(`${searchTag}/`)) {
-            for (const file of files) matchingPathSet.add(file);
-          }
         }
-        const matchingPaths = [...matchingPathSet]
-          .sort((a, b) => (tagIndex.noteOrder.get(a) ?? 0) - (tagIndex.noteOrder.get(b) ?? 0))
-          .slice(0, maxResults);
-        const matchingNotes: { path: string; preview?: string }[] = matchingPaths.map((notePath) => {
+      );
+
+      const tagIndex = getCachedTagIndex(vaultPath, notes, contents, mtimes);
+      const matchingPathSet = new Set<string>();
+      for (const [normalizedTag, files] of tagIndex.tagToFiles) {
+        if (
+          normalizedTag === searchTag ||
+          normalizedTag.startsWith(`${searchTag}/`)
+        ) {
+          for (const file of files) matchingPathSet.add(file);
+        }
+      }
+      const matchingPaths = [...matchingPathSet]
+        .sort(
+          (a, b) =>
+            (tagIndex.noteOrder.get(a) ?? 0) - (tagIndex.noteOrder.get(b) ?? 0)
+        )
+        .slice(0, maxResults);
+      const matchingNotes: { path: string; preview?: string }[] =
+        matchingPaths.map((notePath) => {
           const entry: { path: string; preview?: string } = { path: notePath };
           if (includeContent) {
             const content = contents.get(notePath)!;
@@ -70,50 +90,39 @@ export function registerSearchByTag(server: McpServer, vaultPath: string): void 
           return entry;
         });
 
-        if (matchingNotes.length === 0) {
-          return {
-            content: [
-              { type: "text" as const, text: `No notes found with tag #${displayTagValue(searchTag)}` },
-            ],
-          };
-        }
+      if (matchingNotes.length === 0) {
+        return text(`No notes found with tag #${displayTagValue(searchTag)}`);
+      }
 
-        const lines: string[] = [];
-        lines.push(
-          `Found ${matchingNotes.length} ${matchingNotes.length === 1 ? "note" : "notes"} with tag #${displayTagValue(searchTag)}`,
-        );
-        lines.push("");
+      return richText(
+        includeContent
+          ? "search_by_tag paths and previews"
+          : "search_by_tag paths",
+        (b) => {
+          b.trusted(
+            `Found ${matchingNotes.length} ${matchingNotes.length === 1 ? "note" : "notes"} with tag #${displayTagValue(searchTag)}`
+          );
+          b.trusted("");
 
-        for (const note of matchingNotes) {
-          lines.push("Path:");
-          lines.push(untrustedTagBlock(
-            "search_by_tag result path",
-            displayTagValue(note.path),
-            "  ",
-          ));
-          if (note.preview) {
-            lines.push("  Preview:");
-            lines.push(indentBlock(
-              formatUntrustedVaultContent("search_by_tag preview", displayTagValue(note.preview)),
-              "    ",
-            ));
-            lines.push("");
+          for (const note of matchingNotes) {
+            b.trusted("Path:");
+            b.untrusted(
+              "search_by_tag result path",
+              displayTagValue(note.path),
+              "  "
+            );
+            if (note.preview) {
+              b.trusted("  Preview:");
+              b.untrusted(
+                "search_by_tag preview",
+                displayTagValue(note.preview),
+                "    "
+              );
+              b.trusted("");
+            }
           }
         }
-
-        return {
-          content: [{
-            type: "text" as const,
-            text: lines.join("\n"),
-            _meta: untrustedVaultContentMeta(
-              includeContent ? "search_by_tag paths and previews" : "search_by_tag paths",
-            ),
-          }],
-        };
-      } catch (err) {
-        log.error("search_by_tag failed", { tool: "search_by_tag", err: err as Error });
-        return errorResult(`Error searching by tag: ${sanitizeError(err)}`);
-      }
-    },
+      );
+    }
   );
 }

--- a/src/tools/tags/shared.ts
+++ b/src/tools/tags/shared.ts
@@ -1,5 +1,4 @@
 import { escapeControlChars } from "../../lib/errors.js";
-import { formatUntrustedVaultContent, indentBlock } from "../../lib/tool-output.js";
 import { extractTags } from "../../lib/markdown.js";
 
 import type { TagInfo } from "../../types.js";
@@ -20,22 +19,14 @@ export interface TagIndexCacheEntry {
 
 export const tagIndexCache = new Map<string, TagIndexCacheEntry>();
 
-export function errorResult(text: string) {
-  return { content: [{ type: "text" as const, text }], isError: true as const };
-}
-
 export function displayTagValue(value: string): string {
   return escapeControlChars(value);
-}
-
-export function untrustedTagBlock(label: string, text: string, indent = ""): string {
-  return indentBlock(formatUntrustedVaultContent(label, text), indent);
 }
 
 export function tagIndexFingerprint(
   notes: readonly string[],
   contents: ReadonlyMap<string, string>,
-  mtimes: ReadonlyMap<string, number>,
+  mtimes: ReadonlyMap<string, number>
 ): string {
   return notes
     .map((notePath) => {
@@ -49,7 +40,7 @@ export function getCachedTagIndex(
   vaultPath: string,
   notes: readonly string[],
   contents: ReadonlyMap<string, string>,
-  mtimes: ReadonlyMap<string, number>,
+  mtimes: ReadonlyMap<string, number>
 ): TagIndexCacheEntry {
   const fingerprint = tagIndexFingerprint(notes, contents, mtimes);
   const cached = tagIndexCache.get(vaultPath);
@@ -82,11 +73,13 @@ export function getCachedTagIndex(
     }
   }
 
-  const tagInfos: TagInfo[] = Array.from(tagMap.values()).map(({ tag, files }) => ({
-    tag,
-    count: files.size,
-    files: [...files],
-  }));
+  const tagInfos: TagInfo[] = Array.from(tagMap.values()).map(
+    ({ tag, files }) => ({
+      tag,
+      count: files.size,
+      files: [...files],
+    })
+  );
   const tagToFiles = new Map<string, string[]>();
   for (const info of tagInfos) tagToFiles.set(info.tag, info.files);
 


### PR DESCRIPTION
Migrates the tags group (3 tools) through the tool seam. Part of Wave-1 (map #245). Byte-identical output (independent dump-diff was zero); adds block-level `untrustedContentLabel` assertions to tags.test.ts. Verified combined-green (979 tests). Closes #247.