### PR TITLE
refactor(tools): migrate attachments group + extend the seam with media constructors

### DIFF
--- a/docs/adr/0001-tool-seam.md
+++ b/docs/adr/0001-tool-seam.md
@@ -1,6 +1,6 @@
 # ADR 0001: One deep tool seam behind every MCP tool
 
-- Status: Accepted (read group migrated as the pattern-setter, then canvas, links, and a Wave-1 fan-out of write/tags/sections/bases; 2 groups to follow: attachments, semantic)
+- Status: Accepted (read group migrated as the pattern-setter, then canvas, links, a Wave-1 fan-out of write/tags/sections/bases, and attachments (which extended the seam with the non-text media constructors); 1 group to follow: semantic)
 - Date: 2026-07-18
 
 ## Context
@@ -60,10 +60,26 @@ Text (used by the read group):
 - `asError(result)` - flag a built result as an error (e.g. an error message
   that carries an untrusted path).
 
-Non-text blocks (to be added when the attachments/canvas groups migrate;
-`get_attachment` is the only multi-type tool): `image`, `audio`, `blobResource`,
-`untrustedResource`. The block taxonomy is closed - no tool uses
-`structuredContent`/`outputSchema`, and every result `_meta` is trust metadata.
+Non-text media (added with the attachments group; `get_attachment` is the only
+multi-type tool). Each returns a server-authored caption text block followed by
+exactly one media block:
+
+- `image(caption, data, mimeType)` / `audio(caption, data, mimeType)` - raw
+  base64 bytes.
+- `blobResource(caption, uri, mimeType, blob)` - raw base64 bytes as a
+  `resource` block under a `vault://` URI.
+- `untrustedResource(caption, label, uri, mimeType, body)` - a `resource` block
+  carrying model-readable _text_ (the SVG-as-text/plain XSS mitigation).
+
+**Why only one of the four wraps.** image/audio/blob carry raw base64 bytes,
+which are not model-readable text - no injection surface, so no wrapping and no
+trust `_meta`. `untrustedResource` is the lone trust-bearing constructor: it
+BEGIN/END-wraps the resource text and attaches the trust `_meta` at BOTH the
+resource and block level, so a client that surfaces either layer sees the
+untrusted tag. This is what keeps the closed taxonomy safe: a media block is
+exempt from wrapping precisely because it is not text a model can be steered by.
+The block taxonomy is closed - no tool uses `structuredContent`/`outputSchema`,
+and every result `_meta` is trust metadata.
 
 ### Context
 
@@ -151,10 +167,12 @@ context arrow (see Consequences). write, tags, sections, and bases then migrated
 together as a parallel Wave-1 fan-out (one worktree-isolated agent per group),
 each following the same idioms and staying byte-preserving except the generic
 `Error:` prefix (exception #1); no group needed a new exception or a seam change.
-Remaining 2 groups are file-disjoint and convert independently: **attachments**
-extends the seam with the non-text block constructors (`image`/`audio`/
-`blobResource`/`untrustedResource`; `get_attachment` is the only multi-type
-tool), and **semantic** carries the `extra`-boundary type-cast caveat (verify
-progress plumbing at runtime). Collapsing the 9 `display*Value` aliases to a
-single `escapeControlChars` import is a follow-up sweep. `TOOL_AUTHORING.md §4`
-is rewritten last, once the pattern is proven across all groups.
+The **attachments** group then migrated and extended the seam with the non-text
+media constructors (see Result vocabulary); `find_unused_attachments` also
+became the first tool to thread `ctx.extra` for progress, guarded now by a
+runtime progress-notification test (the `extra`-boundary the callback cast
+cannot type-check). The one **remaining** group, **semantic**, carries the same
+`extra`-boundary caveat for `index_vault`/`search_semantic` (verify progress
+plumbing at runtime). Collapsing the 9 `display*Value` aliases to a single
+`escapeControlChars` import is a follow-up sweep. `TOOL_AUTHORING.md §4` is
+rewritten last, once the pattern is proven across all groups.

--- a/src/__tests__/handlers/attachments.test.ts
+++ b/src/__tests__/handlers/attachments.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
-import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
+import {
+  createTestEnv,
+  textContent,
+  isError,
+  type TestEnv,
+} from "./harness.js";
 
 let env: TestEnv;
 const itWin32 = process.platform === "win32" ? it : it.skip;
-const SYMLINKS_SUPPORTED = process.platform !== "win32" || process.env.CI_SYMLINKS === "1";
+const SYMLINKS_SUPPORTED =
+  process.platform !== "win32" || process.env.CI_SYMLINKS === "1";
 const itSymlink = SYMLINKS_SUPPORTED ? it : it.skip;
 
 beforeEach(async () => {
@@ -16,7 +22,7 @@ beforeEach(async () => {
       "assets/screenshot.jpg": "JPEG-fake-bytes",
       "assets/notes.pdf": "PDF-fake",
       "assets/page.html": "<script>alert(1)</script>",
-      "assets/feed.xml": "<?xml version=\"1.0\"?><feed />",
+      "assets/feed.xml": '<?xml version="1.0"?><feed />',
       "assets/theme.css": "body { background: red; }",
       "assets/vector.svg": [
         "<svg>",
@@ -25,7 +31,8 @@ beforeEach(async () => {
       ].join("\n"),
       "assets/.env": "TOKEN=hidden",
       "assets/.private/private-image.png": "PNG-hidden-dir",
-      "embed-host.md": "# Embed host\n\n![[used-image.png]]\n\nAlso linked: [doc](assets/notes.pdf)\n",
+      "embed-host.md":
+        "# Embed host\n\n![[used-image.png]]\n\nAlso linked: [doc](assets/notes.pdf)\n",
     },
   });
 });
@@ -47,9 +54,18 @@ describe("attachments handlers — list_attachments", () => {
     expect(text).toMatch(/orphan-image\.png/);
     expect(text).toMatch(/screenshot\.jpg/);
     expect(text).toMatch(/notes\.pdf/);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: list_attachments paths]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: list_attachments extensions]");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: list_attachments paths]"
+    );
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: list_attachments extensions]"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "list_attachments extensions and paths"
+    );
     // Markdown notes never appear in attachment listings.
     expect(text).not.toMatch(/embed-host\.md/);
     // Hidden dotfiles are skipped by the inventory and direct reads.
@@ -108,10 +124,17 @@ describe("attachments handlers — list_attachments", () => {
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
 
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: list_attachments extensions]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: list_attachments extensions]"
+    );
     expect(text).toContain(".prompt  1");
     expect(text).toContain("- assets/dirty.prompt");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "list_attachments extensions and paths"
+    );
   });
 });
 
@@ -130,15 +153,42 @@ describe("attachments handlers — find_unused_attachments", () => {
     // orphan-image.png and screenshot.jpg have no references at all.
     expect(text).toMatch(/orphan-image\.png/);
     expect(text).toMatch(/screenshot\.jpg/);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_unused_attachments paths]");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_unused_attachments paths]"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "find_unused_attachments paths"
+    );
+  });
+
+  it("streams progress notifications through the seam's ctx.extra boundary", async () => {
+    // find_unused_attachments builds makeProgressReporter(ctx.extra) and emits
+    // via extra.sendNotification while scanning notes. The seam casts its
+    // callback, so tsc cannot catch a mis-threaded extra - this test pins that
+    // progress still fires end-to-end after the migration.
+    const messages: string[] = [];
+    const result = await env.client.callTool(
+      { name: "find_unused_attachments", arguments: {} },
+      undefined,
+      {
+        onprogress: (progress) => {
+          if (progress.message) messages.push(progress.message);
+        },
+      }
+    );
+    expect(isError(result)).toBe(false);
+    expect(messages.length).toBeGreaterThan(0);
+    expect(messages.some((m) => /Scanned \d+\/\d+ notes/.test(m))).toBe(true);
   });
 
   it("does not treat remote markdown URLs as local attachment references", async () => {
     await fs.appendFile(
       path.join(env.vaultDir, "embed-host.md"),
       "\nRemote-only image: [remote](https://cdn.example/assets/orphan-image.png)\n",
-      "utf-8",
+      "utf-8"
     );
 
     const result = await env.client.callTool({
@@ -195,7 +245,11 @@ describe("attachments handlers — find_unused_attachments", () => {
     expect(textContent(first)).toMatch(/orphan-image\.png/);
 
     const notePath = path.join(env.vaultDir, "embed-host.md");
-    await fs.appendFile(notePath, "\nNow referenced: ![[orphan-image.png]]\n", "utf-8");
+    await fs.appendFile(
+      notePath,
+      "\nNow referenced: ![[orphan-image.png]]\n",
+      "utf-8"
+    );
     const future = new Date(Date.now() + 5_000);
     await fs.utimes(notePath, future, future);
 
@@ -232,7 +286,9 @@ describe("attachments handlers — find_unused_attachments", () => {
       name: "find_unused_attachments",
       arguments: {},
     });
-    expect(textContent(result)).toMatch(/All \d+ attachment\(s\) are referenced/);
+    expect(textContent(result)).toMatch(
+      /All \d+ attachment\(s\) are referenced/
+    );
   });
 });
 
@@ -243,11 +299,17 @@ describe("attachments handlers — get_attachment", () => {
       arguments: { path: "assets/used-image.png" },
     });
     expect(isError(result)).toBe(false);
-    const blocks = (result.content as Array<{ type: string; data?: string; mimeType?: string }>);
+    const blocks = result.content as Array<{
+      type: string;
+      data?: string;
+      mimeType?: string;
+    }>;
     const imageBlock = blocks.find((b) => b.type === "image");
     expect(imageBlock).toBeDefined();
     expect(imageBlock!.mimeType).toBe("image/png");
-    expect(imageBlock!.data).toBe(Buffer.from("PNG-fake-bytes").toString("base64"));
+    expect(imageBlock!.data).toBe(
+      Buffer.from("PNG-fake-bytes").toString("base64")
+    );
   });
 
   it("returns a resource block for non-image/audio types", async () => {
@@ -256,7 +318,10 @@ describe("attachments handlers — get_attachment", () => {
       arguments: { path: "assets/notes.pdf" },
     });
     expect(isError(result)).toBe(false);
-    const blocks = result.content as Array<{ type: string; resource?: { uri?: string; mimeType?: string } }>;
+    const blocks = result.content as Array<{
+      type: string;
+      resource?: { uri?: string; mimeType?: string };
+    }>;
     const resourceBlock = blocks.find((b) => b.type === "resource");
     expect(resourceBlock).toBeDefined();
     expect(resourceBlock!.resource!.mimeType).toBe("application/pdf");
@@ -295,25 +360,40 @@ describe("attachments handlers — get_attachment", () => {
     const blocks = result.content as Array<{
       type: string;
       _meta?: Record<string, unknown>;
-      resource?: { uri?: string; mimeType?: string; text?: string; _meta?: Record<string, unknown> };
+      resource?: {
+        uri?: string;
+        mimeType?: string;
+        text?: string;
+        _meta?: Record<string, unknown>;
+      };
     }>;
     const resourceBlock = blocks.find((b) => b.type === "resource");
     expect(resourceBlock).toBeDefined();
-    expect(resourceBlock!._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
-    expect(resourceBlock!._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("get_attachment text");
-    expect(resourceBlock!.resource!._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
-    expect(resourceBlock!.resource!._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("get_attachment text");
+    expect(resourceBlock!._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(
+      resourceBlock!._meta?.["obsidian-mcp-pro/untrustedContentLabel"]
+    ).toBe("get_attachment text");
+    expect(
+      resourceBlock!.resource!._meta?.["obsidian-mcp-pro/contentTrust"]
+    ).toBe("untrusted-vault-content");
+    expect(
+      resourceBlock!.resource!._meta?.["obsidian-mcp-pro/untrustedContentLabel"]
+    ).toBe("get_attachment text");
     expect(resourceBlock!.resource!.mimeType).toBe("text/plain");
     expect(resourceBlock!.resource!.text).toContain(
-      "[BEGIN UNTRUSTED VAULT CONTENT: get_attachment text]",
+      "[BEGIN UNTRUSTED VAULT CONTENT: get_attachment text]"
     );
     expect(resourceBlock!.resource!.text).not.toContain(
-      "[BEGIN UNTRUSTED VAULT CONTENT: attachment text: assets/vector.svg]",
+      "[BEGIN UNTRUSTED VAULT CONTENT: attachment text: assets/vector.svg]"
     );
     expect(resourceBlock!.resource!.text).toContain(
-      "[VAULT TEXT MARKER ESCAPED: END UNTRUSTED VAULT CONTENT: attachment text: assets/vector.svg]",
+      "[VAULT TEXT MARKER ESCAPED: END UNTRUSTED VAULT CONTENT: attachment text: assets/vector.svg]"
     );
-    expect(resourceBlock!.resource!.text!.match(/^\[END UNTRUSTED VAULT CONTENT:/gm)).toHaveLength(1);
+    expect(
+      resourceBlock!.resource!.text!.match(/^\[END UNTRUSTED VAULT CONTENT:/gm)
+    ).toHaveLength(1);
   });
 
   it("rejects markdown / canvas / base files", async () => {
@@ -325,16 +405,19 @@ describe("attachments handlers — get_attachment", () => {
     expect(textContent(md)).toMatch(/use get_note/i);
   });
 
-  itWin32("rejects trailing-dot aliases before attachment classification", async () => {
-    const result = await env.client.callTool({
-      name: "get_attachment",
-      arguments: { path: "embed-host.md." },
-    });
-    expect(isError(result)).toBe(true);
-    const text = textContent(result);
-    expect(text).toMatch(/space or period|windows normalizes/i);
-    expect(text).not.toContain("Embed host");
-  });
+  itWin32(
+    "rejects trailing-dot aliases before attachment classification",
+    async () => {
+      const result = await env.client.callTool({
+        name: "get_attachment",
+        arguments: { path: "embed-host.md." },
+      });
+      expect(isError(result)).toBe(true);
+      const text = textContent(result);
+      expect(text).toMatch(/space or period|windows normalizes/i);
+      expect(text).not.toContain("Embed host");
+    }
+  );
 
   it("escapes control characters in rejected text-format paths", async () => {
     const result = await env.client.callTool({
@@ -376,8 +459,12 @@ describe("attachments handlers — get_attachment", () => {
     });
     expect(isError(result)).toBe(true);
     const text = textContent(result);
-    expect(text).toContain('Refusing to fetch hidden attachment "assets/.private/private-image.png"');
-    expect(text).not.toContain(Buffer.from("PNG-hidden-dir").toString("base64"));
+    expect(text).toContain(
+      'Refusing to fetch hidden attachment "assets/.private/private-image.png"'
+    );
+    expect(text).not.toContain(
+      Buffer.from("PNG-hidden-dir").toString("base64")
+    );
   });
 
   it("rejects directory attachment paths before reading bytes", async () => {
@@ -390,63 +477,78 @@ describe("attachments handlers — get_attachment", () => {
 
     expect(isError(result)).toBe(true);
     const text = textContent(result);
-    expect(text).toContain('Attachment "assets/not-file.bin" is not a regular file.');
-  });
-
-  itSymlink("rejects symlinked attachment files skipped by the inventory", async () => {
-    await fs.symlink(
-      path.join(env.vaultDir, "assets", "used-image.png"),
-      path.join(env.vaultDir, "assets", "linked-image.png"),
-      process.platform === "win32" ? "file" : undefined,
+    expect(text).toContain(
+      'Attachment "assets/not-file.bin" is not a regular file.'
     );
-
-    const listed = await env.client.callTool({
-      name: "list_attachments",
-      arguments: {},
-    });
-    expect(textContent(listed)).not.toMatch(/linked-image\.png/);
-
-    const result = await env.client.callTool({
-      name: "get_attachment",
-      arguments: { path: "assets/linked-image.png" },
-    });
-    expect(isError(result)).toBe(true);
-    const text = textContent(result);
-    expect(text).toContain("Refusing to fetch symlink attachment");
-    expect(text).not.toContain(Buffer.from("PNG-fake-bytes").toString("base64"));
   });
 
-  itSymlink("rejects symlinked attachment directories skipped by the inventory", async () => {
-    await fs.symlink(
-      path.join(env.vaultDir, "assets"),
-      path.join(env.vaultDir, "linked-assets"),
-      process.platform === "win32" ? "junction" : "dir",
-    );
+  itSymlink(
+    "rejects symlinked attachment files skipped by the inventory",
+    async () => {
+      await fs.symlink(
+        path.join(env.vaultDir, "assets", "used-image.png"),
+        path.join(env.vaultDir, "assets", "linked-image.png"),
+        process.platform === "win32" ? "file" : undefined
+      );
 
-    const listed = await env.client.callTool({
-      name: "list_attachments",
-      arguments: {},
-    });
-    expect(textContent(listed)).not.toMatch(/linked-assets/);
+      const listed = await env.client.callTool({
+        name: "list_attachments",
+        arguments: {},
+      });
+      expect(textContent(listed)).not.toMatch(/linked-image\.png/);
 
-    const result = await env.client.callTool({
-      name: "get_attachment",
-      arguments: { path: "linked-assets/used-image.png" },
-    });
-    expect(isError(result)).toBe(true);
-    const text = textContent(result);
-    expect(text).toContain("Refusing to fetch symlink attachment");
-    expect(text).not.toContain(Buffer.from("PNG-fake-bytes").toString("base64"));
-  });
+      const result = await env.client.callTool({
+        name: "get_attachment",
+        arguments: { path: "assets/linked-image.png" },
+      });
+      expect(isError(result)).toBe(true);
+      const text = textContent(result);
+      expect(text).toContain("Refusing to fetch symlink attachment");
+      expect(text).not.toContain(
+        Buffer.from("PNG-fake-bytes").toString("base64")
+      );
+    }
+  );
 
-  itWin32("rejects Windows alternate data stream attachment paths", async () => {
-    const result = await env.client.callTool({
-      name: "get_attachment",
-      arguments: { path: "assets/used-image.png:hidden.txt" },
-    });
-    expect(isError(result)).toBe(true);
-    expect(textContent(result)).toMatch(/alternate data stream/i);
-  });
+  itSymlink(
+    "rejects symlinked attachment directories skipped by the inventory",
+    async () => {
+      await fs.symlink(
+        path.join(env.vaultDir, "assets"),
+        path.join(env.vaultDir, "linked-assets"),
+        process.platform === "win32" ? "junction" : "dir"
+      );
+
+      const listed = await env.client.callTool({
+        name: "list_attachments",
+        arguments: {},
+      });
+      expect(textContent(listed)).not.toMatch(/linked-assets/);
+
+      const result = await env.client.callTool({
+        name: "get_attachment",
+        arguments: { path: "linked-assets/used-image.png" },
+      });
+      expect(isError(result)).toBe(true);
+      const text = textContent(result);
+      expect(text).toContain("Refusing to fetch symlink attachment");
+      expect(text).not.toContain(
+        Buffer.from("PNG-fake-bytes").toString("base64")
+      );
+    }
+  );
+
+  itWin32(
+    "rejects Windows alternate data stream attachment paths",
+    async () => {
+      const result = await env.client.callTool({
+        name: "get_attachment",
+        arguments: { path: "assets/used-image.png:hidden.txt" },
+      });
+      expect(isError(result)).toBe(true);
+      expect(textContent(result)).toMatch(/alternate data stream/i);
+    }
+  );
 
   it("enforces the maxBytes cap", async () => {
     const result = await env.client.callTool({

--- a/src/__tests__/tool-seam.test.ts
+++ b/src/__tests__/tool-seam.test.ts
@@ -5,10 +5,14 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
   asError,
+  audio,
+  blobResource,
   defineTool,
   error,
+  image,
   richText,
   text,
+  untrustedResource,
   untrustedText,
 } from "../lib/tool-seam.js";
 import {
@@ -85,6 +89,104 @@ describe("tool-seam vocabulary", () => {
     expect(flags(result).isError).toBe(true);
     expect(firstItem(result)._meta).toEqual(
       untrustedVaultContentMeta("expected path")
+    );
+  });
+});
+
+describe("tool-seam media vocabulary", () => {
+  // The media constructors return a caption text block followed by exactly one
+  // media block; read the [0] caption and [1] media block.
+  type Block = {
+    type: string;
+    text?: string;
+    data?: string;
+    mimeType?: string;
+    resource?: {
+      uri?: string;
+      mimeType?: string;
+      blob?: string;
+      text?: string;
+      _meta?: Record<string, unknown>;
+    };
+    _meta?: Record<string, unknown>;
+  };
+  function blocks(result: unknown): Block[] {
+    return (result as { content: Block[] }).content;
+  }
+
+  it("image = caption text block + raw image block, no trust _meta", () => {
+    const [caption, media] = blocks(
+      image("Attached: a.png (image/png, 3 bytes)", "AAA", "image/png")
+    );
+    expect(caption).toEqual({
+      type: "text",
+      text: "Attached: a.png (image/png, 3 bytes)",
+    });
+    expect(media).toEqual({
+      type: "image",
+      data: "AAA",
+      mimeType: "image/png",
+    });
+    expect(media._meta).toBeUndefined();
+  });
+
+  it("audio = caption text block + raw audio block, no trust _meta", () => {
+    const [caption, media] = blocks(
+      audio("Attached: a.mp3 (audio/mpeg, 3 bytes)", "BBB", "audio/mpeg")
+    );
+    expect(caption.text).toBe("Attached: a.mp3 (audio/mpeg, 3 bytes)");
+    expect(media).toEqual({
+      type: "audio",
+      data: "BBB",
+      mimeType: "audio/mpeg",
+    });
+    expect(media._meta).toBeUndefined();
+  });
+
+  it("blobResource = caption + a blob resource under a vault:// uri, no trust _meta", () => {
+    const [caption, media] = blocks(
+      blobResource(
+        "Attached: a.pdf (application/pdf, 3 bytes)",
+        "vault://a.pdf",
+        "application/pdf",
+        "CCC"
+      )
+    );
+    expect(caption.type).toBe("text");
+    expect(media.type).toBe("resource");
+    expect(media.resource).toEqual({
+      uri: "vault://a.pdf",
+      mimeType: "application/pdf",
+      blob: "CCC",
+    });
+    expect(media._meta).toBeUndefined();
+    expect(media.resource!._meta).toBeUndefined();
+  });
+
+  it("untrustedResource wraps the resource text and double-tags trust _meta", () => {
+    const [caption, media] = blocks(
+      untrustedResource(
+        "Attached: a.svg (text)",
+        "get_attachment text",
+        "vault://a.svg",
+        "text/plain",
+        "<svg/>"
+      )
+    );
+    expect(caption.type).toBe("text");
+    expect(media.type).toBe("resource");
+    expect(media.resource!.uri).toBe("vault://a.svg");
+    expect(media.resource!.mimeType).toBe("text/plain");
+    // Resource text is BEGIN/END-wrapped, not raw.
+    expect(media.resource!.text).toBe(
+      formatUntrustedVaultContent("get_attachment text", "<svg/>")
+    );
+    // Trust _meta is attached at BOTH the resource and block level.
+    expect(media.resource!._meta).toEqual(
+      untrustedVaultContentMeta("get_attachment text")
+    );
+    expect(media._meta).toEqual(
+      untrustedVaultContentMeta("get_attachment text")
     );
   });
 });

--- a/src/lib/tool-seam.ts
+++ b/src/lib/tool-seam.ts
@@ -107,6 +107,91 @@ export function asError(result: ToolResult): ToolResult {
   return seal({ ...(result as CallToolResult), isError: true });
 }
 
+// Non-text media results. `get_attachment` is the only multi-type tool: it
+// returns a server-authored caption text block followed by exactly one media
+// block. Raw base64 bytes (`image`/`audio`/`blobResource`) are NOT model-readable
+// text, so there is no injection surface and they carry no trust `_meta` — only
+// `untrustedResource`, which surfaces model-readable text, wraps and tags. The
+// block taxonomy is closed; see docs/adr/0001-tool-seam.md.
+
+/** A caption text block plus an `image` content block carrying raw base64 bytes. */
+export function image(
+  caption: string,
+  data: string,
+  mimeType: string
+): ToolResult {
+  return seal({
+    content: [
+      { type: "text", text: caption },
+      { type: "image", data, mimeType },
+    ],
+  });
+}
+
+/** A caption text block plus an `audio` content block carrying raw base64 bytes. */
+export function audio(
+  caption: string,
+  data: string,
+  mimeType: string
+): ToolResult {
+  return seal({
+    content: [
+      { type: "text", text: caption },
+      { type: "audio", data, mimeType },
+    ],
+  });
+}
+
+/**
+ * A caption text block plus a `resource` block carrying raw base64 `blob` bytes
+ * under a `vault://` URI. Like image/audio, blobs are not model-readable text
+ * and carry no trust `_meta`.
+ */
+export function blobResource(
+  caption: string,
+  uri: string,
+  mimeType: string,
+  blob: string
+): ToolResult {
+  return seal({
+    content: [
+      { type: "text", text: caption },
+      { type: "resource", resource: { uri, mimeType, blob } },
+    ],
+  });
+}
+
+/**
+ * A caption text block plus a `resource` block carrying model-readable *text*
+ * (e.g. an SVG served as text/plain for XSS safety). The only non-text
+ * constructor that wraps: the resource text is BEGIN/END-wrapped and the trust
+ * `_meta` is attached at BOTH the resource and the block level, so a client that
+ * surfaces either layer still sees the untrusted tag.
+ */
+export function untrustedResource(
+  caption: string,
+  label: string,
+  uri: string,
+  mimeType: string,
+  body: string
+): ToolResult {
+  return seal({
+    content: [
+      { type: "text", text: caption },
+      {
+        type: "resource",
+        resource: {
+          uri,
+          mimeType,
+          text: formatUntrustedVaultContent(label, body),
+          _meta: untrustedVaultContentMeta(label),
+        },
+        _meta: untrustedVaultContentMeta(label),
+      },
+    ],
+  });
+}
+
 /**
  * Builder for a single text block that interleaves server-authored framing with
  * inline untrusted vault-content sections. `trusted` appends framing verbatim;

--- a/src/tools/attachments/find_unused_attachments.ts
+++ b/src/tools/attachments/find_unused_attachments.ts
@@ -15,15 +15,9 @@ import {
   extractWikilinkSpans,
   extractMarkdownLinkSpans,
 } from "../../lib/markdown.js";
-import { sanitizeError } from "../../lib/errors.js";
 import { log } from "../../lib/logger.js";
-import {
-  textResult,
-  textResultWithUntrustedMeta,
-  errorResult,
-  displayAttachmentValue,
-  untrustedAttachmentBlock,
-} from "./shared.js";
+import { defineTool, text, richText } from "../../lib/tool-seam.js";
+import { displayAttachmentValue } from "./shared.js";
 
 const ATTACHMENT_INVENTORY_CACHE_LIMIT = 8;
 
@@ -33,7 +27,10 @@ interface AttachmentInventoryCacheEntry {
   referenced: Set<string>;
 }
 
-const attachmentInventoryCache = new Map<string, AttachmentInventoryCacheEntry>();
+const attachmentInventoryCache = new Map<
+  string,
+  AttachmentInventoryCacheEntry
+>();
 
 function isExternalMarkdownTarget(target: string): boolean {
   if (target.startsWith("//")) return true;
@@ -67,7 +64,7 @@ function normalizeLocalMarkdownTarget(target: string): string {
 function collectReferencedAttachments(
   noteContent: string,
   lowerPathIndex: ReadonlyMap<string, string>,
-  basenameIndex: ReadonlyMap<string, string[]>,
+  basenameIndex: ReadonlyMap<string, string[]>
 ): { resolved: Set<string>; unresolved: string[] } {
   const resolved = new Set<string>();
   const unresolved: string[] = [];
@@ -77,7 +74,7 @@ function collectReferencedAttachments(
     if (isExternalMarkdownTarget(trimmedTarget)) return;
 
     const t = normalizeLocalMarkdownTarget(
-      trimmedTarget.split("#")[0]!.split("^")[0]!.trim(),
+      trimmedTarget.split("#")[0]!.split("^")[0]!.trim()
     );
     if (!t) return;
 
@@ -122,7 +119,7 @@ function attachmentListFingerprint(attachments: readonly string[]): string {
 function noteMtimeFingerprint(
   notes: readonly string[],
   contents: ReadonlyMap<string, string>,
-  mtimes: ReadonlyMap<string, number>,
+  mtimes: ReadonlyMap<string, number>
 ): string {
   return notes
     .map((notePath) => {
@@ -134,7 +131,7 @@ function noteMtimeFingerprint(
 
 async function noteStatsFingerprint(
   vaultPath: string,
-  notes: readonly string[],
+  notes: readonly string[]
 ): Promise<string | undefined> {
   const realVaultRoot = await getVaultRootRealPath(vaultPath);
   const parts = await mapConcurrent(
@@ -142,12 +139,14 @@ async function noteStatsFingerprint(
     16,
     async (notePath): Promise<string | undefined> => {
       try {
-        const stats = await getNoteStats(vaultPath, notePath, { realVaultRoot });
+        const stats = await getNoteStats(vaultPath, notePath, {
+          realVaultRoot,
+        });
         return `${notePath}\0${stats.modified?.getTime() ?? 0}`;
       } catch {
         return undefined;
       }
-    },
+    }
   );
   if (parts.some((part) => part === undefined)) return undefined;
   return parts.join("\0");
@@ -159,7 +158,11 @@ async function getCachedAttachmentInventory(
   notes: readonly string[],
   contents: ReadonlyMap<string, string>,
   mtimes: ReadonlyMap<string, number>,
-  reportProgress: (progress: number, total: number, message?: string) => Promise<void>,
+  reportProgress: (
+    progress: number,
+    total: number,
+    message?: string
+  ) => Promise<void>
 ): Promise<AttachmentInventoryCacheEntry> {
   const attachmentsFingerprint = attachmentListFingerprint(attachments);
   const noteFingerprint = noteMtimeFingerprint(notes, contents, mtimes);
@@ -168,7 +171,8 @@ async function getCachedAttachmentInventory(
   const lowerPathIndex = new Map<string, string>();
   const basenameIndex = new Map<string, string[]>();
   for (const p of attachments) {
-    if (!lowerPathIndex.has(p.toLowerCase())) lowerPathIndex.set(p.toLowerCase(), p);
+    if (!lowerPathIndex.has(p.toLowerCase()))
+      lowerPathIndex.set(p.toLowerCase(), p);
     const base = path.basename(p).toLowerCase();
     const list = basenameIndex.get(base);
     if (list) list.push(p);
@@ -180,11 +184,19 @@ async function getCachedAttachmentInventory(
   for (const notePath of notes) {
     const content = contents.get(notePath);
     if (content !== undefined) {
-      const { resolved } = collectReferencedAttachments(content, lowerPathIndex, basenameIndex);
+      const { resolved } = collectReferencedAttachments(
+        content,
+        lowerPathIndex,
+        basenameIndex
+      );
       for (const r of resolved) referenced.add(r);
     }
     scanned++;
-    await reportProgress(scanned, notes.length, `Scanned ${scanned}/${notes.length} notes`);
+    await reportProgress(
+      scanned,
+      notes.length,
+      `Scanned ${scanned}/${notes.length} notes`
+    );
   }
 
   const fresh = { attachmentsFingerprint, noteFingerprint, referenced };
@@ -201,15 +213,25 @@ async function getReusableAttachmentInventory(
   vaultPath: string,
   attachments: readonly string[],
   notes: readonly string[],
-  reportProgress: (progress: number, total: number, message?: string) => Promise<void>,
+  reportProgress: (
+    progress: number,
+    total: number,
+    message?: string
+  ) => Promise<void>
 ): Promise<AttachmentInventoryCacheEntry | undefined> {
   const cacheKey = path.resolve(vaultPath);
   const cached = attachmentInventoryCache.get(cacheKey);
-  if (!cached || cached.attachmentsFingerprint !== attachmentListFingerprint(attachments)) {
+  if (
+    !cached ||
+    cached.attachmentsFingerprint !== attachmentListFingerprint(attachments)
+  ) {
     return undefined;
   }
   const currentNoteFingerprint = await noteStatsFingerprint(vaultPath, notes);
-  if (currentNoteFingerprint === undefined || currentNoteFingerprint !== cached.noteFingerprint) {
+  if (
+    currentNoteFingerprint === undefined ||
+    currentNoteFingerprint !== cached.noteFingerprint
+  ) {
     return undefined;
   }
   attachmentInventoryCache.delete(cacheKey);
@@ -217,15 +239,24 @@ async function getReusableAttachmentInventory(
   let scanned = 0;
   for (const _notePath of notes) {
     scanned++;
-    await reportProgress(scanned, notes.length, `Scanned ${scanned}/${notes.length} notes`);
+    await reportProgress(
+      scanned,
+      notes.length,
+      `Scanned ${scanned}/${notes.length} notes`
+    );
   }
   return cached;
 }
 
-export function registerFindUnusedAttachments(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "find_unused_attachments",
+export function registerFindUnusedAttachments(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "find_unused_attachments",
       title: "Find Unused Attachments",
       description:
         "Locate attachments that no note references — neither via `![[file]]` embeds nor `[text](file)` markdown links. Useful for vault hygiene before archiving or before running a sync. Pair the output with `delete` operations from your shell, since this tool deliberately doesn't unlink files.",
@@ -242,91 +273,102 @@ export function registerFindUnusedAttachments(server: McpServer, vaultPath: stri
           .max(10000)
           .optional()
           .default(200)
-          .describe("Maximum number of unused-attachment paths to return (1-10000, default: 200). Total counts are still reported."),
+          .describe(
+            "Maximum number of unused-attachment paths to return (1-10000, default: 200). Total counts are still reported."
+          ),
         includeBytes: z
           .boolean()
           .optional()
           .default(false)
-          .describe("If true, also stat each unused attachment and report total reclaimable bytes."),
+          .describe(
+            "If true, also stat each unused attachment and report total reclaimable bytes."
+          ),
       },
     },
-    async ({ limit, includeBytes }, extra) => {
-      try {
-        const reportProgress = makeProgressReporter(extra);
-        const attachments = await listAttachments(vaultPath);
-        if (attachments.length === 0) {
-          return textResult("No attachments in this vault — nothing to check.");
-        }
-        const notes = await listNotes(vaultPath);
-        await reportProgress(0, notes.length, "Reading notes…");
-        let inventory = await getReusableAttachmentInventory(vaultPath, attachments, notes, reportProgress);
-        if (!inventory) {
-          const { contents, mtimes } = await readAllCached(vaultPath, notes, (note, err) => {
-            log.warn("find_unused_attachments: note read failed", { note, err });
-          });
-
-          inventory = await getCachedAttachmentInventory(
-            vaultPath,
-            attachments,
-            notes,
-            contents,
-            mtimes,
-            reportProgress,
-          );
-        }
-
-        const unused = attachments.filter((p) => !inventory.referenced.has(p));
-        if (unused.length === 0) {
-          return textResult(
-            `All ${attachments.length} attachment(s) are referenced — nothing to clean up.`,
-          );
-        }
-
-        const truncated = unused.slice(0, limit);
-        const lines: string[] = [
-          `Found ${unused.length} unused attachment(s) of ${attachments.length} total${unused.length > limit ? ` (showing first ${limit})` : ""}:`,
-          "",
-        ];
-
-        if (includeBytes) {
-          // Stat ALL unused attachments so "Total reclaimable" reflects the
-          // full set the user would be deleting, not just the truncated view.
-          // Otherwise a user acting on the number silently under-deletes.
-          let totalBytes = 0;
-          const sizes = new Map<string, number>();
-          for (const p of unused) {
-            try {
-              const stat = await getAttachmentStats(vaultPath, p);
-              sizes.set(p, stat.size);
-              totalBytes += stat.size;
-            } catch {
-              // skip — file may have been removed mid-scan
-            }
-          }
-          lines.push(`Total reclaimable: ${totalBytes.toLocaleString()} bytes (across all ${unused.length} unused attachment(s))`);
-          lines.push("");
-          const rowLines: string[] = [];
-          for (const p of truncated) {
-            const sz = sizes.get(p);
-            const displayedPath = displayAttachmentValue(p);
-            rowLines.push(sz !== undefined ? `- ${displayedPath}  (${sz.toLocaleString()} bytes)` : `- ${displayedPath}`);
-          }
-          lines.push(untrustedAttachmentBlock("find_unused_attachments paths", rowLines.join("\n")));
-        } else {
-          lines.push(untrustedAttachmentBlock(
-            "find_unused_attachments paths",
-            truncated.map((p) => `- ${displayAttachmentValue(p)}`).join("\n"),
-          ));
-        }
-
-        return textResultWithUntrustedMeta(lines.join("\n"), "find_unused_attachments paths");
-      } catch (err) {
-        log.error("find_unused_attachments failed", {
-          tool: "find_unused_attachments",
-          err: err as Error,
-        });
-        return errorResult(`Error finding unused attachments: ${sanitizeError(err)}`);
+    async ({ limit, includeBytes }, { extra }) => {
+      const reportProgress = makeProgressReporter(extra);
+      const attachments = await listAttachments(vaultPath);
+      if (attachments.length === 0) {
+        return text("No attachments in this vault — nothing to check.");
       }
-    },
+      const notes = await listNotes(vaultPath);
+      await reportProgress(0, notes.length, "Reading notes…");
+      let inventory = await getReusableAttachmentInventory(
+        vaultPath,
+        attachments,
+        notes,
+        reportProgress
+      );
+      if (!inventory) {
+        const { contents, mtimes } = await readAllCached(
+          vaultPath,
+          notes,
+          (note, err) => {
+            log.warn("find_unused_attachments: note read failed", {
+              note,
+              err,
+            });
+          }
+        );
+
+        inventory = await getCachedAttachmentInventory(
+          vaultPath,
+          attachments,
+          notes,
+          contents,
+          mtimes,
+          reportProgress
+        );
+      }
+
+      const unused = attachments.filter((p) => !inventory.referenced.has(p));
+      if (unused.length === 0) {
+        return text(
+          `All ${attachments.length} attachment(s) are referenced — nothing to clean up.`
+        );
+      }
+
+      const truncated = unused.slice(0, limit);
+      const header = `Found ${unused.length} unused attachment(s) of ${attachments.length} total${unused.length > limit ? ` (showing first ${limit})` : ""}:`;
+
+      let totalLine: string | null = null;
+      let rowLines: string[];
+      if (includeBytes) {
+        // Stat ALL unused attachments so "Total reclaimable" reflects the
+        // full set the user would be deleting, not just the truncated view.
+        // Otherwise a user acting on the number silently under-deletes.
+        let totalBytes = 0;
+        const sizes = new Map<string, number>();
+        for (const p of unused) {
+          try {
+            const stat = await getAttachmentStats(vaultPath, p);
+            sizes.set(p, stat.size);
+            totalBytes += stat.size;
+          } catch {
+            // skip — file may have been removed mid-scan
+          }
+        }
+        totalLine = `Total reclaimable: ${totalBytes.toLocaleString()} bytes (across all ${unused.length} unused attachment(s))`;
+        rowLines = truncated.map((p) => {
+          const sz = sizes.get(p);
+          const displayedPath = displayAttachmentValue(p);
+          return sz !== undefined
+            ? `- ${displayedPath}  (${sz.toLocaleString()} bytes)`
+            : `- ${displayedPath}`;
+        });
+      } else {
+        rowLines = truncated.map((p) => `- ${displayAttachmentValue(p)}`);
+      }
+
+      return richText("find_unused_attachments paths", (b) => {
+        b.trusted(header);
+        b.trusted("");
+        if (totalLine !== null) {
+          b.trusted(totalLine);
+          b.trusted("");
+        }
+        b.untrusted("find_unused_attachments paths", rowLines.join("\n"));
+      });
+    }
   );
 }

--- a/src/tools/attachments/get_attachment.ts
+++ b/src/tools/attachments/get_attachment.ts
@@ -9,14 +9,15 @@ import {
   getBlockedExtension,
   verifyImageMagicBytes,
 } from "../../lib/mime.js";
-import { sanitizeError } from "../../lib/errors.js";
 import {
-  formatUntrustedVaultContent,
-  untrustedVaultContentMeta,
-} from "../../lib/tool-output.js";
-import { log } from "../../lib/logger.js";
+  defineTool,
+  error,
+  image,
+  audio,
+  blobResource,
+  untrustedResource,
+} from "../../lib/tool-seam.js";
 import {
-  errorResult,
   displayAttachmentValue,
   vaultResourceUri,
   safeResourceMimeType,
@@ -27,23 +28,29 @@ const ABSOLUTE_GET_ATTACHMENT_LIMIT = 50 * 1024 * 1024; // 50 MB hard cap
 
 function hiddenAttachmentSegment(relPath: string): string | null {
   const segments = relPath.replace(/\\/g, "/").split("/");
-  return segments.find((segment) =>
-    segment !== "" &&
-    segment !== "." &&
-    segment !== ".." &&
-    segment.startsWith(".")
-  ) ?? null;
+  return (
+    segments.find(
+      (segment) =>
+        segment !== "" &&
+        segment !== "." &&
+        segment !== ".." &&
+        segment.startsWith(".")
+    ) ?? null
+  );
 }
 
 async function assertNoSymlinkAttachmentPath(
   vaultPath: string,
   fullPath: string,
-  relPath: string,
+  relPath: string
 ): Promise<void> {
   const vaultRoot = path.resolve(vaultPath);
   const resolvedFullPath = path.resolve(fullPath);
   const relativeFromVault = path.relative(vaultRoot, resolvedFullPath);
-  if (relativeFromVault.startsWith("..") || path.isAbsolute(relativeFromVault)) {
+  if (
+    relativeFromVault.startsWith("..") ||
+    path.isAbsolute(relativeFromVault)
+  ) {
     throw new Error("Path traversal via symlink detected");
   }
 
@@ -52,15 +59,22 @@ async function assertNoSymlinkAttachmentPath(
     current = path.join(current, segment);
     const entry = await fs.lstat(current);
     if (entry.isSymbolicLink()) {
-      throw new Error(`Refusing to fetch symlink attachment: ${displayAttachmentValue(relPath)}`);
+      throw new Error(
+        `Refusing to fetch symlink attachment: ${displayAttachmentValue(relPath)}`
+      );
     }
   }
 }
 
-export function registerGetAttachment(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "get_attachment",
+export function registerGetAttachment(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "get_attachment",
       title: "Get Attachment",
       description:
         "Read an attachment file and return its bytes to the client. Images come back as `image` content blocks (rendered inline by Claude / Cursor), audio as `audio` blocks, everything else as a base64 `resource` block with a vault:// URI. Caps at 5 MB by default to keep token usage sane; raise via `maxBytes` up to 50 MB. The attachment must be inside the vault — markdown notes (.md), canvases (.canvas), and Bases (.base) are deliberately rejected so callers don't accidentally pull text-format files through this binary path; use get_note / read_canvas / read_base instead.",
@@ -74,167 +88,157 @@ export function registerGetAttachment(server: McpServer, vaultPath: string): voi
           .string()
           .min(1)
           .max(500)
-          .describe("Vault-relative path to the attachment, e.g. 'assets/diagram.png'."),
+          .describe(
+            "Vault-relative path to the attachment, e.g. 'assets/diagram.png'."
+          ),
         maxBytes: z
           .number()
           .int()
           .min(1)
           .max(ABSOLUTE_GET_ATTACHMENT_LIMIT)
           .optional()
-          .describe(`Maximum file size to fetch in bytes (default: ${DEFAULT_GET_ATTACHMENT_LIMIT.toLocaleString()}, hard cap: ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`),
+          .describe(
+            `Maximum file size to fetch in bytes (default: ${DEFAULT_GET_ATTACHMENT_LIMIT.toLocaleString()}, hard cap: ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`
+          ),
       },
     },
     async ({ path: relPath, maxBytes }) => {
-      try {
-        const hiddenName = hiddenAttachmentSegment(relPath);
-        if (hiddenName) {
-          return errorResult(
-            `Refusing to fetch hidden attachment "${displayAttachmentValue(relPath)}" via get_attachment.`,
-          );
-        }
-
-        // Reject text-format files so the wrong tool isn't used on them.
-        const lowerPath = relPath.toLowerCase();
-        if (lowerPath.endsWith(".md") || lowerPath.endsWith(".canvas") || lowerPath.endsWith(".base")) {
-          return errorResult(
-            `Refusing to fetch "${displayAttachmentValue(relPath)}" via get_attachment - use get_note / read_canvas / read_base instead.`,
-          );
-        }
-
-        // SEC-7: Block dangerous executable extensions.
-        const blockedExt = getBlockedExtension(relPath);
-        if (blockedExt) {
-          return errorResult(
-            `Blocked: "${displayAttachmentValue(relPath)}" has a dangerous extension (${displayAttachmentValue(blockedExt)}). ` +
-            `Executable file types are not served as attachments.`,
-          );
-        }
-
-        const limit = maxBytes ?? DEFAULT_GET_ATTACHMENT_LIMIT;
-        let opened: Awaited<ReturnType<typeof openVaultFileForRead>>;
-        try {
-          opened = await openVaultFileForRead(vaultPath, relPath);
-        } catch (err) {
-          if ((err as Error).message === `Not a regular file: ${relPath}`) {
-            return errorResult(
-              `Attachment "${displayAttachmentValue(relPath)}" is not a regular file.`,
-            );
-          }
-          throw err;
-        }
-        const handle = opened.handle;
-        let bytes: Buffer;
-        try {
-          await assertNoSymlinkAttachmentPath(vaultPath, opened.fullPath, relPath);
-          const stat = await handle.stat();
-          if (!stat.isFile()) {
-            return errorResult(
-              `Attachment "${displayAttachmentValue(relPath)}" is not a regular file.`,
-            );
-          }
-          if (stat.size > limit) {
-            return errorResult(
-              `Attachment "${displayAttachmentValue(relPath)}" is ${stat.size.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`,
-            );
-          }
-          bytes = await handle.readFile();
-        } finally {
-          await handle.close();
-        }
-        if (bytes.byteLength > limit) {
-          return errorResult(
-            `Attachment "${displayAttachmentValue(relPath)}" is ${bytes.byteLength.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`,
-          );
-        }
-        const attachmentSize = bytes.byteLength;
-        const mime = detectMimeType(relPath);
-        const category = categorizeMimeType(mime);
-        const basename = path.basename(relPath);
-        const displayedBasename = displayAttachmentValue(basename);
-
-        // SEC-8: SVG files can contain embedded <script> tags and event
-        // handlers, making them an XSS vector. Return SVG content as
-        // plain text instead of as an image embed.
-        if (mime === "image/svg+xml") {
-          const svgText = bytes.toString("utf-8");
-          const trustLabel = "get_attachment text";
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Attached: ${displayedBasename} (SVG returned as text/plain for security - SVGs may contain embedded scripts)\n` +
-                      `Size: ${attachmentSize.toLocaleString()} bytes`,
-              },
-              {
-                type: "resource" as const,
-                resource: {
-                  uri: vaultResourceUri(relPath),
-                  mimeType: "text/plain",
-                  text: formatUntrustedVaultContent(trustLabel, svgText),
-                  _meta: untrustedVaultContentMeta(trustLabel),
-                },
-                _meta: untrustedVaultContentMeta(trustLabel),
-              },
-            ],
-          };
-        }
-
-        // SEC-9: Best-effort magic-bytes verification for image types.
-        // A mismatch means the file extension doesn't match the actual
-        // content - warn the caller but still serve the file.
-        let magicWarning = "";
-        if (category === "image") {
-          const magicCheck = verifyImageMagicBytes(mime, bytes);
-          if (magicCheck === false) {
-            magicWarning =
-              ` [WARNING: file header does not match expected ${mime} signature - ` +
-              `the extension may be misleading]`;
-          }
-        }
-
-        const data = bytes.toString("base64");
-
-        // Image / audio content blocks render natively in compatible
-        // clients; everything else round-trips as a `resource` block so the
-        // client can save it, hand it off to a tool, or display a download
-        // affordance.
-        if (category === "image") {
-          return {
-            content: [
-              { type: "text" as const, text: `Attached: ${displayedBasename} (${mime}, ${attachmentSize.toLocaleString()} bytes)${magicWarning}` },
-              { type: "image" as const, data, mimeType: mime },
-            ],
-          };
-        }
-        if (category === "audio") {
-          return {
-            content: [
-              { type: "text" as const, text: `Attached: ${displayedBasename} (${mime}, ${attachmentSize.toLocaleString()} bytes)` },
-              { type: "audio" as const, data, mimeType: mime },
-            ],
-          };
-        }
-        const resourceMime = safeResourceMimeType(mime);
-        const mimeLabel = resourceMime === mime ? mime : `${mime} returned as ${resourceMime}`;
-        return {
-          content: [
-            { type: "text" as const, text: `Attached: ${displayedBasename} (${mimeLabel}, ${attachmentSize.toLocaleString()} bytes)` },
-            {
-              type: "resource" as const,
-              resource: {
-                // vault:// URI lets clients distinguish vault files from
-                // arbitrary URLs in their UI without leaking the host path.
-                uri: vaultResourceUri(relPath),
-                mimeType: resourceMime,
-                blob: data,
-              },
-            },
-          ],
-        };
-      } catch (err) {
-        log.error("get_attachment failed", { tool: "get_attachment", err: err as Error });
-        return errorResult(`Error reading attachment: ${sanitizeError(err)}`);
+      const hiddenName = hiddenAttachmentSegment(relPath);
+      if (hiddenName) {
+        return error(
+          `Refusing to fetch hidden attachment "${displayAttachmentValue(relPath)}" via get_attachment.`
+        );
       }
-    },
+
+      // Reject text-format files so the wrong tool isn't used on them.
+      const lowerPath = relPath.toLowerCase();
+      if (
+        lowerPath.endsWith(".md") ||
+        lowerPath.endsWith(".canvas") ||
+        lowerPath.endsWith(".base")
+      ) {
+        return error(
+          `Refusing to fetch "${displayAttachmentValue(relPath)}" via get_attachment - use get_note / read_canvas / read_base instead.`
+        );
+      }
+
+      // SEC-7: Block dangerous executable extensions.
+      const blockedExt = getBlockedExtension(relPath);
+      if (blockedExt) {
+        return error(
+          `Blocked: "${displayAttachmentValue(relPath)}" has a dangerous extension (${displayAttachmentValue(blockedExt)}). ` +
+            `Executable file types are not served as attachments.`
+        );
+      }
+
+      const limit = maxBytes ?? DEFAULT_GET_ATTACHMENT_LIMIT;
+      let opened: Awaited<ReturnType<typeof openVaultFileForRead>>;
+      try {
+        opened = await openVaultFileForRead(vaultPath, relPath);
+      } catch (err) {
+        // Expected: a directory (or other non-regular target) is a domain
+        // error; anything else is unexpected and rethrown to the seam.
+        if ((err as Error).message === `Not a regular file: ${relPath}`) {
+          return error(
+            `Attachment "${displayAttachmentValue(relPath)}" is not a regular file.`
+          );
+        }
+        throw err;
+      }
+      const handle = opened.handle;
+      let bytes: Buffer;
+      try {
+        await assertNoSymlinkAttachmentPath(
+          vaultPath,
+          opened.fullPath,
+          relPath
+        );
+        const stat = await handle.stat();
+        if (!stat.isFile()) {
+          return error(
+            `Attachment "${displayAttachmentValue(relPath)}" is not a regular file.`
+          );
+        }
+        if (stat.size > limit) {
+          return error(
+            `Attachment "${displayAttachmentValue(relPath)}" is ${stat.size.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`
+          );
+        }
+        bytes = await handle.readFile();
+      } finally {
+        await handle.close();
+      }
+      if (bytes.byteLength > limit) {
+        return error(
+          `Attachment "${displayAttachmentValue(relPath)}" is ${bytes.byteLength.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`
+        );
+      }
+      const attachmentSize = bytes.byteLength;
+      const mime = detectMimeType(relPath);
+      const category = categorizeMimeType(mime);
+      const basename = path.basename(relPath);
+      const displayedBasename = displayAttachmentValue(basename);
+
+      // SEC-8: SVG files can contain embedded <script> tags and event
+      // handlers, making them an XSS vector. Return SVG content as
+      // plain text (wrapped + trust-tagged by `untrustedResource`) instead
+      // of as an image embed.
+      if (mime === "image/svg+xml") {
+        const svgText = bytes.toString("utf-8");
+        return untrustedResource(
+          `Attached: ${displayedBasename} (SVG returned as text/plain for security - SVGs may contain embedded scripts)\n` +
+            `Size: ${attachmentSize.toLocaleString()} bytes`,
+          "get_attachment text",
+          vaultResourceUri(relPath),
+          "text/plain",
+          svgText
+        );
+      }
+
+      // SEC-9: Best-effort magic-bytes verification for image types.
+      // A mismatch means the file extension doesn't match the actual
+      // content - warn the caller but still serve the file.
+      let magicWarning = "";
+      if (category === "image") {
+        const magicCheck = verifyImageMagicBytes(mime, bytes);
+        if (magicCheck === false) {
+          magicWarning =
+            ` [WARNING: file header does not match expected ${mime} signature - ` +
+            `the extension may be misleading]`;
+        }
+      }
+
+      const data = bytes.toString("base64");
+
+      // Image / audio content blocks render natively in compatible
+      // clients; everything else round-trips as a `resource` block so the
+      // client can save it, hand it off to a tool, or display a download
+      // affordance.
+      if (category === "image") {
+        return image(
+          `Attached: ${displayedBasename} (${mime}, ${attachmentSize.toLocaleString()} bytes)${magicWarning}`,
+          data,
+          mime
+        );
+      }
+      if (category === "audio") {
+        return audio(
+          `Attached: ${displayedBasename} (${mime}, ${attachmentSize.toLocaleString()} bytes)`,
+          data,
+          mime
+        );
+      }
+      const resourceMime = safeResourceMimeType(mime);
+      const mimeLabel =
+        resourceMime === mime ? mime : `${mime} returned as ${resourceMime}`;
+      // vault:// URI lets clients distinguish vault files from arbitrary URLs
+      // in their UI without leaking the host path.
+      return blobResource(
+        `Attached: ${displayedBasename} (${mimeLabel}, ${attachmentSize.toLocaleString()} bytes)`,
+        vaultResourceUri(relPath),
+        resourceMime,
+        data
+      );
+    }
   );
 }

--- a/src/tools/attachments/list_attachments.ts
+++ b/src/tools/attachments/list_attachments.ts
@@ -1,15 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { listAttachments } from "../../lib/vault.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
-import {
-  textResult,
-  textResultWithUntrustedMeta,
-  errorResult,
-  displayAttachmentValue,
-  untrustedAttachmentBlock,
-} from "./shared.js";
+import { defineTool, text, richText } from "../../lib/tool-seam.js";
+import { displayAttachmentValue } from "./shared.js";
 
 /** Group attachments by their lower-cased extension for the summary line. */
 function summarizeByExtension(paths: readonly string[]): Map<string, number> {
@@ -22,10 +15,15 @@ function summarizeByExtension(paths: readonly string[]): Map<string, number> {
   return out;
 }
 
-export function registerListAttachments(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "list_attachments",
+export function registerListAttachments(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "list_attachments",
       title: "List Attachments",
       description:
         "Enumerate every non-markdown file in the vault — images, PDFs, audio/video clips, anything pasted in beyond notes/canvases/Bases. Returns a sorted list of relative paths plus a per-extension count summary. Use to audit assets, find duplicates by name, or pick targets for find_unused_attachments.",
@@ -39,7 +37,9 @@ export function registerListAttachments(server: McpServer, vaultPath: string): v
           .string()
           .max(500)
           .optional()
-          .describe("Restrict to one extension (e.g., 'png' or '.png'). Omit for every attachment."),
+          .describe(
+            "Restrict to one extension (e.g., 'png' or '.png'). Omit for every attachment."
+          ),
         limit: z
           .number()
           .int()
@@ -47,52 +47,59 @@ export function registerListAttachments(server: McpServer, vaultPath: string): v
           .max(10000)
           .optional()
           .default(200)
-          .describe("Maximum number of attachment paths to return (1-10000, default: 200). Total counts are still reported."),
+          .describe(
+            "Maximum number of attachment paths to return (1-10000, default: 200). Total counts are still reported."
+          ),
       },
     },
     async ({ extension, limit }) => {
-      try {
-        const all = await listAttachments(vaultPath);
-        const filtered = extension
-          ? all.filter((p) => {
-              const ext = (extension.startsWith(".") ? extension : `.${extension}`).toLowerCase();
-              return p.toLowerCase().endsWith(ext);
-            })
-          : all;
-        if (filtered.length === 0) {
-          return textResult(
-            extension
-              ? `No attachments with extension "${displayAttachmentValue(extension)}".`
-              : "No attachments in this vault.",
-          );
-        }
-        const truncated = filtered.slice(0, limit);
-        const lines: string[] = [
-          `${filtered.length} attachment(s)${extension ? ` (.${displayAttachmentValue(extension.replace(/^\./, ""))})` : ""}${filtered.length > limit ? ` (showing first ${limit})` : ""}:`,
-          "",
-        ];
-        const summary = summarizeByExtension(filtered);
-        let trustLabel = "list_attachments paths";
-        if (summary.size > 1) {
-          lines.push("By extension:");
-          const entries = Array.from(summary.entries()).sort((a, b) => b[1] - a[1]);
-          lines.push(untrustedAttachmentBlock(
-            "list_attachments extensions",
-            entries.map(([ext, n]) => `${displayAttachmentValue(ext)}  ${n}`).join("\n"),
-            "  ",
-          ));
-          lines.push("");
-          trustLabel = "list_attachments extensions and paths";
-        }
-        lines.push(untrustedAttachmentBlock(
-          "list_attachments paths",
-          truncated.map((p) => `- ${displayAttachmentValue(p)}`).join("\n"),
-        ));
-        return textResultWithUntrustedMeta(lines.join("\n"), trustLabel);
-      } catch (err) {
-        log.error("list_attachments failed", { tool: "list_attachments", err: err as Error });
-        return errorResult(`Error listing attachments: ${sanitizeError(err)}`);
+      const all = await listAttachments(vaultPath);
+      const filtered = extension
+        ? all.filter((p) => {
+            const ext = (
+              extension.startsWith(".") ? extension : `.${extension}`
+            ).toLowerCase();
+            return p.toLowerCase().endsWith(ext);
+          })
+        : all;
+      if (filtered.length === 0) {
+        return text(
+          extension
+            ? `No attachments with extension "${displayAttachmentValue(extension)}".`
+            : "No attachments in this vault."
+        );
       }
-    },
+      const truncated = filtered.slice(0, limit);
+      const summary = summarizeByExtension(filtered);
+      const hasExtensionBreakdown = summary.size > 1;
+      const trustLabel = hasExtensionBreakdown
+        ? "list_attachments extensions and paths"
+        : "list_attachments paths";
+
+      return richText(trustLabel, (b) => {
+        b.trusted(
+          `${filtered.length} attachment(s)${extension ? ` (.${displayAttachmentValue(extension.replace(/^\./, ""))})` : ""}${filtered.length > limit ? ` (showing first ${limit})` : ""}:`
+        );
+        b.trusted("");
+        if (hasExtensionBreakdown) {
+          b.trusted("By extension:");
+          const entries = Array.from(summary.entries()).sort(
+            (a, b) => b[1] - a[1]
+          );
+          b.untrusted(
+            "list_attachments extensions",
+            entries
+              .map(([ext, n]) => `${displayAttachmentValue(ext)}  ${n}`)
+              .join("\n"),
+            "  "
+          );
+          b.trusted("");
+        }
+        b.untrusted(
+          "list_attachments paths",
+          truncated.map((p) => `- ${displayAttachmentValue(p)}`).join("\n")
+        );
+      });
+    }
   );
 }

--- a/src/tools/attachments/shared.ts
+++ b/src/tools/attachments/shared.ts
@@ -1,34 +1,13 @@
-import {
-  formatUntrustedVaultContent,
-  indentBlock,
-  untrustedVaultContentMeta,
-} from "../../lib/tool-output.js";
 import { escapeControlChars } from "../../lib/errors.js";
 
-function textResult(text: string) {
-  return { content: [{ type: "text" as const, text }] };
-}
-
-function textResultWithUntrustedMeta(text: string, label: string) {
-  return {
-    content: [{
-      type: "text" as const,
-      text,
-      _meta: untrustedVaultContentMeta(label),
-    }],
-  };
-}
-
-function errorResult(text: string) {
-  return { content: [{ type: "text" as const, text }], isError: true as const };
-}
+// The error/result/trust-wrapping recipe (textResult, textResultWithUntrustedMeta,
+// errorResult, untrustedAttachmentBlock) now lives in the tool seam
+// (../../lib/tool-seam.ts): handlers return a ToolResult built via `text` /
+// `richText` / `error` / the media constructors, and the seam owns error
+// sanitization. What remains here are the attachment group's own helpers.
 
 /** Escape control characters in a value before embedding it in a display string. */
 const displayAttachmentValue = escapeControlChars;
-
-function untrustedAttachmentBlock(label: string, text: string, indent = ""): string {
-  return indentBlock(formatUntrustedVaultContent(label, text), indent);
-}
 
 function vaultResourceUri(relPath: string): string {
   return `vault://${relPath.replace(/\\/g, "/").split("/").map(encodeURIComponent).join("/")}`;
@@ -45,12 +24,4 @@ function safeResourceMimeType(mime: string): string {
   return ACTIVE_TEXT_MIME_TYPES.has(mime.toLowerCase()) ? "text/plain" : mime;
 }
 
-export {
-  textResult,
-  textResultWithUntrustedMeta,
-  errorResult,
-  displayAttachmentValue,
-  untrustedAttachmentBlock,
-  vaultResourceUri,
-  safeResourceMimeType,
-};
+export { displayAttachmentValue, vaultResourceUri, safeResourceMimeType };


### PR DESCRIPTION
Migrates the attachments group (3 tools) and **extends the seam** with the non-text media constructors (`image`/`audio`/`blobResource`/`untrustedResource`) that ADR 0001 reserved for it. `get_attachment` is the only multi-type tool (caption + one media block). Only `untrustedResource` wraps (SVG-as-text); raw base64 media carries no trust `_meta` (no injection surface) - rationale recorded in the ADR.

- New constructors unit-tested in `tool-seam.test.ts`; `find_unused_attachments` progress guarded by a runtime notification test (the `extra` boundary).
- **Byte-preserving**: existing attachments tests (media shapes + SVG double-`_meta`) stay green unchanged; an independent full-content dump-diff across 13 branches showed the only delta is the generic `Error:` thrown-error prefix (exception #1).
- typecheck/lint/build clean; **984 tests**. 8 of 9 groups now through the seam; only semantic remains.

Closes #250.