### PR TITLE
refactor(tools): migrate bases group through the tool seam

### DIFF
--- a/src/__tests__/handlers/bases.test.ts
+++ b/src/__tests__/handlers/bases.test.ts
@@ -81,6 +81,9 @@ describe("base handlers — read_base", () => {
     expect(text).not.toContain("Main\nView");
     expect(text).not.toContain("table\tview");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "read_base document",
+    );
   });
 });
 
@@ -107,6 +110,9 @@ describe("base handlers - list_bases", () => {
     expect(text).toContain("boards/roadmap.base");
     expect(text).toContain("tasks.base");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "list_bases paths",
+    );
   });
 });
 
@@ -193,6 +199,9 @@ describe("base handlers — query_base", () => {
     expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: query_base result paths]");
     expect(text).toContain("- note.md");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "query_base paths",
+    );
   });
 
   it("escapes control characters in view labels and frontmatter keys", async () => {
@@ -240,6 +249,9 @@ describe("base handlers — query_base", () => {
     expect(text).not.toContain("bad\tkey");
     expect(text).not.toContain("dirty\nvalue");
     expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "query_base paths and frontmatter",
+    );
   });
 
   it("fails closed for missing views instead of returning base-level rows", async () => {

--- a/src/tools/bases/list-bases.ts
+++ b/src/tools/bases/list-bases.ts
@@ -1,13 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { listBaseFiles } from "../../lib/vault.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
-import { textResult, untrustedTextResult, errorResult, displayBaseValue, untrustedBaseBlock } from "./shared.js";
+import { defineTool, text, richText } from "../../lib/tool-seam.js";
+import { displayBaseValue } from "./shared.js";
 
 export function registerListBases(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "list_bases",
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "list_bases",
       title: "List Bases",
       description:
         "Enumerate every Obsidian Bases (`.base`) file in the vault. Bases are YAML-defined database views over notes (filters, properties, table/calendar/kanban views). Returns a sorted list of relative paths plus the total count. Pair with read_base or query_base.",
@@ -19,16 +20,13 @@ export function registerListBases(server: McpServer, vaultPath: string): void {
       inputSchema: {},
     },
     async () => {
-      try {
-        const bases = await listBaseFiles(vaultPath);
-        if (bases.length === 0) return textResult("No .base files in this vault.");
-        const lines = [`Found ${bases.length} Base file(s):`, ""];
-        lines.push(untrustedBaseBlock("list_bases paths", bases.map(displayBaseValue).join("\n")));
-        return untrustedTextResult("list_bases paths", lines.join("\n"));
-      } catch (err) {
-        log.error("list_bases failed", { tool: "list_bases", err: err as Error });
-        return errorResult(`Error listing bases: ${sanitizeError(err)}`);
-      }
+      const bases = await listBaseFiles(vaultPath);
+      if (bases.length === 0) return text("No .base files in this vault.");
+      return richText("list_bases paths", (b) => {
+        b.trusted(`Found ${bases.length} Base file(s):`);
+        b.trusted("");
+        b.untrusted("list_bases paths", bases.map(displayBaseValue).join("\n"));
+      });
     },
   );
 }

--- a/src/tools/bases/query-base.ts
+++ b/src/tools/bases/query-base.ts
@@ -4,15 +4,16 @@ import { listNotes, readBaseFile } from "../../lib/vault.js";
 import { parseBaseFile, queryBase, buildRow } from "../../lib/bases.js";
 import { readAllCached } from "../../lib/index-cache.js";
 import { extractWikilinks } from "../../lib/markdown.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { indentBlock, formatUntrustedVaultContent } from "../../lib/tool-output.js";
 import { log } from "../../lib/logger.js";
-import { untrustedTextResult, errorResult, displayBaseValue, untrustedBaseBlock } from "./shared.js";
+import { defineTool, richText } from "../../lib/tool-seam.js";
+import { displayBaseValue } from "./shared.js";
 
 export function registerQueryBase(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "query_base",
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "query_base",
       title: "Query Base",
       description:
         "Run a Base file's filters against the vault and return matching note paths. Optionally pick a named view to apply that view's filters and ordering on top of the base-level filters. Supported filter syntax (subset of Obsidian's full DSL): chained methods `file.hasTag(\"tag\")`, `file.hasProperty(\"key\")`, `file.inFolder(\"path\")`, `file.linksTo(\"target\")`, `file.name.contains(\"x\")`/`.startsWith`/`.endsWith`/`.equals`, plus `.isEmpty`/`.isNotEmpty` on any value; legacy function form `taggedWith(file, \"tag\")`; comparisons `key == \"val\"`, `key != x`, `key contains x`, `>=`, `<=`, `>`, `<`; combinators `and:`, `or:`, `not:`. Recognized file properties: file.name, file.basename, file.folder, file.ext, file.path, file.size, file.ctime, file.mtime, file.tags, file.properties, file.links, file.embeds, file.backlinks. Unsupported clauses are reported as warnings and treated as no-match.",
@@ -49,96 +50,90 @@ export function registerQueryBase(server: McpServer, vaultPath: string): void {
       },
     },
     async ({ path: basePath, view, limit, includeFrontmatter }) => {
-      try {
-        const raw = await readBaseFile(vaultPath, basePath);
-        const { doc, warnings } = parseBaseFile(raw);
-        const notes = await listNotes(vaultPath);
-        // PERF-4: Use the mtime-keyed content cache instead of reading each
-        // note individually. readAllCached stat()'s each path and only re-reads
-        // files whose mtime has moved, which makes repeat queries near-instant.
-        const readFailures: string[] = [];
-        const { contents, stats } = await readAllCached(vaultPath, notes, (relPath, err) => {
-          readFailures.push(relPath);
-          log.warn("query_base: note read failed", {
-            note: relPath,
-            err,
-          });
+      const raw = await readBaseFile(vaultPath, basePath);
+      const { doc, warnings } = parseBaseFile(raw);
+      const notes = await listNotes(vaultPath);
+      // PERF-4: Use the mtime-keyed content cache instead of reading each
+      // note individually. readAllCached stat()'s each path and only re-reads
+      // files whose mtime has moved, which makes repeat queries near-instant.
+      const readFailures: string[] = [];
+      const { contents, stats } = await readAllCached(vaultPath, notes, (relPath, err) => {
+        readFailures.push(relPath);
+        log.warn("query_base: note read failed", {
+          note: relPath,
+          err,
         });
-        const validRows = notes
-          .filter((notePath) => contents.has(notePath))
-          .map((notePath) => {
-            const content = contents.get(notePath)!;
-            const row = buildRow(notePath, content, stats.get(notePath));
-            // BUG-4: Populate row.links from the note's outgoing wikilinks so
-            // file.linksTo() / file.hasLink() filters evaluate correctly.
-            // Without this, row.links is undefined and link filters fail
-            // closed with a warning.
-            const linkInfos = extractWikilinks(content);
-            row.links = linkInfos
-              .filter((l) => !l.isEmbed)
-              .map((l) => l.target);
-            row.embeds = linkInfos
-              .filter((l) => l.isEmbed)
-              .map((l) => l.target);
-            return row;
-          });
-        const result = queryBase(validRows, doc, view);
-        const allWarnings = [...warnings, ...result.warnings];
-        if (readFailures.length > 0) {
-          allWarnings.push(
-            `Could not read ${readFailures.length} note(s); they were excluded from results.`,
-          );
-        }
-        const truncated = result.rows.slice(0, limit);
+      });
+      const validRows = notes
+        .filter((notePath) => contents.has(notePath))
+        .map((notePath) => {
+          const content = contents.get(notePath)!;
+          const row = buildRow(notePath, content, stats.get(notePath));
+          // BUG-4: Populate row.links from the note's outgoing wikilinks so
+          // file.linksTo() / file.hasLink() filters evaluate correctly.
+          // Without this, row.links is undefined and link filters fail
+          // closed with a warning.
+          const linkInfos = extractWikilinks(content);
+          row.links = linkInfos
+            .filter((l) => !l.isEmbed)
+            .map((l) => l.target);
+          row.embeds = linkInfos
+            .filter((l) => l.isEmbed)
+            .map((l) => l.target);
+          return row;
+        });
+      const result = queryBase(validRows, doc, view);
+      const allWarnings = [...warnings, ...result.warnings];
+      if (readFailures.length > 0) {
+        allWarnings.push(
+          `Could not read ${readFailures.length} note(s); they were excluded from results.`,
+        );
+      }
+      const truncated = result.rows.slice(0, limit);
 
-        const lines: string[] = [];
-        lines.push("Base:");
-        lines.push(untrustedBaseBlock("query_base base path", displayBaseValue(basePath), "  "));
-        if (view) lines.push(`View: ${displayBaseValue(view)}`);
-        lines.push(
+      const itemTrustLabel = includeFrontmatter
+        ? "query_base paths and frontmatter"
+        : "query_base paths";
+
+      return richText(itemTrustLabel, (b) => {
+        b.trusted("Base:");
+        b.untrusted("query_base base path", displayBaseValue(basePath), "  ");
+        if (view) b.trusted(`View: ${displayBaseValue(view)}`);
+        b.trusted(
           `Matched ${result.rows.length} note(s)${result.rows.length > limit ? ` (showing first ${limit})` : ""}`,
         );
         if (allWarnings.length > 0) {
-          lines.push("");
-          lines.push("Warnings:");
-          lines.push(untrustedBaseBlock(
+          b.trusted("");
+          b.trusted("Warnings:");
+          b.untrusted(
             "query_base warnings",
             allWarnings.map((w) => `- ${displayBaseValue(w)}`).join("\n"),
             "  ",
-          ));
+          );
         }
-        lines.push("");
+        b.trusted("");
         if (includeFrontmatter) {
           for (const row of truncated) {
-            lines.push(untrustedBaseBlock(
-              "query_base row path",
-              `- ${displayBaseValue(row.path)}`,
-            ));
+            b.untrusted("query_base row path", `- ${displayBaseValue(row.path)}`);
             if (Object.keys(row.frontmatter).length > 0) {
               const frontmatterLines: string[] = [];
               for (const [k, v] of Object.entries(row.frontmatter)) {
                 frontmatterLines.push(`${displayBaseValue(k)}: ${JSON.stringify(v)}`);
               }
-              lines.push(indentBlock(
-                formatUntrustedVaultContent("query_base row frontmatter", frontmatterLines.join("\n")),
+              b.untrusted(
+                "query_base row frontmatter",
+                frontmatterLines.join("\n"),
                 "    ",
-              ));
+              );
             }
           }
         } else if (truncated.length > 0) {
-          lines.push(untrustedBaseBlock(
+          b.untrusted(
             "query_base result paths",
             truncated.map((row) => `- ${displayBaseValue(row.path)}`).join("\n"),
-          ));
+          );
         }
-        return untrustedTextResult(
-          includeFrontmatter ? "query_base paths and frontmatter" : "query_base paths",
-          lines.join("\n"),
-        );
-      } catch (err) {
-        log.error("query_base failed", { tool: "query_base", err: err as Error });
-        return errorResult(`Error querying base: ${sanitizeError(err)}`);
-      }
+      });
     },
   );
 }

--- a/src/tools/bases/read-base.ts
+++ b/src/tools/bases/read-base.ts
@@ -2,15 +2,15 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { readBaseFile } from "../../lib/vault.js";
 import { parseBaseFile } from "../../lib/bases.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
-import { formatUntrustedVaultContent } from "../../lib/tool-output.js";
-import { untrustedTextResult, errorResult, displayBaseValue } from "./shared.js";
+import { defineTool, untrustedText } from "../../lib/tool-seam.js";
+import { displayBaseValue } from "./shared.js";
 
 export function registerReadBase(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "read_base",
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "read_base",
       title: "Read Base",
       description:
         "Return the parsed contents of a Base file: filters, properties, view definitions, and any unrecognized fields. Use to discover what queries a Base supports before calling query_base.",
@@ -29,42 +29,34 @@ export function registerReadBase(server: McpServer, vaultPath: string): void {
       },
     },
     async ({ path: basePath }) => {
-      try {
-        const raw = await readBaseFile(vaultPath, basePath);
-        const { doc, warnings } = parseBaseFile(raw);
-        const lines: string[] = [`Base: ${displayBaseValue(basePath)}`, ""];
-        if (warnings.length > 0) {
-          lines.push("Parse warnings:");
-          for (const w of warnings) lines.push(`  - ${displayBaseValue(w)}`);
-          lines.push("");
-        }
-        lines.push("Filters:");
-        lines.push("  " + JSON.stringify(doc.filters ?? null, null, 2).split("\n").join("\n  "));
+      const raw = await readBaseFile(vaultPath, basePath);
+      const { doc, warnings } = parseBaseFile(raw);
+      const lines: string[] = [`Base: ${displayBaseValue(basePath)}`, ""];
+      if (warnings.length > 0) {
+        lines.push("Parse warnings:");
+        for (const w of warnings) lines.push(`  - ${displayBaseValue(w)}`);
         lines.push("");
-        if (doc.properties) {
-          lines.push(`Properties (${Object.keys(doc.properties).length}):`);
-          for (const [key, spec] of Object.entries(doc.properties)) {
-            lines.push(
-              `  - ${displayBaseValue(key)}${spec.displayName ? ` (display: ${displayBaseValue(spec.displayName)})` : ""}`,
-            );
-          }
-          lines.push("");
-        }
-        if (Array.isArray(doc.views) && doc.views.length > 0) {
-          lines.push(`Views (${doc.views.length}):`);
-          for (const v of doc.views) {
-            const nm = v.name ?? "(unnamed)";
-            lines.push(`  - ${displayBaseValue(nm)} [type: ${displayBaseValue(v.type)}]`);
-          }
-        }
-        return untrustedTextResult(
-          "read_base document",
-          formatUntrustedVaultContent("read_base document", lines.join("\n")),
-        );
-      } catch (err) {
-        log.error("read_base failed", { tool: "read_base", err: err as Error });
-        return errorResult(`Error reading base: ${sanitizeError(err)}`);
       }
+      lines.push("Filters:");
+      lines.push("  " + JSON.stringify(doc.filters ?? null, null, 2).split("\n").join("\n  "));
+      lines.push("");
+      if (doc.properties) {
+        lines.push(`Properties (${Object.keys(doc.properties).length}):`);
+        for (const [key, spec] of Object.entries(doc.properties)) {
+          lines.push(
+            `  - ${displayBaseValue(key)}${spec.displayName ? ` (display: ${displayBaseValue(spec.displayName)})` : ""}`,
+          );
+        }
+        lines.push("");
+      }
+      if (Array.isArray(doc.views) && doc.views.length > 0) {
+        lines.push(`Views (${doc.views.length}):`);
+        for (const v of doc.views) {
+          const nm = v.name ?? "(unnamed)";
+          lines.push(`  - ${displayBaseValue(nm)} [type: ${displayBaseValue(v.type)}]`);
+        }
+      }
+      return untrustedText("read_base document", lines.join("\n"));
     },
   );
 }

--- a/src/tools/bases/shared.ts
+++ b/src/tools/bases/shared.ts
@@ -1,31 +1,4 @@
-import {
-  formatUntrustedVaultContent,
-  indentBlock,
-  untrustedVaultContentMeta,
-} from "../../lib/tool-output.js";
 import { escapeControlChars } from "../../lib/errors.js";
-
-export function textResult(text: string) {
-  return { content: [{ type: "text" as const, text }] };
-}
-
-export function untrustedTextResult(label: string, text: string) {
-  return {
-    content: [{
-      type: "text" as const,
-      text,
-      _meta: untrustedVaultContentMeta(label),
-    }],
-  };
-}
-
-export function errorResult(text: string) {
-  return { content: [{ type: "text" as const, text }], isError: true as const };
-}
 
 /** Escape control characters before embedding values in Base tool display text. */
 export const displayBaseValue = escapeControlChars;
-
-export function untrustedBaseBlock(label: string, text: string, indent = ""): string {
-  return indentBlock(formatUntrustedVaultContent(label, text), indent);
-}


### PR DESCRIPTION
Migrates the bases group (3 tools) through the tool seam; leaves the js-yaml parser untouched. Part of Wave-1 (map #245). Byte-preserving; adds block-label assertions to bases.test.ts. Verified combined-green (979 tests). Closes #249.