### PR TITLE
refactor(tools): migrate sections group through the tool seam

### DIFF
--- a/src/tools/sections/edit_block.ts
+++ b/src/tools/sections/edit_block.ts
@@ -1,26 +1,26 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import {
-  updateNote,
-} from "../../lib/vault.js";
-import {
-  findBlockById,
-} from "../../lib/sections.js";
+import { updateNote } from "../../lib/vault.js";
+import { findBlockById } from "../../lib/sections.js";
 import { sanitizeError } from "../../lib/errors.js";
 import { log } from "../../lib/logger.js";
+import { defineTool, text, error } from "../../lib/tool-seam.js";
 import {
   SECTION_EDIT_PAYLOAD_MAX_CHARS,
-  textResult,
-  errorResult,
   displaySectionValue,
   assertReadableEditTarget,
   invalidateSectionListCache,
 } from "./shared.js";
 
-export function registerEditBlockTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "edit_block",
+export function registerEditBlockTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "edit_block",
       title: "Edit Block",
       description:
         "Replace the content of a block tagged with `^id`. The trailing `^id` anchor is preserved on the last line of the new content so existing transclusions (`![[note#^id]]`) keep working. Use to update a single paragraph or list item that other notes reference.",
@@ -36,12 +36,18 @@ export function registerEditBlockTool(server: McpServer, vaultPath: string): voi
           .string()
           .min(1)
           .transform((s) => s.replace(/^\^+/, ""))
-          .refine((s) => s.length > 0, { message: "block id must not be empty after stripping leading '^'" })
-          .describe("Block id with or without the leading `^` (e.g. `myid` or `^myid`)."),
+          .refine((s) => s.length > 0, {
+            message: "block id must not be empty after stripping leading '^'",
+          })
+          .describe(
+            "Block id with or without the leading `^` (e.g. `myid` or `^myid`)."
+          ),
         newContent: z
           .string()
           .max(SECTION_EDIT_PAYLOAD_MAX_CHARS)
-          .describe("Replacement content. The `^id` anchor is appended automatically."),
+          .describe(
+            "Replacement content. The `^id` anchor is appended automatically."
+          ),
       },
     },
     async ({ path: notePath, block, newContent }) => {
@@ -54,15 +60,22 @@ export function registerEditBlockTool(server: McpServer, vaultPath: string): voi
           const after = existing.slice(found.end);
           const body = newContent.replace(/\n+$/, "");
           const isMultiline = body.includes("\n");
-          const replacement = isMultiline ? `${body}\n^${block}\n` : `${body} ^${block}\n`;
+          const replacement = isMultiline
+            ? `${body}\n^${block}\n`
+            : `${body} ^${block}\n`;
           return before + replacement + after;
         });
         invalidateSectionListCache(vaultPath, notePath);
-        return textResult(`Updated block ^${displaySectionValue(block)} in ${displaySectionValue(notePath)}`);
+        return text(
+          `Updated block ^${displaySectionValue(block)} in ${displaySectionValue(notePath)}`
+        );
       } catch (err) {
-        log.error("edit_block failed", { tool: "edit_block", err: err as Error });
-        return errorResult(`Error editing block: ${sanitizeError(err)}`);
+        log.error("edit_block failed", {
+          tool: "edit_block",
+          err: err as Error,
+        });
+        return error(`Error editing block: ${sanitizeError(err)}`);
       }
-    },
+    }
   );
 }

--- a/src/tools/sections/edit_block.ts
+++ b/src/tools/sections/edit_block.ts
@@ -2,9 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { updateNote } from "../../lib/vault.js";
 import { findBlockById } from "../../lib/sections.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
-import { defineTool, text, error } from "../../lib/tool-seam.js";
+import { defineTool, text } from "../../lib/tool-seam.js";
 import {
   SECTION_EDIT_PAYLOAD_MAX_CHARS,
   displaySectionValue,
@@ -51,31 +49,23 @@ export function registerEditBlockTool(
       },
     },
     async ({ path: notePath, block, newContent }) => {
-      try {
-        await assertReadableEditTarget(vaultPath, notePath);
-        await updateNote(vaultPath, notePath, (existing) => {
-          const found = findBlockById(existing, block);
-          if (!found) throw new Error(`Block not found: "^${block}"`);
-          const before = existing.slice(0, found.start);
-          const after = existing.slice(found.end);
-          const body = newContent.replace(/\n+$/, "");
-          const isMultiline = body.includes("\n");
-          const replacement = isMultiline
-            ? `${body}\n^${block}\n`
-            : `${body} ^${block}\n`;
-          return before + replacement + after;
-        });
-        invalidateSectionListCache(vaultPath, notePath);
-        return text(
-          `Updated block ^${displaySectionValue(block)} in ${displaySectionValue(notePath)}`
-        );
-      } catch (err) {
-        log.error("edit_block failed", {
-          tool: "edit_block",
-          err: err as Error,
-        });
-        return error(`Error editing block: ${sanitizeError(err)}`);
-      }
+      await assertReadableEditTarget(vaultPath, notePath);
+      await updateNote(vaultPath, notePath, (existing) => {
+        const found = findBlockById(existing, block);
+        if (!found) throw new Error(`Block not found: "^${block}"`);
+        const before = existing.slice(0, found.start);
+        const after = existing.slice(found.end);
+        const body = newContent.replace(/\n+$/, "");
+        const isMultiline = body.includes("\n");
+        const replacement = isMultiline
+          ? `${body}\n^${block}\n`
+          : `${body} ^${block}\n`;
+        return before + replacement + after;
+      });
+      invalidateSectionListCache(vaultPath, notePath);
+      return text(
+        `Updated block ^${displaySectionValue(block)} in ${displaySectionValue(notePath)}`
+      );
     }
   );
 }

--- a/src/tools/sections/insert_at_section.ts
+++ b/src/tools/sections/insert_at_section.ts
@@ -2,8 +2,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { updateNote } from "../../lib/vault.js";
 import { findSection, insertAfterHeading } from "../../lib/sections.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
 import { defineTool, richText, error } from "../../lib/tool-seam.js";
 import {
   SECTION_EDIT_PAYLOAD_MAX_CHARS,
@@ -51,52 +49,44 @@ export function registerInsertAtSectionTool(
       },
     },
     async ({ path: notePath, section, content, position }) => {
-      try {
-        const headingPath = splitHeadingPath(section);
-        if (headingPath.length === 0) return error("section must not be empty");
+      const headingPath = splitHeadingPath(section);
+      if (headingPath.length === 0) return error("section must not be empty");
 
-        let resolvedHeading = "";
-        await assertReadableEditTarget(vaultPath, notePath);
-        await updateNote(vaultPath, notePath, (existing) => {
-          const found = findSection(existing, headingPath);
-          if (!found) {
-            throw new Error(`Section not found: "${section}"`);
-          }
-          resolvedHeading = found.heading.text;
-          if (position === "after-heading") {
-            return insertAfterHeading(existing, found, content);
-          }
-          if (position === "before") {
-            const before = existing.slice(0, found.start);
-            const after = existing.slice(found.start);
-            const trailing = content.endsWith("\n") ? "" : "\n";
-            return before + content + trailing + after;
-          }
-          const before = existing.slice(0, found.end);
-          const after = existing.slice(found.end);
-          let payload = content;
-          if (!before.endsWith("\n")) payload = "\n" + payload;
-          if (!payload.endsWith("\n")) payload += "\n";
-          return before + payload + after;
-        });
-        invalidateSectionListCache(vaultPath, notePath);
-        return richText("insert_at_section resolved heading", (b) => {
-          b.trusted(
-            `Inserted ${Buffer.byteLength(content, "utf-8")} bytes (${position}) in ${displaySectionValue(notePath)}`
-          );
-          richResolvedHeading(
-            b,
-            "insert_at_section resolved heading",
-            resolvedHeading
-          );
-        });
-      } catch (err) {
-        log.error("insert_at_section failed", {
-          tool: "insert_at_section",
-          err: err as Error,
-        });
-        return error(`Error inserting at section: ${sanitizeError(err)}`);
-      }
+      let resolvedHeading = "";
+      await assertReadableEditTarget(vaultPath, notePath);
+      await updateNote(vaultPath, notePath, (existing) => {
+        const found = findSection(existing, headingPath);
+        if (!found) {
+          throw new Error(`Section not found: "${section}"`);
+        }
+        resolvedHeading = found.heading.text;
+        if (position === "after-heading") {
+          return insertAfterHeading(existing, found, content);
+        }
+        if (position === "before") {
+          const before = existing.slice(0, found.start);
+          const after = existing.slice(found.start);
+          const trailing = content.endsWith("\n") ? "" : "\n";
+          return before + content + trailing + after;
+        }
+        const before = existing.slice(0, found.end);
+        const after = existing.slice(found.end);
+        let payload = content;
+        if (!before.endsWith("\n")) payload = "\n" + payload;
+        if (!payload.endsWith("\n")) payload += "\n";
+        return before + payload + after;
+      });
+      invalidateSectionListCache(vaultPath, notePath);
+      return richText("insert_at_section resolved heading", (b) => {
+        b.trusted(
+          `Inserted ${Buffer.byteLength(content, "utf-8")} bytes (${position}) in ${displaySectionValue(notePath)}`
+        );
+        richResolvedHeading(
+          b,
+          "insert_at_section resolved heading",
+          resolvedHeading
+        );
+      });
     }
   );
 }

--- a/src/tools/sections/insert_at_section.ts
+++ b/src/tools/sections/insert_at_section.ts
@@ -1,29 +1,28 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import {
-  updateNote,
-} from "../../lib/vault.js";
-import {
-  findSection,
-  insertAfterHeading,
-} from "../../lib/sections.js";
+import { updateNote } from "../../lib/vault.js";
+import { findSection, insertAfterHeading } from "../../lib/sections.js";
 import { sanitizeError } from "../../lib/errors.js";
 import { log } from "../../lib/logger.js";
+import { defineTool, richText, error } from "../../lib/tool-seam.js";
 import {
   SECTION_EDIT_PAYLOAD_MAX_CHARS,
-  textResultWithMeta,
-  errorResult,
   displaySectionValue,
-  renderResolvedHeading,
+  richResolvedHeading,
   assertReadableEditTarget,
   invalidateSectionListCache,
   splitHeadingPath,
 } from "./shared.js";
 
-export function registerInsertAtSectionTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "insert_at_section",
+export function registerInsertAtSectionTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "insert_at_section",
       title: "Insert at Section",
       description:
         "Insert content into a specific section without replacing it. `position` controls where: 'before' inserts above the heading, 'after-heading' inserts immediately under the heading line (at the top of the section body), 'append' inserts at the end of the section's body just before the next heading. Use to add a new bullet or paragraph without rewriting the section.",
@@ -35,7 +34,10 @@ export function registerInsertAtSectionTool(server: McpServer, vaultPath: string
       },
       inputSchema: {
         path: z.string().min(1).describe("Vault-relative path to the note."),
-        section: z.string().min(1).describe("Heading path identifying the section."),
+        section: z
+          .string()
+          .min(1)
+          .describe("Heading path identifying the section."),
         content: z
           .string()
           .max(SECTION_EDIT_PAYLOAD_MAX_CHARS)
@@ -43,13 +45,15 @@ export function registerInsertAtSectionTool(server: McpServer, vaultPath: string
         position: z
           .enum(["before", "after-heading", "append"])
           .default("append")
-          .describe("Insert before the heading line, immediately after the heading, or at the end of the section body."),
+          .describe(
+            "Insert before the heading line, immediately after the heading, or at the end of the section body."
+          ),
       },
     },
     async ({ path: notePath, section, content, position }) => {
       try {
         const headingPath = splitHeadingPath(section);
-        if (headingPath.length === 0) return errorResult("section must not be empty");
+        if (headingPath.length === 0) return error("section must not be empty");
 
         let resolvedHeading = "";
         await assertReadableEditTarget(vaultPath, notePath);
@@ -76,17 +80,23 @@ export function registerInsertAtSectionTool(server: McpServer, vaultPath: string
           return before + payload + after;
         });
         invalidateSectionListCache(vaultPath, notePath);
-        return textResultWithMeta(
-          [
-            `Inserted ${Buffer.byteLength(content, "utf-8")} bytes (${position}) in ${displaySectionValue(notePath)}`,
-            renderResolvedHeading("insert_at_section resolved heading", resolvedHeading),
-          ].join("\n"),
-          "insert_at_section resolved heading",
-        );
+        return richText("insert_at_section resolved heading", (b) => {
+          b.trusted(
+            `Inserted ${Buffer.byteLength(content, "utf-8")} bytes (${position}) in ${displaySectionValue(notePath)}`
+          );
+          richResolvedHeading(
+            b,
+            "insert_at_section resolved heading",
+            resolvedHeading
+          );
+        });
       } catch (err) {
-        log.error("insert_at_section failed", { tool: "insert_at_section", err: err as Error });
-        return errorResult(`Error inserting at section: ${sanitizeError(err)}`);
+        log.error("insert_at_section failed", {
+          tool: "insert_at_section",
+          err: err as Error,
+        });
+        return error(`Error inserting at section: ${sanitizeError(err)}`);
       }
-    },
+    }
   );
 }

--- a/src/tools/sections/list_sections.ts
+++ b/src/tools/sections/list_sections.ts
@@ -1,8 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
-import { defineTool, untrustedText, error } from "../../lib/tool-seam.js";
+import { defineTool, untrustedText } from "../../lib/tool-seam.js";
 import { readSectionListCached } from "./shared.js";
 
 export function registerListSectionsTool(
@@ -27,18 +25,10 @@ export function registerListSectionsTool(
       },
     },
     async ({ path: notePath }) => {
-      try {
-        return untrustedText(
-          "list_sections headings",
-          await readSectionListCached(vaultPath, notePath)
-        );
-      } catch (err) {
-        log.error("list_sections failed", {
-          tool: "list_sections",
-          err: err as Error,
-        });
-        return error(`Error listing sections: ${sanitizeError(err)}`);
-      }
+      return untrustedText(
+        "list_sections headings",
+        await readSectionListCached(vaultPath, notePath)
+      );
     }
   );
 }

--- a/src/tools/sections/list_sections.ts
+++ b/src/tools/sections/list_sections.ts
@@ -1,17 +1,19 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { untrustedTextContent } from "../../lib/tool-output.js";
 import { sanitizeError } from "../../lib/errors.js";
 import { log } from "../../lib/logger.js";
-import {
-  errorResult,
-  readSectionListCached,
-} from "./shared.js";
+import { defineTool, untrustedText, error } from "../../lib/tool-seam.js";
+import { readSectionListCached } from "./shared.js";
 
-export function registerListSectionsTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "list_sections",
+export function registerListSectionsTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "list_sections",
       title: "List Sections",
       description:
         "List all headings in a note as a tree of paths (with depth). Useful for discovering valid `section` arguments before calling get_note, update_section, or insert_at_section.",
@@ -26,16 +28,17 @@ export function registerListSectionsTool(server: McpServer, vaultPath: string): 
     },
     async ({ path: notePath }) => {
       try {
-        return {
-          content: [untrustedTextContent(
-            "list_sections headings",
-            await readSectionListCached(vaultPath, notePath),
-          )],
-        };
+        return untrustedText(
+          "list_sections headings",
+          await readSectionListCached(vaultPath, notePath)
+        );
       } catch (err) {
-        log.error("list_sections failed", { tool: "list_sections", err: err as Error });
-        return errorResult(`Error listing sections: ${sanitizeError(err)}`);
+        log.error("list_sections failed", {
+          tool: "list_sections",
+          err: err as Error,
+        });
+        return error(`Error listing sections: ${sanitizeError(err)}`);
       }
-    },
+    }
   );
 }

--- a/src/tools/sections/replace_in_note.ts
+++ b/src/tools/sections/replace_in_note.ts
@@ -1,26 +1,28 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import {
-  updateNote,
-} from "../../lib/vault.js";
+import { updateNote } from "../../lib/vault.js";
 import { sanitizeError } from "../../lib/errors.js";
 import { log } from "../../lib/logger.js";
+import { defineTool, text, error } from "../../lib/tool-seam.js";
 import {
   FIND_MAX_LEN,
   SECTION_EDIT_PAYLOAD_MAX_CHARS,
   NOTE_INPUT_MAX_LEN,
-  textResult,
-  errorResult,
   displaySectionValue,
   assertReadableEditTarget,
   invalidateSectionListCache,
   hasUnsafeRepeatedGroup,
 } from "./shared.js";
 
-export function registerReplaceInNoteTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "replace_in_note",
+export function registerReplaceInNoteTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "replace_in_note",
       title: "Replace in Note",
       description:
         "Search-and-replace within a single note. Supports literal strings or regex patterns. With `expectedCount`, the operation refuses to commit unless that many matches are present, guarding against accidental over-replacement when an LLM drafts a pattern that's too broad. Returns the count of replacements made.",
@@ -40,10 +42,29 @@ export function registerReplaceInNoteTool(server: McpServer, vaultPath: string):
         replace: z
           .string()
           .max(SECTION_EDIT_PAYLOAD_MAX_CHARS)
-          .describe("Replacement text. With `regex: true`, supports $1, $2 backreferences."),
-        regex: z.boolean().default(false).describe("Treat `find` as a JavaScript regex (multi-line, case-sensitive by default)."),
-        flags: z.string().optional().describe("Regex flags (e.g., 'gi'). Defaults to 'g' so all matches are replaced."),
-        expectedCount: z.number().int().min(0).optional().describe("If set, abort unless exactly this many matches are found."),
+          .describe(
+            "Replacement text. With `regex: true`, supports $1, $2 backreferences."
+          ),
+        regex: z
+          .boolean()
+          .default(false)
+          .describe(
+            "Treat `find` as a JavaScript regex (multi-line, case-sensitive by default)."
+          ),
+        flags: z
+          .string()
+          .optional()
+          .describe(
+            "Regex flags (e.g., 'gi'). Defaults to 'g' so all matches are replaced."
+          ),
+        expectedCount: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "If set, abort unless exactly this many matches are found."
+          ),
       },
     },
     async ({ path: notePath, find, replace, regex, flags, expectedCount }) => {
@@ -54,36 +75,36 @@ export function registerReplaceInNoteTool(server: McpServer, vaultPath: string):
         let unsafeRegexPattern = false;
         if (regex) {
           if (find.length > FIND_MAX_LEN) {
-            return errorResult(
-              `Error replacing in note: find pattern too long (${find.length} > ${FIND_MAX_LEN} chars). Use a more targeted pattern.`,
+            return error(
+              `Error replacing in note: find pattern too long (${find.length} > ${FIND_MAX_LEN} chars). Use a more targeted pattern.`
             );
           }
           const f = flags ?? "g";
           const seen = new Set<string>();
           for (const ch of f) {
             if (!ALLOWED_FLAGS.has(ch)) {
-              return errorResult(
-                `Error replacing in note: invalid regex flag '${displaySectionValue(ch)}'. Allowed flags: g, i, m, s, u, y.`,
+              return error(
+                `Error replacing in note: invalid regex flag '${displaySectionValue(ch)}'. Allowed flags: g, i, m, s, u, y.`
               );
             }
             if (seen.has(ch)) {
-              return errorResult(
-                `Error replacing in note: duplicate regex flag '${displaySectionValue(ch)}'.`,
+              return error(
+                `Error replacing in note: duplicate regex flag '${displaySectionValue(ch)}'.`
               );
             }
             seen.add(ch);
           }
           if (!f.includes("g")) {
-            return errorResult(
-              "Error replacing in note: regex flags must include 'g' for replace_in_note.",
+            return error(
+              "Error replacing in note: regex flags must include 'g' for replace_in_note."
             );
           }
           let compiledPattern: RegExp;
           try {
             compiledPattern = new RegExp(find, f);
           } catch (syntaxErr) {
-            return errorResult(
-              `Error replacing in note: invalid regex pattern: ${sanitizeError(syntaxErr)}`,
+            return error(
+              `Error replacing in note: invalid regex pattern: ${sanitizeError(syntaxErr)}`
             );
           }
           unsafeRegexPattern = hasUnsafeRepeatedGroup(find);
@@ -98,19 +119,19 @@ export function registerReplaceInNoteTool(server: McpServer, vaultPath: string):
         await updateNote(vaultPath, notePath, (existing) => {
           if (existing.length > NOTE_INPUT_MAX_LEN) {
             throw new Error(
-              `note is too large for replace_in_note (${existing.length} > ${NOTE_INPUT_MAX_LEN} chars). Use a more targeted tool.`,
+              `note is too large for replace_in_note (${existing.length} > ${NOTE_INPUT_MAX_LEN} chars). Use a more targeted tool.`
             );
           }
           if (unsafeRegexPattern) {
             throw new Error(
-              "unsafe regex pattern: nested quantifiers or ambiguous repeated alternation can cause catastrophic backtracking. Use a simpler pattern.",
+              "unsafe regex pattern: nested quantifiers or ambiguous repeated alternation can cause catastrophic backtracking. Use a simpler pattern."
             );
           }
           const matches = existing.match(pattern);
           count = matches ? matches.length : 0;
           if (expectedCount !== undefined && count !== expectedCount) {
             throw new Error(
-              `Match-count check failed: expected ${expectedCount}, found ${count}. No changes written.`,
+              `Match-count check failed: expected ${expectedCount}, found ${count}. No changes written.`
             );
           }
           if (count === 0) return existing;
@@ -119,15 +140,18 @@ export function registerReplaceInNoteTool(server: McpServer, vaultPath: string):
             : existing.replace(pattern, () => replace);
         });
         invalidateSectionListCache(vaultPath, notePath);
-        return textResult(
+        return text(
           count === 0
             ? `No matches in ${displaySectionValue(notePath)} - file unchanged.`
-            : `Replaced ${count} match(es) in ${displaySectionValue(notePath)}.`,
+            : `Replaced ${count} match(es) in ${displaySectionValue(notePath)}.`
         );
       } catch (err) {
-        log.error("replace_in_note failed", { tool: "replace_in_note", err: err as Error });
-        return errorResult(`Error replacing in note: ${sanitizeError(err)}`);
+        log.error("replace_in_note failed", {
+          tool: "replace_in_note",
+          err: err as Error,
+        });
+        return error(`Error replacing in note: ${sanitizeError(err)}`);
       }
-    },
+    }
   );
 }

--- a/src/tools/sections/replace_in_note.ts
+++ b/src/tools/sections/replace_in_note.ts
@@ -2,7 +2,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { updateNote } from "../../lib/vault.js";
 import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
 import { defineTool, text, error } from "../../lib/tool-seam.js";
 import {
   FIND_MAX_LEN,
@@ -70,88 +69,80 @@ export function registerReplaceInNoteTool(
     async ({ path: notePath, find, replace, regex, flags, expectedCount }) => {
       const ALLOWED_FLAGS = new Set(["g", "i", "m", "s", "u", "y"]);
 
-      try {
-        let pattern: RegExp;
-        let unsafeRegexPattern = false;
-        if (regex) {
-          if (find.length > FIND_MAX_LEN) {
-            return error(
-              `Error replacing in note: find pattern too long (${find.length} > ${FIND_MAX_LEN} chars). Use a more targeted pattern.`
-            );
-          }
-          const f = flags ?? "g";
-          const seen = new Set<string>();
-          for (const ch of f) {
-            if (!ALLOWED_FLAGS.has(ch)) {
-              return error(
-                `Error replacing in note: invalid regex flag '${displaySectionValue(ch)}'. Allowed flags: g, i, m, s, u, y.`
-              );
-            }
-            if (seen.has(ch)) {
-              return error(
-                `Error replacing in note: duplicate regex flag '${displaySectionValue(ch)}'.`
-              );
-            }
-            seen.add(ch);
-          }
-          if (!f.includes("g")) {
-            return error(
-              "Error replacing in note: regex flags must include 'g' for replace_in_note."
-            );
-          }
-          let compiledPattern: RegExp;
-          try {
-            compiledPattern = new RegExp(find, f);
-          } catch (syntaxErr) {
-            return error(
-              `Error replacing in note: invalid regex pattern: ${sanitizeError(syntaxErr)}`
-            );
-          }
-          unsafeRegexPattern = hasUnsafeRepeatedGroup(find);
-          pattern = compiledPattern;
-        } else {
-          const escaped = find.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-          pattern = new RegExp(escaped, "g");
+      let pattern: RegExp;
+      let unsafeRegexPattern = false;
+      if (regex) {
+        if (find.length > FIND_MAX_LEN) {
+          return error(
+            `Error replacing in note: find pattern too long (${find.length} > ${FIND_MAX_LEN} chars). Use a more targeted pattern.`
+          );
         }
-
-        let count = 0;
-        await assertReadableEditTarget(vaultPath, notePath);
-        await updateNote(vaultPath, notePath, (existing) => {
-          if (existing.length > NOTE_INPUT_MAX_LEN) {
-            throw new Error(
-              `note is too large for replace_in_note (${existing.length} > ${NOTE_INPUT_MAX_LEN} chars). Use a more targeted tool.`
+        const f = flags ?? "g";
+        const seen = new Set<string>();
+        for (const ch of f) {
+          if (!ALLOWED_FLAGS.has(ch)) {
+            return error(
+              `Error replacing in note: invalid regex flag '${displaySectionValue(ch)}'. Allowed flags: g, i, m, s, u, y.`
             );
           }
-          if (unsafeRegexPattern) {
-            throw new Error(
-              "unsafe regex pattern: nested quantifiers or ambiguous repeated alternation can cause catastrophic backtracking. Use a simpler pattern."
+          if (seen.has(ch)) {
+            return error(
+              `Error replacing in note: duplicate regex flag '${displaySectionValue(ch)}'.`
             );
           }
-          const matches = existing.match(pattern);
-          count = matches ? matches.length : 0;
-          if (expectedCount !== undefined && count !== expectedCount) {
-            throw new Error(
-              `Match-count check failed: expected ${expectedCount}, found ${count}. No changes written.`
-            );
-          }
-          if (count === 0) return existing;
-          return regex
-            ? existing.replace(pattern, replace)
-            : existing.replace(pattern, () => replace);
-        });
-        invalidateSectionListCache(vaultPath, notePath);
-        return text(
-          count === 0
-            ? `No matches in ${displaySectionValue(notePath)} - file unchanged.`
-            : `Replaced ${count} match(es) in ${displaySectionValue(notePath)}.`
-        );
-      } catch (err) {
-        log.error("replace_in_note failed", {
-          tool: "replace_in_note",
-          err: err as Error,
-        });
-        return error(`Error replacing in note: ${sanitizeError(err)}`);
+          seen.add(ch);
+        }
+        if (!f.includes("g")) {
+          return error(
+            "Error replacing in note: regex flags must include 'g' for replace_in_note."
+          );
+        }
+        let compiledPattern: RegExp;
+        try {
+          compiledPattern = new RegExp(find, f);
+        } catch (syntaxErr) {
+          return error(
+            `Error replacing in note: invalid regex pattern: ${sanitizeError(syntaxErr)}`
+          );
+        }
+        unsafeRegexPattern = hasUnsafeRepeatedGroup(find);
+        pattern = compiledPattern;
+      } else {
+        const escaped = find.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        pattern = new RegExp(escaped, "g");
       }
+
+      let count = 0;
+      await assertReadableEditTarget(vaultPath, notePath);
+      await updateNote(vaultPath, notePath, (existing) => {
+        if (existing.length > NOTE_INPUT_MAX_LEN) {
+          throw new Error(
+            `note is too large for replace_in_note (${existing.length} > ${NOTE_INPUT_MAX_LEN} chars). Use a more targeted tool.`
+          );
+        }
+        if (unsafeRegexPattern) {
+          throw new Error(
+            "unsafe regex pattern: nested quantifiers or ambiguous repeated alternation can cause catastrophic backtracking. Use a simpler pattern."
+          );
+        }
+        const matches = existing.match(pattern);
+        count = matches ? matches.length : 0;
+        if (expectedCount !== undefined && count !== expectedCount) {
+          throw new Error(
+            `Match-count check failed: expected ${expectedCount}, found ${count}. No changes written.`
+          );
+        }
+        if (count === 0) return existing;
+        return regex
+          ? existing.replace(pattern, replace)
+          : existing.replace(pattern, () => replace);
+      });
+      invalidateSectionListCache(vaultPath, notePath);
+      return text(
+        count === 0
+          ? `No matches in ${displaySectionValue(notePath)} - file unchanged.`
+          : `Replaced ${count} match(es) in ${displaySectionValue(notePath)}.`
+      );
     }
   );
 }

--- a/src/tools/sections/shared.ts
+++ b/src/tools/sections/shared.ts
@@ -6,15 +6,9 @@ import {
   resolveVaultPathSafe,
   assertNoteFileSize,
 } from "../../lib/vault.js";
-import {
-  parseHeadings,
-} from "../../lib/sections.js";
+import { parseHeadings } from "../../lib/sections.js";
 import { escapeControlChars } from "../../lib/errors.js";
-import {
-  formatUntrustedVaultContent,
-  indentBlock,
-  untrustedVaultContentMeta,
-} from "../../lib/tool-output.js";
+import type { RichTextBuilder } from "../../lib/tool-seam.js";
 
 export const SECTION_LIST_CACHE_LIMIT = 16;
 export const SECTION_EDIT_PAYLOAD_MAX_CHARS = 1_000_000;
@@ -30,35 +24,25 @@ export interface SectionListCacheEntry {
 
 export const sectionListCache = new Map<string, SectionListCacheEntry>();
 
-export function textResult(text: string) {
-  return { content: [{ type: "text" as const, text }] };
-}
-
-export function textResultWithMeta(text: string, metaLabel: string) {
-  return {
-    content: [{
-      type: "text" as const,
-      text,
-      _meta: untrustedVaultContentMeta(metaLabel),
-    }],
-  };
-}
-
-export function errorResult(text: string) {
-  return { content: [{ type: "text" as const, text }], isError: true as const };
-}
-
 /** Escape control characters before embedding values in section-tool display text. */
 export const displaySectionValue = escapeControlChars;
 
-export function renderResolvedHeading(label: string, heading: string): string {
-  return [
-    "Resolved heading:",
-    indentBlock(formatUntrustedVaultContent(label, displaySectionValue(heading)), "  "),
-  ].join("\n");
+/** Append the "Resolved heading:" line plus the heading as a wrapped untrusted
+ *  block. Shared by insert_at_section and update_section, whose success
+ *  messages both echo the section-path resolution back to the caller. */
+export function richResolvedHeading(
+  b: RichTextBuilder,
+  label: string,
+  heading: string
+): void {
+  b.trusted("Resolved heading:");
+  b.untrusted(label, displaySectionValue(heading), "  ");
 }
 
-export async function assertReadableEditTarget(vaultPath: string, notePath: string): Promise<void> {
+export async function assertReadableEditTarget(
+  vaultPath: string,
+  notePath: string
+): Promise<void> {
   await resolveVaultPathSafe(vaultPath, notePath, "read");
 }
 
@@ -88,7 +72,10 @@ export function regexQuantifierLength(pattern: string, index: number): number {
   return pattern.charAt(i) === "}" ? i - index + 1 : 0;
 }
 
-export function regexQuantifierCanRepeat(pattern: string, index: number): boolean {
+export function regexQuantifierCanRepeat(
+  pattern: string,
+  index: number
+): boolean {
   const ch = pattern.charAt(index);
   if (ch === "*" || ch === "+") return true;
   if (ch === "?") return false;
@@ -115,7 +102,10 @@ export function regexQuantifierCanRepeat(pattern: string, index: number): boolea
   return Number(maxText) > 1;
 }
 
-export function regexCharacterClassEnd(pattern: string, openIndex: number): number {
+export function regexCharacterClassEnd(
+  pattern: string,
+  openIndex: number
+): number {
   for (let i = openIndex + 1; i < pattern.length; i += 1) {
     const ch = pattern.charAt(i);
     if (ch === "\\") {
@@ -155,7 +145,10 @@ export function hasQuantifiedAtom(pattern: string): boolean {
   return false;
 }
 
-export function regexGroupBodyStart(pattern: string, openIndex: number): number {
+export function regexGroupBodyStart(
+  pattern: string,
+  openIndex: number
+): number {
   if (pattern.charAt(openIndex + 1) !== "?") return openIndex + 1;
 
   const kind = pattern.charAt(openIndex + 2);
@@ -255,7 +248,10 @@ export function regexAtomTokens(pattern: string): string[] {
   return tokens;
 }
 
-export function regexTokensSharePrefix(a: readonly string[], b: readonly string[]): boolean {
+export function regexTokensSharePrefix(
+  a: readonly string[],
+  b: readonly string[]
+): boolean {
   const len = Math.min(a.length, b.length);
   if (len === 0) return true;
   for (let i = 0; i < len; i += 1) {
@@ -289,7 +285,10 @@ export function hasAmbiguousAlternation(pattern: string): boolean {
 
     const end = regexGroupEnd(pattern, i);
     const bodyStart = regexGroupBodyStart(pattern, i);
-    if (bodyStart < end && hasAmbiguousAlternation(pattern.slice(bodyStart, end))) {
+    if (
+      bodyStart < end &&
+      hasAmbiguousAlternation(pattern.slice(bodyStart, end))
+    ) {
       return true;
     }
     i = end;
@@ -332,7 +331,10 @@ export function hasUnsafeRepeatedGroup(pattern: string): boolean {
 }
 
 export function splitHeadingPath(section: string): string[] {
-  return section.split("/").map((s) => s.trim()).filter(Boolean);
+  return section
+    .split("/")
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
 export function assertMarkdownSectionListPath(relativePath: string): void {
@@ -341,20 +343,27 @@ export function assertMarkdownSectionListPath(relativePath: string): void {
   }
 }
 
-export function sectionListCacheKey(vaultPath: string, notePath: string): string {
+export function sectionListCacheKey(
+  vaultPath: string,
+  notePath: string
+): string {
   return `${path.resolve(vaultPath)}\0${notePath}`;
 }
 
 export async function getSectionListSignature(
   vaultPath: string,
-  notePath: string,
+  notePath: string
 ): Promise<{ fullPath: string; size: number; mtimeMs: number }> {
   assertMarkdownSectionListPath(notePath);
   let opened: Awaited<ReturnType<typeof openVaultFileForRead>> | undefined;
   try {
     opened = await openVaultFileForRead(vaultPath, notePath);
     assertNoteFileSize(notePath, opened.stats.size);
-    return { fullPath: opened.fullPath, size: opened.stats.size, mtimeMs: opened.stats.mtimeMs };
+    return {
+      fullPath: opened.fullPath,
+      size: opened.stats.size,
+      mtimeMs: opened.stats.mtimeMs,
+    };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       await readNote(vaultPath, notePath);
@@ -367,15 +376,24 @@ export async function getSectionListSignature(
 
 export function renderSectionList(notePath: string, content: string): string {
   const headings = parseHeadings(content);
-  if (headings.length === 0) return `No headings in ${displaySectionValue(notePath)}`;
-  const lines = [`${headings.length} heading(s) in ${displaySectionValue(notePath)}:`, ""];
+  if (headings.length === 0)
+    return `No headings in ${displaySectionValue(notePath)}`;
+  const lines = [
+    `${headings.length} heading(s) in ${displaySectionValue(notePath)}:`,
+    "",
+  ];
   for (const h of headings) {
-    lines.push(`${"  ".repeat(h.level - 1)}${"#".repeat(h.level)} ${displaySectionValue(h.text)}`);
+    lines.push(
+      `${"  ".repeat(h.level - 1)}${"#".repeat(h.level)} ${displaySectionValue(h.text)}`
+    );
   }
   return lines.join("\n");
 }
 
-export async function readSectionListCached(vaultPath: string, notePath: string): Promise<string> {
+export async function readSectionListCached(
+  vaultPath: string,
+  notePath: string
+): Promise<string> {
   const signature = await getSectionListSignature(vaultPath, notePath);
   const key = sectionListCacheKey(vaultPath, notePath);
   const cached = sectionListCache.get(key);
@@ -416,6 +434,9 @@ export async function readSectionListCached(vaultPath: string, notePath: string)
   return text;
 }
 
-export function invalidateSectionListCache(vaultPath: string, notePath: string): void {
+export function invalidateSectionListCache(
+  vaultPath: string,
+  notePath: string
+): void {
   sectionListCache.delete(sectionListCacheKey(vaultPath, notePath));
 }

--- a/src/tools/sections/update_section.ts
+++ b/src/tools/sections/update_section.ts
@@ -1,29 +1,28 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import {
-  updateNote,
-} from "../../lib/vault.js";
-import {
-  findSection,
-  replaceSectionBody,
-} from "../../lib/sections.js";
+import { updateNote } from "../../lib/vault.js";
+import { findSection, replaceSectionBody } from "../../lib/sections.js";
 import { sanitizeError } from "../../lib/errors.js";
 import { log } from "../../lib/logger.js";
+import { defineTool, richText, error } from "../../lib/tool-seam.js";
 import {
   SECTION_EDIT_PAYLOAD_MAX_CHARS,
-  textResultWithMeta,
-  errorResult,
   displaySectionValue,
-  renderResolvedHeading,
+  richResolvedHeading,
   assertReadableEditTarget,
   invalidateSectionListCache,
   splitHeadingPath,
 } from "./shared.js";
 
-export function registerUpdateSectionTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "update_section",
+export function registerUpdateSectionTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "update_section",
       title: "Update Section",
       description:
         "Replace the body of a specific section (everything between a heading and the next heading at any level). The heading line itself is preserved. `section` is a heading path: `'Tasks'`, `'Project A/Status'`, etc. - case-insensitive and whitespace-tolerant. Use this instead of rewriting the whole file when you only need to update one section.",
@@ -37,21 +36,27 @@ export function registerUpdateSectionTool(server: McpServer, vaultPath: string):
         path: z
           .string()
           .min(1)
-          .describe("Vault-relative path to the note (e.g., 'folder/note.md'). Extension required."),
+          .describe(
+            "Vault-relative path to the note (e.g., 'folder/note.md'). Extension required."
+          ),
         section: z
           .string()
           .min(1)
-          .describe("Heading path identifying the section to replace (e.g., 'Tasks' or 'Daily/Today')."),
+          .describe(
+            "Heading path identifying the section to replace (e.g., 'Tasks' or 'Daily/Today')."
+          ),
         newBody: z
           .string()
           .max(SECTION_EDIT_PAYLOAD_MAX_CHARS)
-          .describe("Replacement body content. The heading line itself is kept intact."),
+          .describe(
+            "Replacement body content. The heading line itself is kept intact."
+          ),
       },
     },
     async ({ path: notePath, section, newBody }) => {
       try {
         const headingPath = splitHeadingPath(section);
-        if (headingPath.length === 0) return errorResult("section must not be empty");
+        if (headingPath.length === 0) return error("section must not be empty");
 
         let resolvedHeading = "";
         let bodyBytes = 0;
@@ -67,17 +72,23 @@ export function registerUpdateSectionTool(server: McpServer, vaultPath: string):
           return updated;
         });
         invalidateSectionListCache(vaultPath, notePath);
-        return textResultWithMeta(
-          [
-            `Updated section in ${displaySectionValue(notePath)} (${bodyBytes} bytes of new body)`,
-            renderResolvedHeading("update_section resolved heading", resolvedHeading),
-          ].join("\n"),
-          "update_section resolved heading",
-        );
+        return richText("update_section resolved heading", (b) => {
+          b.trusted(
+            `Updated section in ${displaySectionValue(notePath)} (${bodyBytes} bytes of new body)`
+          );
+          richResolvedHeading(
+            b,
+            "update_section resolved heading",
+            resolvedHeading
+          );
+        });
       } catch (err) {
-        log.error("update_section failed", { tool: "update_section", err: err as Error });
-        return errorResult(`Error updating section: ${sanitizeError(err)}`);
+        log.error("update_section failed", {
+          tool: "update_section",
+          err: err as Error,
+        });
+        return error(`Error updating section: ${sanitizeError(err)}`);
       }
-    },
+    }
   );
 }

--- a/src/tools/sections/update_section.ts
+++ b/src/tools/sections/update_section.ts
@@ -2,8 +2,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { updateNote } from "../../lib/vault.js";
 import { findSection, replaceSectionBody } from "../../lib/sections.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
 import { defineTool, richText, error } from "../../lib/tool-seam.js";
 import {
   SECTION_EDIT_PAYLOAD_MAX_CHARS,
@@ -54,41 +52,33 @@ export function registerUpdateSectionTool(
       },
     },
     async ({ path: notePath, section, newBody }) => {
-      try {
-        const headingPath = splitHeadingPath(section);
-        if (headingPath.length === 0) return error("section must not be empty");
+      const headingPath = splitHeadingPath(section);
+      if (headingPath.length === 0) return error("section must not be empty");
 
-        let resolvedHeading = "";
-        let bodyBytes = 0;
-        await assertReadableEditTarget(vaultPath, notePath);
-        await updateNote(vaultPath, notePath, (existing) => {
-          const found = findSection(existing, headingPath);
-          if (!found) {
-            throw new Error(`Section not found: "${section}"`);
-          }
-          resolvedHeading = found.heading.text;
-          const updated = replaceSectionBody(existing, found, newBody);
-          bodyBytes = Buffer.byteLength(newBody, "utf-8");
-          return updated;
-        });
-        invalidateSectionListCache(vaultPath, notePath);
-        return richText("update_section resolved heading", (b) => {
-          b.trusted(
-            `Updated section in ${displaySectionValue(notePath)} (${bodyBytes} bytes of new body)`
-          );
-          richResolvedHeading(
-            b,
-            "update_section resolved heading",
-            resolvedHeading
-          );
-        });
-      } catch (err) {
-        log.error("update_section failed", {
-          tool: "update_section",
-          err: err as Error,
-        });
-        return error(`Error updating section: ${sanitizeError(err)}`);
-      }
+      let resolvedHeading = "";
+      let bodyBytes = 0;
+      await assertReadableEditTarget(vaultPath, notePath);
+      await updateNote(vaultPath, notePath, (existing) => {
+        const found = findSection(existing, headingPath);
+        if (!found) {
+          throw new Error(`Section not found: "${section}"`);
+        }
+        resolvedHeading = found.heading.text;
+        const updated = replaceSectionBody(existing, found, newBody);
+        bodyBytes = Buffer.byteLength(newBody, "utf-8");
+        return updated;
+      });
+      invalidateSectionListCache(vaultPath, notePath);
+      return richText("update_section resolved heading", (b) => {
+        b.trusted(
+          `Updated section in ${displaySectionValue(notePath)} (${bodyBytes} bytes of new body)`
+        );
+        richResolvedHeading(
+          b,
+          "update_section resolved heading",
+          resolvedHeading
+        );
+      });
     }
   );
 }


### PR DESCRIPTION
Migrates the sections group (5 tools) through the tool seam. Part of Wave-1 (map #245). Byte-preserving: only the generic `Error:` prefix (ADR exception #1) on thrown paths. Verified combined-green (979 tests). Closes #248.