### PR TITLE
refactor(index-cache): drop dead persistence surface + relocate isPersistenceEnabled

### DIFF
--- a/src/__tests__/index-cache.test.ts
+++ b/src/__tests__/index-cache.test.ts
@@ -2,12 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
-import {
-  readAllCached,
-  clearCache,
-  cacheSize,
-  flushNow,
-} from "../lib/index-cache.js";
+import { readAllCached, clearCache, cacheSize } from "../lib/index-cache.js";
 
 let vaultDir: string;
 
@@ -32,12 +27,13 @@ async function linkCacheDirOutside(outsideDir: string): Promise<boolean> {
     await fs.symlink(
       outsideDir,
       path.join(vaultDir, ".obsidian", "cache"),
-      process.platform === "win32" ? "junction" : "dir",
+      process.platform === "win32" ? "junction" : "dir"
     );
     return true;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (code === "EPERM" || code === "EACCES" || code === "EINVAL") return false;
+    if (code === "EPERM" || code === "EACCES" || code === "EINVAL")
+      return false;
     throw err;
   }
 }
@@ -83,9 +79,13 @@ describe("readAllCached", () => {
   it("calls onError for missing files and omits them from contents", async () => {
     await write("a.md", "alpha");
     const errors: string[] = [];
-    const result = await readAllCached(vaultDir, ["a.md", "missing.md"], (rel) => {
-      errors.push(rel);
-    });
+    const result = await readAllCached(
+      vaultDir,
+      ["a.md", "missing.md"],
+      (rel) => {
+        errors.push(rel);
+      }
+    );
     expect(result.contents.has("missing.md")).toBe(false);
     expect(result.contents.get("a.md")).toBe("alpha");
     expect(errors).toContain("missing.md");
@@ -106,10 +106,18 @@ describe("readAllCached", () => {
 
 describe("legacy persistent cache", () => {
   function snapshotPath(): string {
-    return path.join(vaultDir, ".obsidian", "cache", "mcp-pro-index-cache.json");
+    return path.join(
+      vaultDir,
+      ".obsidian",
+      "cache",
+      "mcp-pro-index-cache.json"
+    );
   }
 
-  async function writeLegacySnapshot(relPath: string, content: string): Promise<void> {
+  async function writeLegacySnapshot(
+    relPath: string,
+    content: string
+  ): Promise<void> {
     const fullPath = path.join(vaultDir, relPath);
     const stat = await fs.stat(fullPath);
     const snap = snapshotPath();
@@ -127,14 +135,13 @@ describe("legacy persistent cache", () => {
           },
         },
       }),
-      "utf-8",
+      "utf-8"
     );
   }
 
   it("does not write note bodies to a disk snapshot", async () => {
     await write("a.md", "alpha");
     await readAllCached(vaultDir, ["a.md"]);
-    await flushNow(vaultDir);
 
     await expect(fs.access(snapshotPath())).rejects.toThrow();
   });
@@ -162,7 +169,9 @@ describe("legacy persistent cache", () => {
   });
 
   it("does not follow a .obsidian/cache symlink outside the vault while cleaning up", async () => {
-    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "cache-outside-"));
+    const outsideDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "cache-outside-")
+    );
     try {
       const linked = await linkCacheDirOutside(outsideDir);
       if (!linked) return;
@@ -171,9 +180,10 @@ describe("legacy persistent cache", () => {
       await fs.writeFile(outsideSnapshot, "outside cache", "utf-8");
       await write("a.md", "alpha");
       await readAllCached(vaultDir, ["a.md"]);
-      await flushNow(vaultDir);
 
-      await expect(fs.readFile(outsideSnapshot, "utf-8")).resolves.toBe("outside cache");
+      await expect(fs.readFile(outsideSnapshot, "utf-8")).resolves.toBe(
+        "outside cache"
+      );
     } finally {
       await fs.rm(outsideDir, { recursive: true, force: true });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,17 +3,23 @@
 import { readFileSync, realpathSync } from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
-import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  McpServer,
+  ResourceTemplate,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { Variables } from "@modelcontextprotocol/sdk/shared/uriTemplate.js";
 import { getVaultConfig, getDailyNoteConfig } from "./config.js";
 import { listNotes, readNote } from "./lib/vault.js";
 import { describePermissions } from "./lib/permissions.js";
-import { flushAllCachesAsync, readAllCached } from "./lib/index-cache.js";
+import { readAllCached } from "./lib/index-cache.js";
 import { extractTags } from "./lib/markdown.js";
 import { log, configureLogger } from "./lib/logger.js";
 import { escapeControlChars, sanitizeError } from "./lib/errors.js";
-import { formatUntrustedVaultContent, untrustedVaultContentMeta } from "./lib/tool-output.js";
+import {
+  formatUntrustedVaultContent,
+  untrustedVaultContentMeta,
+} from "./lib/tool-output.js";
 import { formatMomentDate } from "./lib/dates.js";
 import { registerReadTools } from "./tools/read.js";
 import { registerWriteTools } from "./tools/write.js";
@@ -63,11 +69,13 @@ export function parseArgs(argv: string[]): CliOptions {
       opts.command = "version";
     } else if (a === "--transport" && argv[i + 1]) {
       const v = argv[++i]!;
-      if (v !== "stdio" && v !== "http") throw new Error(`--transport must be stdio or http (got "${v}")`);
+      if (v !== "stdio" && v !== "http")
+        throw new Error(`--transport must be stdio or http (got "${v}")`);
       opts.transport = v;
     } else if (a.startsWith("--transport=")) {
       const v = a.slice("--transport=".length);
-      if (v !== "stdio" && v !== "http") throw new Error(`--transport must be stdio or http (got "${v}")`);
+      if (v !== "stdio" && v !== "http")
+        throw new Error(`--transport must be stdio or http (got "${v}")`);
       opts.transport = v;
     } else if (a === "--port" && argv[i + 1]) {
       opts.port = Number(argv[++i]!);
@@ -78,22 +86,32 @@ export function parseArgs(argv: string[]): CliOptions {
     } else if (a.startsWith("--host=")) {
       opts.host = a.slice("--host=".length);
     } else if (a === "--token" || a.startsWith("--token=")) {
-      throw new Error("--token was removed because command-line secrets can leak. Set MCP_HTTP_TOKEN instead.");
+      throw new Error(
+        "--token was removed because command-line secrets can leak. Set MCP_HTTP_TOKEN instead."
+      );
     } else if (a === "--allow-origin" && argv[i + 1]) {
-      opts.allowedOrigins = argv[++i]!.split(",").map((s) => s.trim()).filter(Boolean);
+      opts.allowedOrigins = argv[++i]!.split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
     } else if (a.startsWith("--allow-origin=")) {
-      opts.allowedOrigins = a.slice("--allow-origin=".length).split(",").map((s) => s.trim()).filter(Boolean);
+      opts.allowedOrigins = a
+        .slice("--allow-origin=".length)
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
     } else if (a === "--rate-limit" && argv[i + 1]) {
       opts.rateLimitPerMinute = Number(argv[++i]!);
     } else if (a.startsWith("--rate-limit=")) {
       opts.rateLimitPerMinute = Number(a.slice("--rate-limit=".length));
     } else if (a === "--client" && argv[i + 1]) {
       const v = argv[++i]!;
-      if (v !== "claude" && v !== "cursor") throw new Error(`--client must be claude or cursor`);
+      if (v !== "claude" && v !== "cursor")
+        throw new Error(`--client must be claude or cursor`);
       opts.installClient = v;
     } else if (a.startsWith("--client=")) {
       const v = a.slice("--client=".length);
-      if (v !== "claude" && v !== "cursor") throw new Error(`--client must be claude or cursor`);
+      if (v !== "claude" && v !== "cursor")
+        throw new Error(`--client must be claude or cursor`);
       opts.installClient = v;
     } else if (a === "--vault" && argv[i + 1]) {
       opts.installVaultPath = argv[++i]!;
@@ -174,9 +192,9 @@ function readPackageVersion(): string {
     // build/index.js -> package.json is one level up (project root)
     const here = path.dirname(fileURLToPath(import.meta.url));
     const pkgPath = path.resolve(here, "..", "package.json");
-    const pkg = JSON.parse(
-      readFileSync(pkgPath, "utf-8"),
-    ) as { version?: string };
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+      version?: string;
+    };
     return pkg.version ?? "0.0.0";
   } catch {
     return "0.0.0";
@@ -198,10 +216,11 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
       // server hosts callable starter templates (registered via
       // `registerPrompts`).
       capabilities: { logging: {}, prompts: { listChanged: false } },
-    },
+    }
   );
 
-  const noVaultError = "No Obsidian vault configured. Set OBSIDIAN_VAULT_PATH environment variable.";
+  const noVaultError =
+    "No Obsidian vault configured. Set OBSIDIAN_VAULT_PATH environment variable.";
 
   // --- MCP Resources ---
 
@@ -212,7 +231,9 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
     async (uri: URL, params: Variables) => {
       if (!vaultPath) throw new Error(noVaultError);
       const rawPath = params.path;
-      const notePath = Array.isArray(rawPath) ? rawPath.join("/") : (rawPath ?? "");
+      const notePath = Array.isArray(rawPath)
+        ? rawPath.join("/")
+        : (rawPath ?? "");
 
       if (!notePath) {
         throw new Error("Note path is required");
@@ -232,7 +253,9 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
           ],
         };
       } catch (err) {
-        throw new Error(`Failed to read note: ${sanitizeError(err)}`, { cause: err });
+        throw new Error(`Failed to read note: ${sanitizeError(err)}`, {
+          cause: err,
+        });
       }
     }
   );
@@ -303,7 +326,7 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
       // same thing — clients need a proper error so they can branch on it.
       const pathLabel = "daily note resource expected path";
       throw new Error(
-        `No daily note found for today.\n${formatUntrustedVaultContent(pathLabel, displayResourceValue(notePath))}`,
+        `No daily note found for today.\n${formatUntrustedVaultContent(pathLabel, displayResourceValue(notePath))}`
       );
     }
   });
@@ -327,7 +350,9 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
   registerSemanticTools(server, vaultForTools);
   registerPrompts(server);
   if (!vaultPath) {
-    log.warn(`Tools registered but vault unconfigured — calls will return errors`);
+    log.warn(
+      `Tools registered but vault unconfigured — calls will return errors`
+    );
   }
 
   return server;
@@ -420,7 +445,11 @@ async function main(): Promise<void> {
   });
 }
 
-export { startHttpServer, type HttpServerHandle, type HttpServerOptions } from "./http-server.js";
+export {
+  startHttpServer,
+  type HttpServerHandle,
+  type HttpServerOptions,
+} from "./http-server.js";
 
 // Only auto-run as CLI when this file is the entrypoint. Library consumers
 // (e.g. the Obsidian plugin wrapper) import named exports and drive the
@@ -458,29 +487,6 @@ function installProcessErrorHandlers(): void {
     log.error("Uncaught exception", { err });
     process.exit(1);
   });
-
-  // Flush the index cache to disk on graceful shutdown so the next run can
-  // skip re-reading every note. `beforeExit` is the right hook for clean
-  // exits; SIGINT/SIGTERM handlers re-raise after the flush so the process
-  // still terminates with the expected exit code. We do NOT flush from
-  // `uncaughtException` — the process is in undefined state and writing
-  // could corrupt the snapshot.
-  let flushed = false;
-  const flush = async (): Promise<void> => {
-    if (flushed) return;
-    flushed = true;
-    try { await flushAllCachesAsync(); } catch { /* best-effort */ }
-  };
-  process.on("beforeExit", () => { void flush(); });
-  for (const sig of ["SIGINT", "SIGTERM"] as const) {
-    process.on(sig, () => {
-      void flush().finally(() => {
-      // Restore default behavior so the second signal terminates promptly.
-        process.removeAllListeners(sig);
-        process.kill(process.pid, sig);
-      });
-    });
-  }
 }
 
 if (isCliEntry()) {

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -2,8 +2,10 @@ import fs from "fs/promises";
 import path from "path";
 import { createHash, randomBytes } from "crypto";
 import { log } from "./logger.js";
-import { isPersistenceEnabled } from "./index-cache.js";
-import { openVaultInternalFileForRead, resolveVaultInternalPathSafe } from "./vault.js";
+import {
+  openVaultInternalFileForRead,
+  resolveVaultInternalPathSafe,
+} from "./vault.js";
 import { renameWithRetry } from "./fs-ops.js";
 
 /**
@@ -47,6 +49,13 @@ let maxEmbeddingBytes = MAX_EMBEDDING_BYTES_DEFAULT;
  *  reset to the production default. */
 export function setMaxEmbeddingBytesForTests(bytes: number | null): void {
   maxEmbeddingBytes = bytes === null ? MAX_EMBEDDING_BYTES_DEFAULT : bytes;
+}
+
+/** Whether the embedding store may persist to disk. Disabled via
+ *  `OBSIDIAN_CACHE_DISABLED` (`1`/`true`/`yes`). */
+function isPersistenceEnabled(): boolean {
+  const v = process.env.OBSIDIAN_CACHE_DISABLED;
+  return !(v === "1" || v === "true" || v === "yes");
 }
 
 export interface ChunkEmbedding {
@@ -144,15 +153,21 @@ function isSnapshotEntry(entry: unknown): entry is ChunkEmbedding {
     candidate.notePath.length > 0 &&
     isPositiveInteger(candidate.chunkIndex) &&
     Array.isArray(candidate.headingPath) &&
-    candidate.headingPath.every((part): part is string => typeof part === "string") &&
+    candidate.headingPath.every(
+      (part): part is string => typeof part === "string"
+    ) &&
     typeof candidate.text === "string" &&
     typeof candidate.hash === "string" &&
     Array.isArray(candidate.vector)
   );
 }
 
-export function validateEmbeddingVector(vector: unknown, expectedDimension: number | null): string | null {
-  if (!Array.isArray(vector) || vector.length === 0) return "vector must be a non-empty number array";
+export function validateEmbeddingVector(
+  vector: unknown,
+  expectedDimension: number | null
+): string | null {
+  if (!Array.isArray(vector) || vector.length === 0)
+    return "vector must be a non-empty number array";
   for (const value of vector) {
     if (typeof value !== "number" || !Number.isFinite(value)) {
       return "vector contains a non-finite value";
@@ -183,14 +198,20 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
     }
     let raw: string;
     try {
-      const opened = await openVaultInternalFileForRead(vaultPath, STORE_REL_PATH);
+      const opened = await openVaultInternalFileForRead(
+        vaultPath,
+        STORE_REL_PATH
+      );
       const stat = opened.stats;
       if (stat.size > maxEmbeddingBytes) {
         await opened.handle.close();
-        log.warn("embedding-store: snapshot exceeds MAX_EMBEDDING_BYTES; ignoring", {
-          bytes: stat.size,
-          max: maxEmbeddingBytes,
-        });
+        log.warn(
+          "embedding-store: snapshot exceeds MAX_EMBEDDING_BYTES; ignoring",
+          {
+            bytes: stat.size,
+            max: maxEmbeddingBytes,
+          }
+        );
         state.loaded = true;
         state.loadingPromise = null;
         return state;
@@ -202,7 +223,9 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
       }
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        log.warn("embedding-store: failed to read snapshot", { err: err as Error });
+        log.warn("embedding-store: failed to read snapshot", {
+          err: err as Error,
+        });
       }
       state.loaded = true;
       state.loadingPromise = null;
@@ -212,7 +235,9 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
     try {
       snapshot = JSON.parse(raw) as StoreSnapshot;
     } catch (err) {
-      log.warn("embedding-store: snapshot is invalid JSON; ignoring", { err: err as Error });
+      log.warn("embedding-store: snapshot is invalid JSON; ignoring", {
+        err: err as Error,
+      });
       state.loaded = true;
       state.loadingPromise = null;
       return state;
@@ -248,7 +273,8 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
       // Silently drop entries whose vector length doesn't match the snapshot's
       // declared dimension. Guards against hand-edited or partially-corrupted
       // snapshots where one row's length drifted from the rest.
-      if (validateEmbeddingVector(entry.vector, snapshot.dimension) !== null) continue;
+      if (validateEmbeddingVector(entry.vector, snapshot.dimension) !== null)
+        continue;
       state.byKey.set(key(entry.notePath, entry.chunkIndex), entry);
       let owned = state.byNote.get(entry.notePath);
       if (!owned) {
@@ -258,7 +284,8 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
       owned.add(key(entry.notePath, entry.chunkIndex));
     }
     for (const [note, hash] of Object.entries(snapshot.noteHashes ?? {})) {
-      if (typeof hash === "string" && state.byNote.has(note)) state.noteHashes.set(note, hash);
+      if (typeof hash === "string" && state.byNote.has(note))
+        state.noteHashes.set(note, hash);
     }
     // Mark loaded only AFTER all async I/O and parsing is complete.
     state.loaded = true;
@@ -320,19 +347,24 @@ async function doSave(vaultPath: string, state: StoreState): Promise<void> {
   // UTF-8 string gives the actual write size, not the JS string length.
   const byteLength = Buffer.byteLength(serialized, "utf-8");
   if (byteLength > maxEmbeddingBytes) {
-    log.warn("embedding-store: snapshot exceeds MAX_EMBEDDING_BYTES, persistence skipped", {
-      bytes: byteLength,
-      max: maxEmbeddingBytes,
-      chunks: state.byKey.size,
-      notes: state.byNote.size,
-    });
+    log.warn(
+      "embedding-store: snapshot exceeds MAX_EMBEDDING_BYTES, persistence skipped",
+      {
+        bytes: byteLength,
+        max: maxEmbeddingBytes,
+        chunks: state.byKey.size,
+        notes: state.byNote.size,
+      }
+    );
     return;
   }
   let file: string;
   try {
     file = await storePath(vaultPath);
   } catch (err) {
-    log.warn("embedding-store: snapshot path failed vault-boundary check", { err: err as Error });
+    log.warn("embedding-store: snapshot path failed vault-boundary check", {
+      err: err as Error,
+    });
     return;
   }
   // Include a random suffix so two concurrent saves in the same process
@@ -347,12 +379,18 @@ async function doSave(vaultPath: string, state: StoreState): Promise<void> {
       // Best-effort cleanup: if writeFile succeeded but rename failed, the
       // tmp file is still on disk. ENOENT (writeFile never created it) is
       // fine to swallow here.
-      try { await fs.unlink(tmp); } catch { /* ignore */ }
+      try {
+        await fs.unlink(tmp);
+      } catch {
+        /* ignore */
+      }
       throw innerErr;
     }
     state.dirty = false;
   } catch (err) {
-    log.warn("embedding-store: failed to persist snapshot", { err: err as Error });
+    log.warn("embedding-store: failed to persist snapshot", {
+      err: err as Error,
+    });
   }
 }
 
@@ -361,11 +399,15 @@ async function doSave(vaultPath: string, state: StoreState): Promise<void> {
  *  (e.g. when the user wants to fully reset the index). */
 export async function clearStore(
   vaultPath: string,
-  options?: { removeSnapshot?: boolean },
+  options?: { removeSnapshot?: boolean }
 ): Promise<void> {
   stores.delete(path.resolve(vaultPath));
   if (options?.removeSnapshot) {
-    try { await fs.unlink(await storePath(vaultPath)); } catch { /* ignore */ }
+    try {
+      await fs.unlink(await storePath(vaultPath));
+    } catch {
+      /* ignore */
+    }
   }
 }
 
@@ -374,7 +416,7 @@ export async function clearStore(
 export function invalidateIfIncompatible(
   vaultPath: string,
   providerId: string,
-  model: string,
+  model: string
 ): void {
   const state = stateFor(vaultPath);
   if (!state.loaded) return;
@@ -389,7 +431,11 @@ export function invalidateIfIncompatible(
 }
 
 /** Has the given note's content changed since the last index pass? */
-export function noteIsCurrent(vaultPath: string, notePath: string, contentHash: string): boolean {
+export function noteIsCurrent(
+  vaultPath: string,
+  notePath: string,
+  contentHash: string
+): boolean {
   const state = stateFor(vaultPath);
   return state.noteHashes.get(notePath) === contentHash;
 }
@@ -401,14 +447,16 @@ export function setNoteChunks(
   contentHash: string,
   chunks: ChunkEmbedding[],
   providerId: string,
-  model: string,
+  model: string
 ): void {
   const state = stateFor(vaultPath);
   let nextDimension = state.dimension;
   for (const ch of chunks) {
     const error = validateEmbeddingVector(ch.vector, nextDimension);
     if (error !== null) {
-      throw new Error(`Invalid embedding vector at chunk ${ch.chunkIndex}: ${error}`);
+      throw new Error(
+        `Invalid embedding vector at chunk ${ch.chunkIndex}: ${error}`
+      );
     }
     if (nextDimension === null) nextDimension = ch.vector.length;
   }
@@ -451,7 +499,10 @@ export function dropNoteChunks(vaultPath: string, notePath: string): boolean {
 
 /** Drop chunks for notes that no longer exist in the vault. Called at the
  *  end of an index pass. */
-export function pruneMissingNotes(vaultPath: string, currentNotes: Iterable<string>): number {
+export function pruneMissingNotes(
+  vaultPath: string,
+  currentNotes: Iterable<string>
+): number {
   const state = stateFor(vaultPath);
   const live = new Set<string>(currentNotes);
   let pruned = 0;
@@ -484,7 +535,7 @@ export function snapshotForTests(vaultPath: string): {
 export function cosineSimilarity(a: number[], b: number[]): number {
   if (a.length !== b.length) {
     throw new Error(
-      `cosineSimilarity: dimension mismatch (a.length=${a.length}, b.length=${b.length})`,
+      `cosineSimilarity: dimension mismatch (a.length=${a.length}, b.length=${b.length})`
     );
   }
   if (a.length === 0) return 0;
@@ -523,7 +574,10 @@ export interface SearchOptions {
 
 function normalizeSearchFolder(folder: string | undefined): string | null {
   if (!folder) return null;
-  const slashed = folder.trim().replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+  const slashed = folder
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^\/+|\/+$/g, "");
   if (!slashed) return null;
   const normalized = path.posix.normalize(slashed).replace(/^\/+|\/+$/g, "");
   if (normalized === "." || normalized === "") return null;
@@ -534,7 +588,7 @@ function normalizeSearchFolder(folder: string | undefined): string | null {
 export function searchEmbeddings(
   vaultPath: string,
   queryVector: number[],
-  options: SearchOptions = {},
+  options: SearchOptions = {}
 ): SearchHit[] {
   const state = stateFor(vaultPath);
   const limit = options.limit ?? 10;
@@ -545,7 +599,8 @@ export function searchEmbeddings(
   const hits: SearchHit[] = [];
   for (const entry of state.byKey.values()) {
     if (folder !== null) {
-      if (entry.notePath !== folder && !entry.notePath.startsWith(folder + "/")) continue;
+      if (entry.notePath !== folder && !entry.notePath.startsWith(folder + "/"))
+        continue;
     }
     if (exclude && exclude.has(entry.notePath)) continue;
     if (filterNote && !filterNote(entry.notePath)) continue;
@@ -572,14 +627,16 @@ export function searchEmbeddings(
       if (h.score > existing.best.score) existing.best = h;
     }
   }
-  const out = Array.from(byNote.values()).map(({ best, scores }) => {
-    const score = noteFocusScore(scores);
-    return { ...best, score };
-  }).sort((a, b) => {
-    const scoreDelta = b.score - a.score;
-    if (scoreDelta !== 0) return scoreDelta;
-    return a.notePath.localeCompare(b.notePath);
-  });
+  const out = Array.from(byNote.values())
+    .map(({ best, scores }) => {
+      const score = noteFocusScore(scores);
+      return { ...best, score };
+    })
+    .sort((a, b) => {
+      const scoreDelta = b.score - a.score;
+      if (scoreDelta !== 0) return scoreDelta;
+      return a.notePath.localeCompare(b.notePath);
+    });
   return out.slice(0, limit);
 }
 
@@ -591,7 +648,9 @@ function noteFocusScore(scores: number[]): number {
   return NOTE_BEST_CHUNK_WEIGHT * best + NOTE_FOCUS_WEIGHT * focus;
 }
 
-export function buildSimilarNotesQueryVector(chunks: readonly ChunkEmbedding[]): number[] {
+export function buildSimilarNotesQueryVector(
+  chunks: readonly ChunkEmbedding[]
+): number[] {
   const firstChunk = chunks[0];
   if (!firstChunk) return [];
 
@@ -601,10 +660,17 @@ export function buildSimilarNotesQueryVector(chunks: readonly ChunkEmbedding[]):
   let totalWeight = 0;
 
   for (const chunk of chunks) {
-    const anchorSimilarity = Math.max(0, cosineSimilarity(anchor, chunk.vector));
-    const weight = chunk === firstChunk
-      ? 1
-      : Math.max(SIMILAR_SOURCE_MIN_CHUNK_WEIGHT, anchorSimilarity ** SIMILAR_SOURCE_ANCHOR_POWER);
+    const anchorSimilarity = Math.max(
+      0,
+      cosineSimilarity(anchor, chunk.vector)
+    );
+    const weight =
+      chunk === firstChunk
+        ? 1
+        : Math.max(
+            SIMILAR_SOURCE_MIN_CHUNK_WEIGHT,
+            anchorSimilarity ** SIMILAR_SOURCE_ANCHOR_POWER
+          );
     for (let d = 0; d < dim; d++) {
       out[d] = out[d]! + chunk.vector[d]! * weight;
     }
@@ -619,7 +685,10 @@ export function buildSimilarNotesQueryVector(chunks: readonly ChunkEmbedding[]):
 }
 
 /** Get the embeddings owned by a specific note (used by find_similar). */
-export function getNoteEmbeddings(vaultPath: string, notePath: string): ChunkEmbedding[] {
+export function getNoteEmbeddings(
+  vaultPath: string,
+  notePath: string
+): ChunkEmbedding[] {
   const state = stateFor(vaultPath);
   const owned = state.byNote.get(notePath);
   if (!owned) return [];

--- a/src/lib/index-cache.ts
+++ b/src/lib/index-cache.ts
@@ -58,22 +58,15 @@ interface VaultCacheState {
   entries: Map<string, CacheEntry>;
   /** True once we've attempted legacy snapshot cleanup for this vault. */
   loaded: boolean;
-  /** True when entries have changed since the last legacy cleanup. */
-  dirty: boolean;
 }
 
 const caches = new Map<string, VaultCacheState>(); // vaultRoot -> state
-
-export function isPersistenceEnabled(): boolean {
-  const v = process.env.OBSIDIAN_CACHE_DISABLED;
-  return !(v === "1" || v === "true" || v === "yes");
-}
 
 function stateFor(vaultPath: string): VaultCacheState {
   const key = path.resolve(vaultPath);
   let s = caches.get(key);
   if (!s) {
-    s = { entries: new Map(), loaded: false, dirty: false };
+    s = { entries: new Map(), loaded: false };
     caches.set(key, s);
   }
   return s;
@@ -83,7 +76,10 @@ async function cacheFilePath(vaultPath: string): Promise<string> {
   return resolveVaultInternalPathSafe(vaultPath, CACHE_REL_PATH);
 }
 
-async function loadFromDisk(vaultPath: string, state: VaultCacheState): Promise<void> {
+async function loadFromDisk(
+  vaultPath: string,
+  state: VaultCacheState
+): Promise<void> {
   if (state.loaded) return;
   state.loaded = true;
   await removeLegacySnapshot(vaultPath);
@@ -94,7 +90,9 @@ async function removeLegacySnapshot(vaultPath: string): Promise<void> {
   try {
     file = await cacheFilePath(vaultPath);
   } catch (err) {
-    log.warn("index-cache: snapshot path failed vault-boundary check", { err: err as Error });
+    log.warn("index-cache: snapshot path failed vault-boundary check", {
+      err: err as Error,
+    });
     return;
   }
   try {
@@ -102,16 +100,14 @@ async function removeLegacySnapshot(vaultPath: string): Promise<void> {
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code !== "ENOENT") {
-      log.warn("index-cache: failed to remove legacy snapshot", { file, err: err as Error });
+      log.warn("index-cache: failed to remove legacy snapshot", {
+        file,
+        err: err as Error,
+      });
     }
     return;
   }
   log.debug("index-cache: removed legacy persistent snapshot", { file });
-}
-
-async function flushVaultCache(vaultPath: string, state: VaultCacheState): Promise<void> {
-  state.dirty = false;
-  await removeLegacySnapshot(vaultPath);
 }
 
 export interface ReadAllResult {
@@ -137,7 +133,7 @@ export interface ReadAllResult {
 export async function readAllCached(
   vaultPath: string,
   relPaths: readonly string[],
-  onError?: (relPath: string, err: Error) => void,
+  onError?: (relPath: string, err: Error) => void
 ): Promise<ReadAllResult> {
   const state = stateFor(vaultPath);
   await loadFromDisk(vaultPath, state);
@@ -155,7 +151,9 @@ export async function readAllCached(
     let fullPath: string;
     let opened: Awaited<ReturnType<typeof openVaultFileForRead>> | undefined;
     try {
-      opened = await openVaultFileForRead(vaultPath, relPath, "read", { realVaultRoot });
+      opened = await openVaultFileForRead(vaultPath, relPath, "read", {
+        realVaultRoot,
+      });
       fullPath = opened.fullPath;
     } catch (err) {
       onError?.(relPath, err as Error);
@@ -178,7 +176,7 @@ export async function readAllCached(
       await openedFile.handle.close();
       // ENOENT during stat means the file disappeared between listing and
       // reading — drop the cache entry and skip.
-      if (cache.delete(relPath)) state.dirty = true;
+      cache.delete(relPath);
       onError?.(relPath, err as Error);
       return undefined;
     }
@@ -194,13 +192,12 @@ export async function readAllCached(
       content = await openedFile.handle.readFile("utf-8");
     } catch (err) {
       onError?.(relPath, err as Error);
-      if (cache.delete(relPath)) state.dirty = true;
+      cache.delete(relPath);
       return undefined;
     } finally {
       await openedFile.handle.close();
     }
     cache.set(relPath, { fullPath, relPath, content, mtimeMs });
-    state.dirty = true;
     contents.set(relPath, content);
     cacheMisses++;
     return undefined;
@@ -220,46 +217,26 @@ export async function readAllCached(
     } catch {
       // File no longer exists on disk - evict the stale entry.
       cache.delete(key);
-      state.dirty = true;
     }
   });
 
   return { contents, mtimes, stats: statsByPath, cacheHits, cacheMisses };
 }
 
-/** Best-effort cleanup for legacy disk snapshots during shutdown. */
-export async function flushAllCachesAsync(): Promise<void> {
-  await Promise.all(
-    Array.from(caches.entries()).map(async ([vaultRoot, state]) => {
-      try {
-        await flushVaultCache(vaultRoot, state);
-      } catch {
-        // best-effort; we're shutting down
-      }
-    }),
-  );
-}
-
-/** Force immediate legacy snapshot cleanup for a single vault. */
-export async function flushNow(vaultPath: string): Promise<void> {
-  const state = caches.get(path.resolve(vaultPath));
-  if (!state) {
-    await removeLegacySnapshot(vaultPath);
-    return;
-  }
-  await flushVaultCache(vaultPath, state);
-}
-
 /** For tests / hot reload: drop everything cached for a given vault.
  *  Pass `removeSnapshot: true` to also delete a legacy disk snapshot. */
 export async function clearCache(
   vaultPath: string,
-  options?: { removeSnapshot?: boolean },
+  options?: { removeSnapshot?: boolean }
 ): Promise<void> {
   const root = path.resolve(vaultPath);
   caches.delete(root);
   if (options?.removeSnapshot) {
-    try { await fs.unlink(await cacheFilePath(vaultPath)); } catch { /* ignore */ }
+    try {
+      await fs.unlink(await cacheFilePath(vaultPath));
+    } catch {
+      /* ignore */
+    }
   }
 }
 


### PR DESCRIPTION
Architecture review candidate C2: removes dead `state.dirty` + the flush surface, relocates `isPersistenceEnabled` to embedding-store (its only caller), and deletes the shutdown flush wiring. Grounded per issue #253. Verified combined-green with the Wave-1 branches (979 tests); symlink-boundary security test still passes. Closes #253.