### PR TITLE
refactor(tools): migrate semantic group through the tool seam (final group)

### DIFF
--- a/docs/adr/0001-tool-seam.md
+++ b/docs/adr/0001-tool-seam.md
@@ -1,6 +1,6 @@
 # ADR 0001: One deep tool seam behind every MCP tool
 
-- Status: Accepted (read group migrated as the pattern-setter, then canvas, links, a Wave-1 fan-out of write/tags/sections/bases, and attachments (which extended the seam with the non-text media constructors); 1 group to follow: semantic)
+- Status: Accepted and complete — all 9 groups migrated (read as the pattern-setter, then canvas, links, a Wave-1 fan-out of write/tags/sections/bases, attachments which extended the seam with the non-text media constructors, and finally semantic). Follow-up sweep remaining: collapse the `display*Value` aliases and rewrite `TOOL_AUTHORING.md §4`.
 - Date: 2026-07-18
 
 ## Context
@@ -171,8 +171,12 @@ The **attachments** group then migrated and extended the seam with the non-text
 media constructors (see Result vocabulary); `find_unused_attachments` also
 became the first tool to thread `ctx.extra` for progress, guarded now by a
 runtime progress-notification test (the `extra`-boundary the callback cast
-cannot type-check). The one **remaining** group, **semantic**, carries the same
-`extra`-boundary caveat for `index_vault`/`search_semantic` (verify progress
-plumbing at runtime). Collapsing the 9 `display*Value` aliases to a single
-`escapeControlChars` import is a follow-up sweep. `TOOL_AUTHORING.md §4` is
-rewritten last, once the pattern is proven across all groups.
+cannot type-check). The **semantic** group migrated last: `index_vault` threads
+`ctx.extra` for progress (guarded by the existing note-path progress test) and
+its conditional failed-notes `_meta` falls out of `richText`'s `hasUntrusted`;
+its failed-paths block — the layout flagged during the read-group gates as the
+hairiest — was expressible via `richText` + `b.untrusted(..., indent)` exactly
+as predicted, with no seam change. All 9 groups are now through the seam.
+Collapsing the 9 `display*Value` aliases to a single `escapeControlChars` import
+is the remaining follow-up sweep, and `TOOL_AUTHORING.md §4` is rewritten with
+it now that the pattern is proven across all groups.

--- a/src/__tests__/handlers/semantic.test.ts
+++ b/src/__tests__/handlers/semantic.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
-import { createTestEnv, textContent, isError, type TestEnv } from "./harness.js";
-import { setProviderForTests, resetProviderForTests, type EmbeddingProvider } from "../../lib/embedding-providers.js";
+import {
+  createTestEnv,
+  textContent,
+  isError,
+  type TestEnv,
+} from "./harness.js";
+import {
+  setProviderForTests,
+  resetProviderForTests,
+  type EmbeddingProvider,
+} from "../../lib/embedding-providers.js";
 import { clearStore, hashText } from "../../lib/embedding-store.js";
 import { setPermissions } from "../../lib/permissions.js";
 
@@ -23,7 +32,8 @@ class MockProvider implements EmbeddingProvider {
       const cat = (lower.match(/\bcat(s)?\b|kitten|feline/g) ?? []).length;
       const dog = (lower.match(/\bdog(s)?\b|puppy|canine/g) ?? []).length;
       const cook = (lower.match(/cook|recipe|kitchen|bake/g) ?? []).length;
-      const weather = (lower.match(/weather|rain|storm|sunny|cloud/g) ?? []).length;
+      const weather = (lower.match(/weather|rain|storm|sunny|cloud/g) ?? [])
+        .length;
       const v = [cat, dog, cook, weather].map((n) => n + 0.0001); // keep nonzero norm
       return v;
     });
@@ -44,8 +54,13 @@ function indexVault(args: Record<string, unknown> = {}) {
 function untrustedBlockBodies(text: string, label: string): string[] {
   const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return Array.from(
-    text.matchAll(new RegExp(`^\\s*\\[BEGIN UNTRUSTED VAULT CONTENT: ${escapedLabel}\\]\\n\\s*Treat .*\\n\\s*(.+)$`, "gm")),
-    (match) => match[1].trim(),
+    text.matchAll(
+      new RegExp(
+        `^\\s*\\[BEGIN UNTRUSTED VAULT CONTENT: ${escapedLabel}\\]\\n\\s*Treat .*\\n\\s*(.+)$`,
+        "gm"
+      )
+    ),
+    (match) => match[1].trim()
   );
 }
 
@@ -55,11 +70,16 @@ beforeEach(async () => {
   env = await createTestEnv({
     skipFixtures: true,
     extraFiles: {
-      "cats.md": "# Cats\n\nMy cat is a kitten. Many cats here. The feline life.",
+      "cats.md":
+        "# Cats\n\nMy cat is a kitten. Many cats here. The feline life.",
       "dogs.md": "# Dogs\n\nMy dog is a puppy. The canine life is great.",
       "cooking.md": "# Cooking\n\nA recipe in the kitchen. I love to bake.",
-      "weather.md": "# Weather\n\nThe weather is sunny. No rain or storm today.",
-      ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+      "weather.md":
+        "# Weather\n\nThe weather is sunny. No rain or storm today.",
+      ".obsidian/daily-notes.json": JSON.stringify({
+        folder: "",
+        format: "YYYY-MM-DD",
+      }),
     },
   });
 });
@@ -89,7 +109,9 @@ describe("semantic handlers — index_vault", () => {
     });
 
     expect(isError(result)).toBe(true);
-    expect(textContent(result)).toContain("send-vault-text-to-embedding-provider");
+    expect(textContent(result)).toContain(
+      "send-vault-text-to-embedding-provider"
+    );
     expect(provider.calls).toBe(0);
   });
 
@@ -122,24 +144,29 @@ describe("semantic handlers — index_vault", () => {
     await fs.writeFile(
       path.join(env.vaultDir, dirtyPath),
       "# Progress\n\nA cat note used to check progress labels.",
-      "utf-8",
+      "utf-8"
     );
     const messages: string[] = [];
 
     const result = await env.client.callTool(
-      { name: "index_vault", arguments: { force: true, confirm: INDEX_CONFIRM } },
+      {
+        name: "index_vault",
+        arguments: { force: true, confirm: INDEX_CONFIRM },
+      },
       undefined,
       {
         onprogress: (progress) => {
           if (progress.message) messages.push(progress.message);
         },
-      },
+      }
     );
 
     expect(isError(result)).toBe(false);
     expect(messages.length).toBeGreaterThan(0);
     expect(messages.join("\n")).not.toContain(dirtyPath);
-    expect(messages.some((message) => /note \d+\/\d+/.test(message))).toBe(true);
+    expect(messages.some((message) => /note \d+\/\d+/.test(message))).toBe(
+      true
+    );
   });
 
   it("escapes configured provider labels in summaries", async () => {
@@ -173,7 +200,10 @@ describe("semantic handlers — index_vault", () => {
       skipFixtures: true,
       extraFiles: {
         [dirtyPath]: "# Dirty\n\nCats cats cats.",
-        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+        ".obsidian/daily-notes.json": JSON.stringify({
+          folder: "",
+          format: "YYYY-MM-DD",
+        }),
       },
     });
     setProviderForTests(new FailingProvider());
@@ -184,12 +214,20 @@ describe("semantic handlers — index_vault", () => {
     const block = result.content[0] as { _meta?: Record<string, unknown> };
     expect(isError(result)).toBe(false);
     expect(text).toContain("Failures:        1");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: index_vault failed note]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: index_vault failed note]"
+    );
     expect(text).toContain("dirty\\x7fsemantic.md: provider failed");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: index_vault failed note: dirty\\x7fsemantic.md]");
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: index_vault failed note: dirty\\x7fsemantic.md]"
+    );
     expect(text).not.toContain(dirtyPath);
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
-    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe("index_vault failed notes");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "index_vault failed notes"
+    );
   });
 
   it("records invalid live provider vectors as failed notes without aborting the index", async () => {
@@ -197,8 +235,10 @@ describe("semantic handlers — index_vault", () => {
       override embed(texts: string[]): Promise<number[][]> {
         return Promise.resolve(
           texts.map((text) =>
-            text.toLowerCase().includes("cat") ? [Number.NaN, 0, 0, 0] : [1, 0, 0, 0],
-          ),
+            text.toLowerCase().includes("cat")
+              ? [Number.NaN, 0, 0, 0]
+              : [1, 0, 0, 0]
+          )
         );
       }
     }
@@ -219,7 +259,7 @@ describe("semantic handlers — index_vault", () => {
     await fs.writeFile(
       path.join(env.vaultDir, "cats.md"),
       "# Cats\n\nCats changed enough to require a fresh embedding.",
-      "utf-8",
+      "utf-8"
     );
 
     class WrongDimensionProvider implements EmbeddingProvider {
@@ -248,11 +288,17 @@ describe("semantic handlers — search_semantic", () => {
     await indexVault();
     const result = await env.client.callTool({
       name: "search_semantic",
-      arguments: { query: "I want to learn about kittens and feline behavior", limit: 3 },
+      arguments: {
+        query: "I want to learn about kittens and feline behavior",
+        limit: 3,
+      },
     });
     expect(isError(result)).toBe(false);
     const text = textContent(result);
-    const resultPaths = untrustedBlockBodies(text, "search_semantic result path");
+    const resultPaths = untrustedBlockBodies(
+      text,
+      "search_semantic result path"
+    );
     expect(resultPaths.length).toBeGreaterThan(0);
     expect(resultPaths[0]).toBe("cats.md");
   });
@@ -319,7 +365,11 @@ describe("semantic handlers — search_semantic", () => {
     // Force the search to a folder that contains nothing.
     const result = await env.client.callTool({
       name: "search_semantic",
-      arguments: { query: "cooking recipes", folder: "no-such-folder", limit: 5 },
+      arguments: {
+        query: "cooking recipes",
+        folder: "no-such-folder",
+        limit: 5,
+      },
     });
     expect(textContent(result)).toMatch(/No matches/);
   });
@@ -329,7 +379,11 @@ describe("semantic handlers — search_semantic", () => {
 
     const result = await env.client.callTool({
       name: "search_semantic",
-      arguments: { query: "cats\ninjected", folder: "no-such-folder", limit: 5 },
+      arguments: {
+        query: "cats\ninjected",
+        folder: "no-such-folder",
+        limit: 5,
+      },
     });
 
     const text = textContent(result);
@@ -344,7 +398,10 @@ describe("semantic handlers — search_semantic", () => {
       skipFixtures: true,
       extraFiles: {
         "dirty.md": "# Dirty\tHeading\n\nCats cats cats ring \x07 bells.",
-        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+        ".obsidian/daily-notes.json": JSON.stringify({
+          folder: "",
+          format: "YYYY-MM-DD",
+        }),
       },
     });
 
@@ -356,19 +413,32 @@ describe("semantic handlers — search_semantic", () => {
 
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_semantic result path]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: search_semantic result path]"
+    );
     expect(text).toContain("dirty.md");
     expect(text).toContain("    Heading:");
     expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic heading]");
     expect(text).toContain("Dirty\\tHeading");
     expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic snippet]");
     expect(text).toContain("\\x07");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: search_semantic result path: dirty.md]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic heading: dirty.md]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic snippet: dirty.md]");
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: search_semantic result path: dirty.md]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: semantic heading: dirty.md]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: semantic snippet: dirty.md]"
+    );
     expect(text).not.toContain("Dirty\tHeading");
     expect(text).not.toContain("\x07");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "search_semantic vault text"
+    );
   });
 
   it("filters persisted embedding hits through the current read allowlist", async () => {
@@ -378,8 +448,12 @@ describe("semantic handlers — search_semantic", () => {
       skipFixtures: true,
       extraFiles: {
         "public/cats.md": "# Public Cats\n\nCats are friendly companions.",
-        "private/secret.md": "# Private Cats\n\nCats guard the private launch notes.",
-        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+        "private/secret.md":
+          "# Private Cats\n\nCats guard the private launch notes.",
+        ".obsidian/daily-notes.json": JSON.stringify({
+          folder: "",
+          format: "YYYY-MM-DD",
+        }),
       },
     });
 
@@ -405,7 +479,10 @@ describe("semantic handlers — search_semantic", () => {
       skipFixtures: true,
       extraFiles: {
         "cats.md": "# Cats\n\nCats carry the stale launch instructions.",
-        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+        ".obsidian/daily-notes.json": JSON.stringify({
+          folder: "",
+          format: "YYYY-MM-DD",
+        }),
       },
     });
 
@@ -413,7 +490,7 @@ describe("semantic handlers — search_semantic", () => {
     await fs.writeFile(
       path.join(env.vaultDir, "cats.md"),
       "# Dogs\n\nThe current note is only about dogs.",
-      "utf-8",
+      "utf-8"
     );
 
     const result = await env.client.callTool({
@@ -428,8 +505,16 @@ describe("semantic handlers — search_semantic", () => {
   });
 
   it("rejects forged persisted snippets even when the note hash matches", async () => {
-    const liveContent = await fs.readFile(path.join(env.vaultDir, "cats.md"), "utf-8");
-    const snapshotPath = path.join(env.vaultDir, ".obsidian", "cache", "mcp-pro-embeddings.json");
+    const liveContent = await fs.readFile(
+      path.join(env.vaultDir, "cats.md"),
+      "utf-8"
+    );
+    const snapshotPath = path.join(
+      env.vaultDir,
+      ".obsidian",
+      "cache",
+      "mcp-pro-embeddings.json"
+    );
     await fs.mkdir(path.dirname(snapshotPath), { recursive: true });
     await fs.writeFile(
       snapshotPath,
@@ -451,7 +536,7 @@ describe("semantic handlers — search_semantic", () => {
           },
         ],
       }),
-      "utf-8",
+      "utf-8"
     );
     await clearStore(env.vaultDir);
 
@@ -477,15 +562,27 @@ describe("semantic handlers — find_similar_notes", () => {
     expect(isError(result)).toBe(false);
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    const resultPaths = untrustedBlockBodies(text, "find_similar_notes result path");
+    const resultPaths = untrustedBlockBodies(
+      text,
+      "find_similar_notes result path"
+    );
     expect(resultPaths.length).toBeGreaterThan(0);
     expect(resultPaths).not.toContain("cats.md");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path: cats.md]");
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path]");
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path: cats.md]"
+    );
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path]"
+    );
     // dogs.md (also pets) shares no topic dimension with cats; results
     // simply rank the rest by similarity. Just check we got hits back.
     expect(text).toMatch(/note\(s\) similar to cats\.md/);
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "find_similar_notes paths and headings"
+    );
   });
 
   it("errors when the source note has no embeddings", async () => {
@@ -517,7 +614,10 @@ describe("semantic handlers — find_similar_notes", () => {
       extraFiles: {
         "dirty.md": "# Dirty\tHeading\n\nCats cats cats ring bells.",
         "source.md": "# Source\n\nCats.",
-        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+        ".obsidian/daily-notes.json": JSON.stringify({
+          folder: "",
+          format: "YYYY-MM-DD",
+        }),
       },
     });
 
@@ -529,15 +629,26 @@ describe("semantic handlers — find_similar_notes", () => {
 
     const text = textContent(result);
     const block = result.content[0] as { _meta?: Record<string, unknown> };
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path]"
+    );
     expect(text).toContain("dirty.md");
     expect(text).toContain("    Heading:");
     expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic heading]");
     expect(text).toContain("Dirty\\tHeading");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path: dirty.md]");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: semantic heading: dirty.md]");
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path: dirty.md]"
+    );
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: semantic heading: dirty.md]"
+    );
     expect(text).not.toContain("Dirty\tHeading");
-    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe("untrusted-vault-content");
+    expect(block._meta?.["obsidian-mcp-pro/contentTrust"]).toBe(
+      "untrusted-vault-content"
+    );
+    expect(block._meta?.["obsidian-mcp-pro/untrustedContentLabel"]).toBe(
+      "find_similar_notes paths and headings"
+    );
   });
 
   it("rejects an unreadable source note from the persisted embedding store", async () => {
@@ -547,8 +658,12 @@ describe("semantic handlers — find_similar_notes", () => {
       skipFixtures: true,
       extraFiles: {
         "public/cats.md": "# Public Cats\n\nCats are friendly companions.",
-        "private/secret.md": "# Private Cats\n\nCats guard the private launch notes.",
-        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+        "private/secret.md":
+          "# Private Cats\n\nCats guard the private launch notes.",
+        ".obsidian/daily-notes.json": JSON.stringify({
+          folder: "",
+          format: "YYYY-MM-DD",
+        }),
       },
     });
 
@@ -572,8 +687,12 @@ describe("semantic handlers — find_similar_notes", () => {
       extraFiles: {
         "public/cats.md": "# Public Cats\n\nCats are friendly companions.",
         "public/dogs.md": "# Public Dogs\n\nDogs are loyal companions.",
-        "private/secret.md": "# Private Cats\n\nCats guard the private launch notes.",
-        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+        "private/secret.md":
+          "# Private Cats\n\nCats guard the private launch notes.",
+        ".obsidian/daily-notes.json": JSON.stringify({
+          folder: "",
+          format: "YYYY-MM-DD",
+        }),
       },
     });
 
@@ -587,9 +706,13 @@ describe("semantic handlers — find_similar_notes", () => {
 
     const text = textContent(result);
     expect(isError(result)).toBe(false);
-    expect(text).toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path]");
+    expect(text).toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path]"
+    );
     expect(text).toContain("public/dogs.md");
-    expect(text).not.toContain("[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path: public/dogs.md]");
+    expect(text).not.toContain(
+      "[BEGIN UNTRUSTED VAULT CONTENT: find_similar_notes result path: public/dogs.md]"
+    );
     expect(text).not.toContain("private/secret.md");
   });
 
@@ -601,7 +724,10 @@ describe("semantic handlers — find_similar_notes", () => {
       extraFiles: {
         "source.md": "# Cats\n\nCats are the original source topic.",
         "target.md": "# Target\n\nCats are nearby.",
-        ".obsidian/daily-notes.json": JSON.stringify({ folder: "", format: "YYYY-MM-DD" }),
+        ".obsidian/daily-notes.json": JSON.stringify({
+          folder: "",
+          format: "YYYY-MM-DD",
+        }),
       },
     });
 
@@ -609,7 +735,7 @@ describe("semantic handlers — find_similar_notes", () => {
     await fs.writeFile(
       path.join(env.vaultDir, "source.md"),
       "# Weather\n\nThe current source topic is rain.",
-      "utf-8",
+      "utf-8"
     );
 
     const result = await env.client.callTool({
@@ -631,7 +757,10 @@ describe("semantic handlers — provider missing", () => {
     expect(isError(r1)).toBe(true);
     expect(textContent(r1)).toMatch(/OBSIDIAN_EMBEDDING_PROVIDER/);
 
-    const r2 = await env.client.callTool({ name: "search_semantic", arguments: { query: "x" } });
+    const r2 = await env.client.callTool({
+      name: "search_semantic",
+      arguments: { query: "x" },
+    });
     expect(isError(r2)).toBe(true);
     expect(textContent(r2)).toMatch(/OBSIDIAN_EMBEDDING_PROVIDER/);
   });
@@ -661,4 +790,3 @@ describe("semantic handlers — provider missing", () => {
     }
   });
 });
-

--- a/src/tools/semantic/find_similar_notes.ts
+++ b/src/tools/semantic/find_similar_notes.ts
@@ -15,15 +15,11 @@ import {
   invalidateIfIncompatible,
   type SearchHit,
 } from "../../lib/embedding-store.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { log } from "../../lib/logger.js";
+import { defineTool, text, richText, error } from "../../lib/tool-seam.js";
 import {
-  textResult,
-  errorResult,
   displaySemanticValue,
   semanticPathBlock,
   semanticHeadingBlock,
-  untrustedVaultTextResult,
 } from "./shared.js";
 
 interface FreshSearchOptions {
@@ -36,35 +32,44 @@ interface FreshSearchOptions {
 async function searchFreshEmbeddings(
   vaultPath: string,
   queryVector: number[],
-  options: FreshSearchOptions,
+  options: FreshSearchOptions
 ): Promise<{ hits: SearchHit[]; stalePruned: number }> {
   const hits: SearchHit[] = [];
   const accepted = new Set<string>();
   const stale = new Set<string>();
   let stalePruned = 0;
 
-  function headingPathsEqual(a: readonly string[], b: readonly string[]): boolean {
+  function headingPathsEqual(
+    a: readonly string[],
+    b: readonly string[]
+  ): boolean {
     return a.length === b.length && a.every((part, index) => part === b[index]);
   }
 
   function storedChunksMatchLiveChunks(
     vaultPath: string,
     notePath: string,
-    chunks: ReturnType<typeof chunkNote>,
+    chunks: ReturnType<typeof chunkNote>
   ): boolean {
     const stored = getNoteEmbeddings(vaultPath, notePath);
     if (stored.length !== chunks.length) return false;
-    const storedByIndex = new Map(stored.map((chunk) => [chunk.chunkIndex, chunk]));
+    const storedByIndex = new Map(
+      stored.map((chunk) => [chunk.chunkIndex, chunk])
+    );
     for (const chunk of chunks) {
       const storedChunk = storedByIndex.get(chunk.index);
       if (!storedChunk) return false;
       if (storedChunk.text !== chunk.text) return false;
-      if (!headingPathsEqual(storedChunk.headingPath, chunk.headingPath)) return false;
+      if (!headingPathsEqual(storedChunk.headingPath, chunk.headingPath))
+        return false;
     }
     return true;
   }
 
-  async function storedNoteIsCurrent(vaultPath: string, notePath: string): Promise<boolean> {
+  async function storedNoteIsCurrent(
+    vaultPath: string,
+    notePath: string
+  ): Promise<boolean> {
     try {
       const content = await readNote(vaultPath, notePath);
       const chunks = chunkNote(content);
@@ -77,7 +82,10 @@ async function searchFreshEmbeddings(
     }
   }
 
-  async function pruneStaleStoredNote(vaultPath: string, notePath: string): Promise<boolean> {
+  async function pruneStaleStoredNote(
+    vaultPath: string,
+    notePath: string
+  ): Promise<boolean> {
     const current = await storedNoteIsCurrent(vaultPath, notePath);
     if (current) return false;
     return dropNoteChunks(vaultPath, notePath);
@@ -115,7 +123,10 @@ async function searchFreshEmbeddings(
   return { hits, stalePruned };
 }
 
-function canReadStoredEmbeddingNote(vaultPath: string, notePath: string): boolean {
+function canReadStoredEmbeddingNote(
+  vaultPath: string,
+  notePath: string
+): boolean {
   try {
     resolveVaultPath(vaultPath, notePath, "read");
     return true;
@@ -124,10 +135,15 @@ function canReadStoredEmbeddingNote(vaultPath: string, notePath: string): boolea
   }
 }
 
-export function registerFindSimilarNotesTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "find_similar_notes",
+export function registerFindSimilarNotesTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "find_similar_notes",
       title: "Find Similar Notes",
       description:
         "Given a note path, return the K most semantically similar notes from the index (excluding the source note). Uses the source note's existing chunk embeddings and anchors the source query to chunks aligned with the note's opening topic — no live API call to the embedding provider, so this is fast and free. Run `index_vault` first to populate embeddings for both the source and the candidates.",
@@ -141,7 +157,9 @@ export function registerFindSimilarNotesTool(server: McpServer, vaultPath: strin
           .string()
           .min(1)
           .max(500)
-          .describe("Vault-relative path to the source note, e.g. 'projects/atlas.md'."),
+          .describe(
+            "Vault-relative path to the source note, e.g. 'projects/atlas.md'."
+          ),
         limit: z
           .number()
           .int()
@@ -149,103 +167,120 @@ export function registerFindSimilarNotesTool(server: McpServer, vaultPath: strin
           .max(100)
           .optional()
           .default(10)
-          .describe("Maximum number of similar notes to return (1-100, default: 10)."),
+          .describe(
+            "Maximum number of similar notes to return (1-100, default: 10)."
+          ),
       },
     },
     async ({ path: notePath, limit }) => {
-      try {
-        await loadStore(vaultPath);
-        const provider = getActiveProvider();
-        if (provider) {
-          invalidateIfIncompatible(vaultPath, provider.id, provider.model);
-        }
-        resolveVaultPath(vaultPath, notePath, "read");
-        const ownChunks = getNoteEmbeddings(vaultPath, notePath);
-        if (ownChunks.length === 0) {
-          return errorResult(
-            `No embeddings found for "${displaySemanticValue(notePath)}". Run \`index_vault\` first (or check the path is correct).`,
-          );
-        }
-
-        async function storedNoteIsCurrent(vaultPath: string, notePath: string): Promise<boolean> {
-          try {
-            const content = await readNote(vaultPath, notePath);
-            const chunks = chunkNote(content);
-            return (
-              noteIsCurrent(vaultPath, notePath, hashText(content)) &&
-              storedChunksMatchLiveChunks(vaultPath, notePath, chunks)
-            );
-          } catch {
-            return false;
-          }
-        }
-
-        function headingPathsEqual(a: readonly string[], b: readonly string[]): boolean {
-          return a.length === b.length && a.every((part, index) => part === b[index]);
-        }
-
-        function storedChunksMatchLiveChunks(
-          vaultPath: string,
-          notePath: string,
-          chunks: ReturnType<typeof chunkNote>,
-        ): boolean {
-          const stored = getNoteEmbeddings(vaultPath, notePath);
-          if (stored.length !== chunks.length) return false;
-          const storedByIndex = new Map(stored.map((chunk) => [chunk.chunkIndex, chunk]));
-          for (const chunk of chunks) {
-            const storedChunk = storedByIndex.get(chunk.index);
-            if (!storedChunk) return false;
-            if (storedChunk.text !== chunk.text) return false;
-            if (!headingPathsEqual(storedChunk.headingPath, chunk.headingPath)) return false;
-          }
-          return true;
-        }
-
-        async function pruneStaleStoredNote(vaultPath: string, notePath: string): Promise<boolean> {
-          const current = await storedNoteIsCurrent(vaultPath, notePath);
-          if (current) return false;
-          return dropNoteChunks(vaultPath, notePath);
-        }
-
-        if (await pruneStaleStoredNote(vaultPath, notePath)) {
-          await saveStore(vaultPath);
-          return errorResult(
-            `No current embeddings found for "${displaySemanticValue(notePath)}". Run \`index_vault\` to refresh it.`,
-          );
-        }
-        const queryVector = buildSimilarNotesQueryVector(ownChunks);
-        const exclude = new Set([notePath]);
-        const { hits } = await searchFreshEmbeddings(vaultPath, queryVector, {
-          limit,
-          excludeNotes: exclude,
-          filterNote: (hitPath) => canReadStoredEmbeddingNote(vaultPath, hitPath),
-        });
-        const ranked = hits.map((h) => ({
-          notePath: h.notePath,
-          score: h.score,
-          chunkIndex: h.chunkIndex,
-          headingPath: h.headingPath,
-          text: h.text,
-        }));
-
-        if (ranked.length === 0) {
-          return textResult(`No similar notes found for "${displaySemanticValue(notePath)}".`);
-        }
-        const lines: string[] = [`${ranked.length} note(s) similar to ${displaySemanticValue(notePath)}:`, ""];
-        for (const r of ranked) {
-          lines.push(`- score: ${r.score.toFixed(3)}`);
-          lines.push("    Path:");
-          lines.push(semanticPathBlock("find_similar_notes result path", r.notePath));
-          if (r.headingPath.length > 0) {
-            lines.push("    Heading:");
-            lines.push(semanticHeadingBlock(r.headingPath));
-          }
-        }
-        return untrustedVaultTextResult(lines.join("\n"), "find_similar_notes paths and headings");
-      } catch (err) {
-        log.error("find_similar_notes failed", { tool: "find_similar_notes", err: err as Error });
-        return errorResult(`Error finding similar notes: ${sanitizeError(err)}`);
+      await loadStore(vaultPath);
+      const provider = getActiveProvider();
+      if (provider) {
+        invalidateIfIncompatible(vaultPath, provider.id, provider.model);
       }
-    },
+      resolveVaultPath(vaultPath, notePath, "read");
+      const ownChunks = getNoteEmbeddings(vaultPath, notePath);
+      if (ownChunks.length === 0) {
+        return error(
+          `No embeddings found for "${displaySemanticValue(notePath)}". Run \`index_vault\` first (or check the path is correct).`
+        );
+      }
+
+      async function storedNoteIsCurrent(
+        vaultPath: string,
+        notePath: string
+      ): Promise<boolean> {
+        try {
+          const content = await readNote(vaultPath, notePath);
+          const chunks = chunkNote(content);
+          return (
+            noteIsCurrent(vaultPath, notePath, hashText(content)) &&
+            storedChunksMatchLiveChunks(vaultPath, notePath, chunks)
+          );
+        } catch {
+          return false;
+        }
+      }
+
+      function headingPathsEqual(
+        a: readonly string[],
+        b: readonly string[]
+      ): boolean {
+        return (
+          a.length === b.length && a.every((part, index) => part === b[index])
+        );
+      }
+
+      function storedChunksMatchLiveChunks(
+        vaultPath: string,
+        notePath: string,
+        chunks: ReturnType<typeof chunkNote>
+      ): boolean {
+        const stored = getNoteEmbeddings(vaultPath, notePath);
+        if (stored.length !== chunks.length) return false;
+        const storedByIndex = new Map(
+          stored.map((chunk) => [chunk.chunkIndex, chunk])
+        );
+        for (const chunk of chunks) {
+          const storedChunk = storedByIndex.get(chunk.index);
+          if (!storedChunk) return false;
+          if (storedChunk.text !== chunk.text) return false;
+          if (!headingPathsEqual(storedChunk.headingPath, chunk.headingPath))
+            return false;
+        }
+        return true;
+      }
+
+      async function pruneStaleStoredNote(
+        vaultPath: string,
+        notePath: string
+      ): Promise<boolean> {
+        const current = await storedNoteIsCurrent(vaultPath, notePath);
+        if (current) return false;
+        return dropNoteChunks(vaultPath, notePath);
+      }
+
+      if (await pruneStaleStoredNote(vaultPath, notePath)) {
+        await saveStore(vaultPath);
+        return error(
+          `No current embeddings found for "${displaySemanticValue(notePath)}". Run \`index_vault\` to refresh it.`
+        );
+      }
+      const queryVector = buildSimilarNotesQueryVector(ownChunks);
+      const exclude = new Set([notePath]);
+      const { hits } = await searchFreshEmbeddings(vaultPath, queryVector, {
+        limit,
+        excludeNotes: exclude,
+        filterNote: (hitPath) => canReadStoredEmbeddingNote(vaultPath, hitPath),
+      });
+      const ranked = hits.map((h) => ({
+        notePath: h.notePath,
+        score: h.score,
+        chunkIndex: h.chunkIndex,
+        headingPath: h.headingPath,
+        text: h.text,
+      }));
+
+      if (ranked.length === 0) {
+        return text(
+          `No similar notes found for "${displaySemanticValue(notePath)}".`
+        );
+      }
+      return richText("find_similar_notes paths and headings", (b) => {
+        b.trusted(
+          `${ranked.length} note(s) similar to ${displaySemanticValue(notePath)}:`
+        );
+        b.trusted("");
+        for (const r of ranked) {
+          b.trusted(`- score: ${r.score.toFixed(3)}`);
+          b.trusted("    Path:");
+          semanticPathBlock(b, "find_similar_notes result path", r.notePath);
+          if (r.headingPath.length > 0) {
+            b.trusted("    Heading:");
+            semanticHeadingBlock(b, r.headingPath);
+          }
+        }
+      });
+    }
   );
 }

--- a/src/tools/semantic/index_vault.ts
+++ b/src/tools/semantic/index_vault.ts
@@ -22,15 +22,12 @@ import {
 } from "../../lib/embedding-store.js";
 import { makeProgressReporter } from "../../lib/progress.js";
 import { sanitizeError } from "../../lib/errors.js";
-import { formatUntrustedFailedPath } from "../../lib/tool-output.js";
 import { log } from "../../lib/logger.js";
+import { defineTool, text, richText, error } from "../../lib/tool-seam.js";
 import {
   MISSING_PROVIDER_HINT,
   INDEX_VAULT_CONFIRMATION,
   EMBED_BATCH_SIZE,
-  textResult,
-  untrustedVaultTextResult,
-  errorResult,
   displaySemanticValue,
 } from "./shared.js";
 
@@ -43,34 +40,45 @@ interface IndexProgress {
   failed: Array<{ path: string; error: string }>;
 }
 
-function headingPathsEqual(a: readonly string[], b: readonly string[]): boolean {
+function headingPathsEqual(
+  a: readonly string[],
+  b: readonly string[]
+): boolean {
   return a.length === b.length && a.every((part, index) => part === b[index]);
 }
 
 function storedChunksMatchLiveChunks(
   vaultPath: string,
   notePath: string,
-  chunks: ReturnType<typeof chunkNote>,
+  chunks: ReturnType<typeof chunkNote>
 ): boolean {
   const stored = getNoteEmbeddings(vaultPath, notePath);
   if (stored.length !== chunks.length) return false;
-  const storedByIndex = new Map(stored.map((chunk) => [chunk.chunkIndex, chunk]));
+  const storedByIndex = new Map(
+    stored.map((chunk) => [chunk.chunkIndex, chunk])
+  );
   for (const chunk of chunks) {
     const storedChunk = storedByIndex.get(chunk.index);
     if (!storedChunk) return false;
     if (storedChunk.text !== chunk.text) return false;
-    if (!headingPathsEqual(storedChunk.headingPath, chunk.headingPath)) return false;
+    if (!headingPathsEqual(storedChunk.headingPath, chunk.headingPath))
+      return false;
   }
   return true;
 }
 
-export function registerIndexVaultTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "index_vault",
+export function registerIndexVaultTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "index_vault",
       title: "Index Vault for Semantic Search",
       description:
-        "Build or refresh the embedding index used by `search_semantic` and `find_similar_notes`. Splits readable notes into heading-aware chunks, sends those chunks to the configured embedding provider (Ollama by default, OpenAI optional), and persists the index to `<vault>/.obsidian/cache/mcp-pro-embeddings.json`. Requires `confirm: \"send-vault-text-to-embedding-provider\"` so callers explicitly acknowledge that vault text will leave this tool boundary. Incremental: notes whose content hash matches the prior pass are skipped. Use `force: true` to re-embed everything (e.g., after switching models). Emits progress notifications when the client subscribes.",
+        'Build or refresh the embedding index used by `search_semantic` and `find_similar_notes`. Splits readable notes into heading-aware chunks, sends those chunks to the configured embedding provider (Ollama by default, OpenAI optional), and persists the index to `<vault>/.obsidian/cache/mcp-pro-embeddings.json`. Requires `confirm: "send-vault-text-to-embedding-provider"` so callers explicitly acknowledge that vault text will leave this tool boundary. Incremental: notes whose content hash matches the prior pass are skipped. Use `force: true` to re-embed everything (e.g., after switching models). Emits progress notifications when the client subscribes.',
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -82,213 +90,249 @@ export function registerIndexVaultTool(server: McpServer, vaultPath: string): vo
           .boolean()
           .optional()
           .default(false)
-          .describe("If true, re-embed every note even if its content hash matches the cached one."),
+          .describe(
+            "If true, re-embed every note even if its content hash matches the cached one."
+          ),
         folder: z
           .string()
           .max(500)
           .optional()
-          .describe("Restrict the indexing pass to this folder. Notes outside the folder are left untouched."),
+          .describe(
+            "Restrict the indexing pass to this folder. Notes outside the folder are left untouched."
+          ),
         confirm: z
           .literal(INDEX_VAULT_CONFIRMATION)
           .optional()
           .describe(
-            `Required safety latch. Set exactly to "${INDEX_VAULT_CONFIRMATION}" to acknowledge that readable note chunks will be sent to the configured embedding provider.`,
+            `Required safety latch. Set exactly to "${INDEX_VAULT_CONFIRMATION}" to acknowledge that readable note chunks will be sent to the configured embedding provider.`
           ),
       },
     },
-    async ({ force, folder, confirm }, extra) => {
+    async ({ force, folder, confirm }, { extra }) => {
       return withFileLock(vaultRewriteLockKey(vaultPath), async () => {
-        try {
-          const provider = getActiveProvider();
-          if (!provider) {
-            return errorResult(
-              `Semantic search has no embedding provider configured. ${MISSING_PROVIDER_HINT}`,
-            );
-          }
-          if (confirm !== INDEX_VAULT_CONFIRMATION) {
-            return errorResult(
-              `index_vault sends readable note chunks to the configured embedding provider (${displaySemanticValue(provider.id)}/${displaySemanticValue(provider.model)}). ` +
-                `Set confirm to "${INDEX_VAULT_CONFIRMATION}" to proceed.`,
-            );
-          }
-
-          await loadStore(vaultPath);
-          invalidateIfIncompatible(vaultPath, provider.id, provider.model);
-
-          const progressMeta: Parameters<typeof makeProgressReporter>[0] = {
-            ...(extra._meta?.progressToken != null
-              ? { _meta: { progressToken: extra._meta.progressToken } }
-              : {}),
-            sendNotification: extra.sendNotification.bind(extra),
-          };
-          const reportProgress = makeProgressReporter(progressMeta);
-          const notes = await listNotes(vaultPath, folder);
-          if (notes.length === 0) {
-            return textResult(
-              folder ? `No notes in "${displaySemanticValue(folder)}" to index.` : "Vault is empty — nothing to index.",
-            );
-          }
-
-          const { contents } = await readAllCached(vaultPath, notes, (note, err) => {
-            log.warn("index_vault: note read failed", { note, err });
-          });
-
-          const stats: IndexProgress = {
-            notesScanned: 0,
-            notesEmbedded: 0,
-            chunksEmbedded: 0,
-            notesUnchanged: 0,
-            notesPruned: 0,
-            failed: [],
-          };
-
-          interface PendingChunk {
-            notePath: string;
-            contentHash: string;
-            chunkIndex: number;
-            headingPath: string[];
-            text: string;
-          }
-          const pending: PendingChunk[] = [];
-          const noteHashByPath = new Map<string, string>();
-          const expectedChunksByNote = new Map<string, number>();
-
-          for (const notePath of notes) {
-            const content = contents.get(notePath);
-            if (content === undefined) continue;
-            const contentHash = hashText(content);
-            const chunks = chunkNote(content);
-            if (
-              !force &&
-              noteIsCurrent(vaultPath, notePath, contentHash) &&
-              storedChunksMatchLiveChunks(vaultPath, notePath, chunks)
-            ) {
-              stats.notesUnchanged++;
-              stats.notesScanned++;
-              await reportProgress(stats.notesScanned, notes.length, `Unchanged note ${stats.notesScanned}/${notes.length}`);
-              continue;
-            }
-            noteHashByPath.set(notePath, contentHash);
-            expectedChunksByNote.set(notePath, chunks.length);
-            for (const ch of chunks) {
-              pending.push({
-                notePath,
-                contentHash,
-                chunkIndex: ch.index,
-                headingPath: ch.headingPath,
-                text: ch.text,
-              });
-            }
-            stats.notesScanned++;
-            await reportProgress(stats.notesScanned, notes.length, `Chunked note ${stats.notesScanned}/${notes.length}`);
-          }
-
-          const noteChunks = new Map<string, ChunkEmbedding[]>();
-          const failedNotes = new Set<string>();
-          let expectedVectorDimension: number | null = null;
-          for (let i = 0; i < pending.length; i += EMBED_BATCH_SIZE) {
-            const batch = pending.slice(i, i + EMBED_BATCH_SIZE);
-            let vectors: number[][];
-            try {
-              vectors = await provider.embed(batch.map((b) => b.text));
-            } catch (err) {
-              for (const item of batch) {
-                stats.failed.push({ path: item.notePath, error: (err as Error).message });
-                failedNotes.add(item.notePath);
-              }
-              continue;
-            }
-            for (let j = 0; j < batch.length; j++) {
-              const item = batch[j];
-              if (!item) continue;
-              const vector = vectors[j];
-              if (!Array.isArray(vector)) {
-                stats.failed.push({ path: item.notePath, error: "provider returned no vector" });
-                failedNotes.add(item.notePath);
-                continue;
-              }
-              const vectorError = validateEmbeddingVector(vector, expectedVectorDimension);
-              if (vectorError !== null) {
-                stats.failed.push({ path: item.notePath, error: vectorError });
-                failedNotes.add(item.notePath);
-                continue;
-              }
-              expectedVectorDimension ??= vector.length;
-              const list = noteChunks.get(item.notePath) ?? [];
-              list.push({
-                notePath: item.notePath,
-                chunkIndex: item.chunkIndex,
-                headingPath: item.headingPath,
-                text: item.text,
-                hash: "",
-                vector,
-              });
-              noteChunks.set(item.notePath, list);
-            }
-            await reportProgress(
-              Math.min(i + batch.length, pending.length),
-              pending.length,
-              `Embedded ${Math.min(i + batch.length, pending.length)}/${pending.length} chunks`,
-            );
-          }
-
-          for (const [notePath, contentHash] of noteHashByPath) {
-            const expectedChunks = expectedChunksByNote.get(notePath) ?? 0;
-            const chunks = noteChunks.get(notePath) ?? [];
-            if (failedNotes.has(notePath) || chunks.length !== expectedChunks) {
-              if (!failedNotes.has(notePath)) {
-                stats.failed.push({
-                  path: notePath,
-                  error: `embedded ${chunks.length}/${expectedChunks} chunks`,
-                });
-              }
-              continue;
-            }
-            try {
-              setNoteChunks(vaultPath, notePath, contentHash, chunks, provider.id, provider.model);
-            } catch (err) {
-              stats.failed.push({ path: notePath, error: (err as Error).message });
-              failedNotes.add(notePath);
-              continue;
-            }
-            stats.chunksEmbedded += chunks.length;
-            if (chunks.length > 0) stats.notesEmbedded++;
-          }
-
-          if (!folder) {
-            stats.notesPruned = pruneMissingNotes(vaultPath, notes);
-          }
-
-          await saveStore(vaultPath);
-
-          const lines = [
-            `Indexed${folder ? ` "${displaySemanticValue(folder)}"` : ""} via ${displaySemanticValue(provider.id)}/${displaySemanticValue(provider.model)}`,
-            `  Notes scanned:   ${stats.notesScanned}`,
-            `  Notes embedded:  ${stats.notesEmbedded}`,
-            `  Notes unchanged: ${stats.notesUnchanged}`,
-            `  Chunks embedded: ${stats.chunksEmbedded}`,
-          ];
-          if (stats.notesPruned > 0) lines.push(`  Notes pruned:    ${stats.notesPruned}`);
-          if (stats.failed.length > 0) {
-            lines.push(`  Failures:        ${stats.failed.length}`);
-            for (const f of stats.failed.slice(0, 5)) {
-              lines.push(formatUntrustedFailedPath(
-                "index_vault failed note",
-                f.path,
-                f.error,
-                "    ",
-              ));
-            }
-            if (stats.failed.length > 5) lines.push(`    ...and ${stats.failed.length - 5} more`);
-          }
-          return stats.failed.length > 0
-            ? untrustedVaultTextResult(lines.join("\n"), "index_vault failed notes")
-            : textResult(lines.join("\n"));
-        } catch (err) {
-          log.error("index_vault failed", { tool: "index_vault", err: err as Error });
-          return errorResult(`Error indexing vault: ${sanitizeError(err)}`);
+        const provider = getActiveProvider();
+        if (!provider) {
+          return error(
+            `Semantic search has no embedding provider configured. ${MISSING_PROVIDER_HINT}`
+          );
         }
+        if (confirm !== INDEX_VAULT_CONFIRMATION) {
+          return error(
+            `index_vault sends readable note chunks to the configured embedding provider (${displaySemanticValue(provider.id)}/${displaySemanticValue(provider.model)}). ` +
+              `Set confirm to "${INDEX_VAULT_CONFIRMATION}" to proceed.`
+          );
+        }
+
+        await loadStore(vaultPath);
+        invalidateIfIncompatible(vaultPath, provider.id, provider.model);
+
+        const progressMeta: Parameters<typeof makeProgressReporter>[0] = {
+          ...(extra._meta?.progressToken != null
+            ? { _meta: { progressToken: extra._meta.progressToken } }
+            : {}),
+          sendNotification: extra.sendNotification.bind(extra),
+        };
+        const reportProgress = makeProgressReporter(progressMeta);
+        const notes = await listNotes(vaultPath, folder);
+        if (notes.length === 0) {
+          return text(
+            folder
+              ? `No notes in "${displaySemanticValue(folder)}" to index.`
+              : "Vault is empty — nothing to index."
+          );
+        }
+
+        const { contents } = await readAllCached(
+          vaultPath,
+          notes,
+          (note, err) => {
+            log.warn("index_vault: note read failed", { note, err });
+          }
+        );
+
+        const stats: IndexProgress = {
+          notesScanned: 0,
+          notesEmbedded: 0,
+          chunksEmbedded: 0,
+          notesUnchanged: 0,
+          notesPruned: 0,
+          failed: [],
+        };
+
+        interface PendingChunk {
+          notePath: string;
+          contentHash: string;
+          chunkIndex: number;
+          headingPath: string[];
+          text: string;
+        }
+        const pending: PendingChunk[] = [];
+        const noteHashByPath = new Map<string, string>();
+        const expectedChunksByNote = new Map<string, number>();
+
+        for (const notePath of notes) {
+          const content = contents.get(notePath);
+          if (content === undefined) continue;
+          const contentHash = hashText(content);
+          const chunks = chunkNote(content);
+          if (
+            !force &&
+            noteIsCurrent(vaultPath, notePath, contentHash) &&
+            storedChunksMatchLiveChunks(vaultPath, notePath, chunks)
+          ) {
+            stats.notesUnchanged++;
+            stats.notesScanned++;
+            await reportProgress(
+              stats.notesScanned,
+              notes.length,
+              `Unchanged note ${stats.notesScanned}/${notes.length}`
+            );
+            continue;
+          }
+          noteHashByPath.set(notePath, contentHash);
+          expectedChunksByNote.set(notePath, chunks.length);
+          for (const ch of chunks) {
+            pending.push({
+              notePath,
+              contentHash,
+              chunkIndex: ch.index,
+              headingPath: ch.headingPath,
+              text: ch.text,
+            });
+          }
+          stats.notesScanned++;
+          await reportProgress(
+            stats.notesScanned,
+            notes.length,
+            `Chunked note ${stats.notesScanned}/${notes.length}`
+          );
+        }
+
+        const noteChunks = new Map<string, ChunkEmbedding[]>();
+        const failedNotes = new Set<string>();
+        let expectedVectorDimension: number | null = null;
+        for (let i = 0; i < pending.length; i += EMBED_BATCH_SIZE) {
+          const batch = pending.slice(i, i + EMBED_BATCH_SIZE);
+          let vectors: number[][];
+          try {
+            vectors = await provider.embed(batch.map((b) => b.text));
+          } catch (err) {
+            for (const item of batch) {
+              stats.failed.push({
+                path: item.notePath,
+                error: (err as Error).message,
+              });
+              failedNotes.add(item.notePath);
+            }
+            continue;
+          }
+          for (let j = 0; j < batch.length; j++) {
+            const item = batch[j];
+            if (!item) continue;
+            const vector = vectors[j];
+            if (!Array.isArray(vector)) {
+              stats.failed.push({
+                path: item.notePath,
+                error: "provider returned no vector",
+              });
+              failedNotes.add(item.notePath);
+              continue;
+            }
+            const vectorError = validateEmbeddingVector(
+              vector,
+              expectedVectorDimension
+            );
+            if (vectorError !== null) {
+              stats.failed.push({ path: item.notePath, error: vectorError });
+              failedNotes.add(item.notePath);
+              continue;
+            }
+            expectedVectorDimension ??= vector.length;
+            const list = noteChunks.get(item.notePath) ?? [];
+            list.push({
+              notePath: item.notePath,
+              chunkIndex: item.chunkIndex,
+              headingPath: item.headingPath,
+              text: item.text,
+              hash: "",
+              vector,
+            });
+            noteChunks.set(item.notePath, list);
+          }
+          await reportProgress(
+            Math.min(i + batch.length, pending.length),
+            pending.length,
+            `Embedded ${Math.min(i + batch.length, pending.length)}/${pending.length} chunks`
+          );
+        }
+
+        for (const [notePath, contentHash] of noteHashByPath) {
+          const expectedChunks = expectedChunksByNote.get(notePath) ?? 0;
+          const chunks = noteChunks.get(notePath) ?? [];
+          if (failedNotes.has(notePath) || chunks.length !== expectedChunks) {
+            if (!failedNotes.has(notePath)) {
+              stats.failed.push({
+                path: notePath,
+                error: `embedded ${chunks.length}/${expectedChunks} chunks`,
+              });
+            }
+            continue;
+          }
+          try {
+            setNoteChunks(
+              vaultPath,
+              notePath,
+              contentHash,
+              chunks,
+              provider.id,
+              provider.model
+            );
+          } catch (err) {
+            stats.failed.push({
+              path: notePath,
+              error: (err as Error).message,
+            });
+            failedNotes.add(notePath);
+            continue;
+          }
+          stats.chunksEmbedded += chunks.length;
+          if (chunks.length > 0) stats.notesEmbedded++;
+        }
+
+        if (!folder) {
+          stats.notesPruned = pruneMissingNotes(vaultPath, notes);
+        }
+
+        await saveStore(vaultPath);
+
+        // Conditional block-level _meta: richText attaches the
+        // "index_vault failed notes" trust tag only if a failed-path
+        // untrusted section is appended, so a clean run stays untagged
+        // (matching the prior untrustedVaultTextResult-vs-textResult split).
+        return richText("index_vault failed notes", (b) => {
+          b.trusted(
+            `Indexed${folder ? ` "${displaySemanticValue(folder)}"` : ""} via ${displaySemanticValue(provider.id)}/${displaySemanticValue(provider.model)}`
+          );
+          b.trusted(`  Notes scanned:   ${stats.notesScanned}`);
+          b.trusted(`  Notes embedded:  ${stats.notesEmbedded}`);
+          b.trusted(`  Notes unchanged: ${stats.notesUnchanged}`);
+          b.trusted(`  Chunks embedded: ${stats.chunksEmbedded}`);
+          if (stats.notesPruned > 0)
+            b.trusted(`  Notes pruned:    ${stats.notesPruned}`);
+          if (stats.failed.length > 0) {
+            b.trusted(`  Failures:        ${stats.failed.length}`);
+            for (const f of stats.failed.slice(0, 5)) {
+              b.untrusted(
+                "index_vault failed note",
+                `- ${displaySemanticValue(f.path)}: ${sanitizeError(f.error)}`,
+                "    "
+              );
+            }
+            if (stats.failed.length > 5)
+              b.trusted(`    ...and ${stats.failed.length - 5} more`);
+          }
+        });
       });
-    },
+    }
   );
 }

--- a/src/tools/semantic/search_semantic.ts
+++ b/src/tools/semantic/search_semantic.ts
@@ -16,14 +16,9 @@ import {
   noteIsCurrent,
   type SearchHit,
 } from "../../lib/embedding-store.js";
-import { sanitizeError } from "../../lib/errors.js";
-import { formatUntrustedVaultContent, indentBlock } from "../../lib/tool-output.js";
-import { log } from "../../lib/logger.js";
+import { defineTool, text, richText, error } from "../../lib/tool-seam.js";
 import {
   MISSING_PROVIDER_HINT,
-  textResult,
-  untrustedVaultTextResult,
-  errorResult,
   displaySemanticValue,
   semanticPathBlock,
   semanticHeadingBlock,
@@ -39,30 +34,39 @@ interface FreshSearchOptions {
 async function searchFreshEmbeddings(
   vaultPath: string,
   queryVector: number[],
-  options: FreshSearchOptions,
+  options: FreshSearchOptions
 ): Promise<{ hits: SearchHit[]; stalePruned: number }> {
-  function headingPathsEqual(a: readonly string[], b: readonly string[]): boolean {
+  function headingPathsEqual(
+    a: readonly string[],
+    b: readonly string[]
+  ): boolean {
     return a.length === b.length && a.every((part, index) => part === b[index]);
   }
 
   function storedChunksMatchLiveChunks(
     vaultPath: string,
     notePath: string,
-    chunks: ReturnType<typeof chunkNote>,
+    chunks: ReturnType<typeof chunkNote>
   ): boolean {
     const stored = getNoteEmbeddings(vaultPath, notePath);
     if (stored.length !== chunks.length) return false;
-    const storedByIndex = new Map(stored.map((chunk) => [chunk.chunkIndex, chunk]));
+    const storedByIndex = new Map(
+      stored.map((chunk) => [chunk.chunkIndex, chunk])
+    );
     for (const chunk of chunks) {
       const storedChunk = storedByIndex.get(chunk.index);
       if (!storedChunk) return false;
       if (storedChunk.text !== chunk.text) return false;
-      if (!headingPathsEqual(storedChunk.headingPath, chunk.headingPath)) return false;
+      if (!headingPathsEqual(storedChunk.headingPath, chunk.headingPath))
+        return false;
     }
     return true;
   }
 
-  async function storedNoteIsCurrent(vaultPath: string, notePath: string): Promise<boolean> {
+  async function storedNoteIsCurrent(
+    vaultPath: string,
+    notePath: string
+  ): Promise<boolean> {
     try {
       const content = await readNote(vaultPath, notePath);
       const chunks = chunkNote(content);
@@ -75,7 +79,10 @@ async function searchFreshEmbeddings(
     }
   }
 
-  async function pruneStaleStoredNote(vaultPath: string, notePath: string): Promise<boolean> {
+  async function pruneStaleStoredNote(
+    vaultPath: string,
+    notePath: string
+  ): Promise<boolean> {
     const current = await storedNoteIsCurrent(vaultPath, notePath);
     if (current) return false;
     return dropNoteChunks(vaultPath, notePath);
@@ -117,7 +124,10 @@ async function searchFreshEmbeddings(
   return { hits, stalePruned };
 }
 
-function canReadStoredEmbeddingNote(vaultPath: string, notePath: string): boolean {
+function canReadStoredEmbeddingNote(
+  vaultPath: string,
+  notePath: string
+): boolean {
   try {
     resolveVaultPath(vaultPath, notePath, "read");
     return true;
@@ -126,10 +136,15 @@ function canReadStoredEmbeddingNote(vaultPath: string, notePath: string): boolea
   }
 }
 
-export function registerSearchSemanticTool(server: McpServer, vaultPath: string): void {
-  server.registerTool(
-    "search_semantic",
+export function registerSearchSemanticTool(
+  server: McpServer,
+  vaultPath: string
+): void {
+  defineTool(
+    server,
+    vaultPath,
     {
+      name: "search_semantic",
       title: "Semantic Search",
       description:
         "Search notes by meaning rather than keywords. Embeds the query with the configured provider, scores every chunk in the persisted index by cosine similarity, ranks one result per note using the best chunk plus a small top-chunk focus signal, and returns the best chunk as the snippet source. Run `index_vault` first to populate the index — this tool does not auto-index because the user should know they're paying the embedding cost. Pair with `get_note` to retrieve full bodies after picking a hit.",
@@ -143,7 +158,9 @@ export function registerSearchSemanticTool(server: McpServer, vaultPath: string)
           .string()
           .min(1)
           .max(10_000)
-          .describe("Natural-language description of what you're looking for, e.g. 'notes about onboarding new hires'."),
+          .describe(
+            "Natural-language description of what you're looking for, e.g. 'notes about onboarding new hires'."
+          ),
         limit: z
           .number()
           .int()
@@ -156,71 +173,74 @@ export function registerSearchSemanticTool(server: McpServer, vaultPath: string)
           .string()
           .max(500)
           .optional()
-          .describe("Restrict the search to a folder relative to the vault root."),
+          .describe(
+            "Restrict the search to a folder relative to the vault root."
+          ),
         includeSnippet: z
           .boolean()
           .optional()
           .default(true)
-          .describe("If true (default), include a short snippet of the matching chunk under each hit."),
+          .describe(
+            "If true (default), include a short snippet of the matching chunk under each hit."
+          ),
       },
     },
     async ({ query, limit, folder, includeSnippet }) => {
-      try {
-        const provider = getActiveProvider();
-        if (!provider) {
-          return errorResult(
-            `Semantic search has no embedding provider configured. ${MISSING_PROVIDER_HINT}`,
-          );
-        }
-        await loadStore(vaultPath);
-        invalidateIfIncompatible(vaultPath, provider.id, provider.model);
-        const snap = snapshotForTests(vaultPath);
-        if (snap.totalChunks === 0) {
-          return errorResult(
-            `Embedding index is empty${snap.providerId === null ? "" : " for the active provider/model"}. Run \`index_vault\` to build it before searching semantically.`,
-          );
-        }
+      const provider = getActiveProvider();
+      if (!provider) {
+        return error(
+          `Semantic search has no embedding provider configured. ${MISSING_PROVIDER_HINT}`
+        );
+      }
+      await loadStore(vaultPath);
+      invalidateIfIncompatible(vaultPath, provider.id, provider.model);
+      const snap = snapshotForTests(vaultPath);
+      if (snap.totalChunks === 0) {
+        return error(
+          `Embedding index is empty${snap.providerId === null ? "" : " for the active provider/model"}. Run \`index_vault\` to build it before searching semantically.`
+        );
+      }
 
-        const [vector] = await provider.embed([query]);
-        if (!Array.isArray(vector)) {
-          return errorResult("Provider did not return a vector for the query.");
-        }
-        const vectorError = validateEmbeddingVector(vector, snap.dimension);
-        if (vectorError !== null) {
-          return errorResult(`Provider returned an invalid query vector: ${vectorError}.`);
-        }
-        const { hits } = await searchFreshEmbeddings(vaultPath, vector, {
-          limit,
-          ...(folder ? { folder } : {}),
-          filterNote: (notePath) => canReadStoredEmbeddingNote(vaultPath, notePath),
-        });
-        if (hits.length === 0) {
-          return textResult(`No matches for "${displaySemanticValue(query)}".`);
-        }
+      const [vector] = await provider.embed([query]);
+      if (!Array.isArray(vector)) {
+        return error("Provider did not return a vector for the query.");
+      }
+      const vectorError = validateEmbeddingVector(vector, snap.dimension);
+      if (vectorError !== null) {
+        return error(
+          `Provider returned an invalid query vector: ${vectorError}.`
+        );
+      }
+      const { hits } = await searchFreshEmbeddings(vaultPath, vector, {
+        limit,
+        ...(folder ? { folder } : {}),
+        filterNote: (notePath) =>
+          canReadStoredEmbeddingNote(vaultPath, notePath),
+      });
+      if (hits.length === 0) {
+        return text(`No matches for "${displaySemanticValue(query)}".`);
+      }
 
-        const lines: string[] = [`${hits.length} match(es) for "${displaySemanticValue(query)}":`, ""];
+      return richText("search_semantic vault text", (b) => {
+        b.trusted(
+          `${hits.length} match(es) for "${displaySemanticValue(query)}":`
+        );
+        b.trusted("");
         for (const hit of hits) {
-          lines.push(`- score: ${hit.score.toFixed(3)}`);
-          lines.push("    Path:");
-          lines.push(semanticPathBlock("search_semantic result path", hit.notePath));
+          b.trusted(`- score: ${hit.score.toFixed(3)}`);
+          b.trusted("    Path:");
+          semanticPathBlock(b, "search_semantic result path", hit.notePath);
           if (hit.headingPath.length > 0) {
-            lines.push("    Heading:");
-            lines.push(semanticHeadingBlock(hit.headingPath));
+            b.trusted("    Heading:");
+            semanticHeadingBlock(b, hit.headingPath);
           }
           if (includeSnippet) {
             const snippet = hit.text.replace(/\s+/g, " ").trim().slice(0, 200);
             const clipped = `${displaySemanticValue(snippet)}${hit.text.length > 200 ? "..." : ""}`;
-            lines.push(indentBlock(
-              formatUntrustedVaultContent("semantic snippet", clipped),
-              "    ",
-            ));
+            b.untrusted("semantic snippet", clipped, "    ");
           }
         }
-        return untrustedVaultTextResult(lines.join("\n"), "search_semantic vault text");
-      } catch (err) {
-        log.error("search_semantic failed", { tool: "search_semantic", err: err as Error });
-        return errorResult(`Error during semantic search: ${sanitizeError(err)}`);
-      }
-    },
+      });
+    }
   );
 }

--- a/src/tools/semantic/shared.ts
+++ b/src/tools/semantic/shared.ts
@@ -1,9 +1,11 @@
+import type { RichTextBuilder } from "../../lib/tool-seam.js";
 import { escapeControlChars } from "../../lib/errors.js";
-import {
-  formatUntrustedVaultContent,
-  indentBlock,
-  untrustedVaultContentMeta,
-} from "../../lib/tool-output.js";
+
+// The error/result/trust-wrapping recipe (textResult, untrustedVaultTextResult,
+// errorResult) now lives in the tool seam (../../lib/tool-seam.ts): handlers
+// return a ToolResult built via `text` / `richText` / `error`, and the seam owns
+// error sanitization. What remains here are the semantic group's own constants,
+// escaping helper, and builder-based render helpers that emit through richText.
 
 const MISSING_PROVIDER_HINT =
   "Set OBSIDIAN_EMBEDDING_PROVIDER=ollama (default) and run an Ollama server with `ollama pull nomic-embed-text`. " +
@@ -12,53 +14,36 @@ const MISSING_PROVIDER_HINT =
 const INDEX_VAULT_CONFIRMATION = "send-vault-text-to-embedding-provider";
 const EMBED_BATCH_SIZE = 16;
 
-function textResult(text: string) {
-  return { content: [{ type: "text" as const, text }] };
-}
-
-function untrustedVaultTextResult(text: string, label: string) {
-  return {
-    content: [{
-      type: "text" as const,
-      text,
-      _meta: untrustedVaultContentMeta(label),
-    }],
-  };
-}
-
-function errorResult(text: string) {
-  return { content: [{ type: "text" as const, text }], isError: true as const };
-}
-
 const displaySemanticValue = escapeControlChars;
 
 function displayHeadingPath(path: readonly string[]): string {
   return path.map(displaySemanticValue).join(" / ");
 }
 
-function semanticHeadingBlock(headingPath: readonly string[]): string {
-  return indentBlock(
-    formatUntrustedVaultContent("semantic heading", displayHeadingPath(headingPath)),
-    "    ",
-  );
+/** Append the note path as a wrapped untrusted block. */
+function semanticPathBlock(
+  b: RichTextBuilder,
+  label: string,
+  notePath: string,
+  indent = "    "
+): void {
+  b.untrusted(label, displaySemanticValue(notePath), indent);
 }
 
-function semanticPathBlock(label: string, notePath: string, indent = "    "): string {
-  return indentBlock(
-    formatUntrustedVaultContent(label, displaySemanticValue(notePath)),
-    indent,
-  );
+/** Append the heading path (joined) as a wrapped untrusted block. */
+function semanticHeadingBlock(
+  b: RichTextBuilder,
+  headingPath: readonly string[]
+): void {
+  b.untrusted("semantic heading", displayHeadingPath(headingPath), "    ");
 }
 
 export {
   MISSING_PROVIDER_HINT,
   INDEX_VAULT_CONFIRMATION,
   EMBED_BATCH_SIZE,
-  textResult,
-  untrustedVaultTextResult,
-  errorResult,
   displaySemanticValue,
   displayHeadingPath,
-  semanticHeadingBlock,
   semanticPathBlock,
+  semanticHeadingBlock,
 };


### PR DESCRIPTION
The **last of 9 groups**. Routes find_similar_notes, index_vault, search_semantic through `defineTool`.

- `index_vault` threads `ctx.extra` for progress (guarded by the existing note-path progress test) and its conditional failed-notes `_meta` falls out of `richText`'s `hasUntrusted`; its failed-paths block maps to `b.untrusted` exactly as the read-group gates predicted - **no seam change**.
- shared `semanticPathBlock`/`semanticHeadingBlock` become builder-based; domain errors -> `error()`; added `untrustedContentLabel` assertions.
- **Byte-preserving**: existing semantic tests stay green unchanged (only the generic `Error:` thrown-error prefix differs, exception #1). typecheck/lint/build clean; **984 tests**. Seam module untouched.

**All 9 groups now through the seam.** Only the `display*Value` collapse + `TOOL_AUTHORING §4` sweep (#252) remains. Closes #251.