### PR TITLE
refactor(tools): collapse display*Value aliases + document defineTool (seam cleanup)

### DIFF
--- a/docs/TOOL_AUTHORING.md
+++ b/docs/TOOL_AUTHORING.md
@@ -161,21 +161,42 @@ All four things are there: range, default, semantics, tradeoff.
 
 ## § 4 — Handler conventions
 
-> **Migration in progress (ADR 0001).** The `read` group now registers through
-> the tool seam (`src/lib/tool-seam.ts`): handlers return a `ToolResult` built
-> via `text` / `untrustedText` / `richText` / `error`, and the seam owns error
-> sanitization and untrusted-content wrapping. When editing a seam-migrated
-> group, follow that pattern, **not** the per-file recipe below. The recipe
-> still describes the 8 groups not yet migrated. See `docs/adr/0001-tool-seam.md`.
+Every tool registers through the **tool seam** (`src/lib/tool-seam.ts`). Do not
+write the old per-file recipe (a terminal `try/catch` + `errorResult` +
+hand-rolled untrusted-content wrapping) — the seam owns all of that. See
+`docs/adr/0001-tool-seam.md` for the full rationale.
 
-Keep handlers thin. The scorer doesn't see handler code, but reviewers do:
+Register with `defineTool(server, vaultPath, spec, handler)`. The `spec` carries
+the client-facing surface (`name` / `title` / `description` / `annotations` /
+`inputSchema`) unchanged; the handler is schema plus pure logic that returns a
+`ToolResult` or throws.
 
-- Use the shared `errorResult(text)` helper at the top of each file.
-- Catch errors, log to `console.error`, return `isError: true`.
-- Text output should be human-readable (grouped, with counts/summaries) —
-  not raw JSON — because LLMs will re-parse this.
-- When a result is empty, still return a friendly message
-  (`"No backlinks found for: ..."`), not just `content: []`.
+- Build the result **only** through the seam constructors — a raw
+  `{ content: [...] }` literal will not type-check:
+  - `text(body)` — one trusted, unwrapped block (confirmations, empty-result
+    messages with no vault content).
+  - `untrustedText(label, body)` — one fully-untrusted vault-text block.
+  - `richText(itemTrustLabel, b => …)` — mixed framing: `b.trusted(line)` for
+    server text, `b.untrusted(label, body, indent?)` for wrapped vault sections.
+    The block-level trust `_meta` is attached only if at least one `b.untrusted`
+    was appended, so conditional-`_meta` cases fall out for free.
+  - `error(message)` — a verbatim, handler-authored error block.
+  - `asError(result)` — flag a built result as an error.
+  - `image` / `audio` / `blobResource` / `untrustedResource` — the `get_attachment`
+    media blocks (caption text + one media block).
+- **Escaping vs wrapping.** Escape any vault-derived value interpolated into
+  trusted text with `escapeControlChars` (from `../../lib/errors.js`). Surface
+  whole pieces of vault content through `untrustedText` / `b.untrusted`, never by
+  hand — the seam BEGIN/END-wraps them and attaches the trust `_meta`.
+- **Errors.** Domain/expected failures return `error(...)` verbatim (already
+  escaped). Just throw on anything unexpected — the seam logs `"<name> failed"`,
+  applies `sanitizeError`, and returns a generic `Error:` result. Never build
+  `isError` results by hand.
+- Use the closure `vaultPath` from the register param; destructure `ctx` only
+  for `extra` (progress) or `server` (elicitation) when a handler needs it.
+- Text output should be human-readable (grouped, with counts/summaries) — not
+  raw JSON — because LLMs re-parse it. When a result is empty, still return a
+  friendly message (`"No backlinks found for: …"`), not `content: []`.
 
 ---
 

--- a/docs/adr/0001-tool-seam.md
+++ b/docs/adr/0001-tool-seam.md
@@ -1,6 +1,6 @@
 # ADR 0001: One deep tool seam behind every MCP tool
 
-- Status: Accepted and complete — all 9 groups migrated (read as the pattern-setter, then canvas, links, a Wave-1 fan-out of write/tags/sections/bases, attachments which extended the seam with the non-text media constructors, and finally semantic). Follow-up sweep remaining: collapse the `display*Value` aliases and rewrite `TOOL_AUTHORING.md §4`.
+- Status: Accepted and complete — all 9 groups (41 tools) migrated (read as the pattern-setter, then canvas, links, a Wave-1 fan-out of write/tags/sections/bases, attachments which extended the seam with the non-text media constructors, and finally semantic). The follow-up sweep is also done: the per-group `display*Value` aliases are collapsed to a single `escapeControlChars`, and `TOOL_AUTHORING.md §4` documents `defineTool` as the norm.
 - Date: 2026-07-18
 
 ## Context
@@ -176,7 +176,8 @@ cannot type-check). The **semantic** group migrated last: `index_vault` threads
 its conditional failed-notes `_meta` falls out of `richText`'s `hasUntrusted`;
 its failed-paths block — the layout flagged during the read-group gates as the
 hairiest — was expressible via `richText` + `b.untrusted(..., indent)` exactly
-as predicted, with no seam change. All 9 groups are now through the seam.
-Collapsing the 9 `display*Value` aliases to a single `escapeControlChars` import
-is the remaining follow-up sweep, and `TOOL_AUTHORING.md §4` is rewritten with
-it now that the pattern is proven across all groups.
+as predicted, with no seam change. All 9 groups are now through the seam. The
+follow-up sweep then collapsed the 11 `display*Value` aliases (one per group
+plus `index.ts`/`prompts.ts`) — each a misleading rename of `escapeControlChars`
+— down to that single canonical function, and rewrote `TOOL_AUTHORING.md §4` to
+document `defineTool` and the `ToolResult` vocabulary as the norm.

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,6 @@ import { registerPrompts } from "./tools/prompts.js";
 import { startHttpServer } from "./http-server.js";
 import { runInstall, type InstallClient } from "./install.js";
 
-const displayResourceValue = escapeControlChars;
-
 interface CliOptions {
   command: "serve" | "install" | "help" | "version";
   transport: "stdio" | "http";
@@ -277,8 +275,8 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
       const content = contents.get(notePath);
       if (content === undefined) continue;
       for (const tag of extractTags(content)) {
-        const normalizedTag = `#${displayResourceValue(tag)}`;
-        (tagIndex[normalizedTag] ??= []).push(displayResourceValue(notePath));
+        const normalizedTag = `#${escapeControlChars(tag)}`;
+        (tagIndex[normalizedTag] ??= []).push(escapeControlChars(notePath));
       }
     }
 
@@ -326,7 +324,7 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
       // same thing — clients need a proper error so they can branch on it.
       const pathLabel = "daily note resource expected path";
       throw new Error(
-        `No daily note found for today.\n${formatUntrustedVaultContent(pathLabel, displayResourceValue(notePath))}`
+        `No daily note found for today.\n${formatUntrustedVaultContent(pathLabel, escapeControlChars(notePath))}`
       );
     }
   });

--- a/src/tools/attachments/find_unused_attachments.ts
+++ b/src/tools/attachments/find_unused_attachments.ts
@@ -17,7 +17,7 @@ import {
 } from "../../lib/markdown.js";
 import { log } from "../../lib/logger.js";
 import { defineTool, text, richText } from "../../lib/tool-seam.js";
-import { displayAttachmentValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 
 const ATTACHMENT_INVENTORY_CACHE_LIMIT = 8;
 
@@ -351,13 +351,13 @@ export function registerFindUnusedAttachments(
         totalLine = `Total reclaimable: ${totalBytes.toLocaleString()} bytes (across all ${unused.length} unused attachment(s))`;
         rowLines = truncated.map((p) => {
           const sz = sizes.get(p);
-          const displayedPath = displayAttachmentValue(p);
+          const displayedPath = escapeControlChars(p);
           return sz !== undefined
             ? `- ${displayedPath}  (${sz.toLocaleString()} bytes)`
             : `- ${displayedPath}`;
         });
       } else {
-        rowLines = truncated.map((p) => `- ${displayAttachmentValue(p)}`);
+        rowLines = truncated.map((p) => `- ${escapeControlChars(p)}`);
       }
 
       return richText("find_unused_attachments paths", (b) => {

--- a/src/tools/attachments/get_attachment.ts
+++ b/src/tools/attachments/get_attachment.ts
@@ -18,7 +18,7 @@ import {
   untrustedResource,
 } from "../../lib/tool-seam.js";
 import {
-  displayAttachmentValue,
+  escapeControlChars,
   vaultResourceUri,
   safeResourceMimeType,
 } from "./shared.js";
@@ -60,7 +60,7 @@ async function assertNoSymlinkAttachmentPath(
     const entry = await fs.lstat(current);
     if (entry.isSymbolicLink()) {
       throw new Error(
-        `Refusing to fetch symlink attachment: ${displayAttachmentValue(relPath)}`
+        `Refusing to fetch symlink attachment: ${escapeControlChars(relPath)}`
       );
     }
   }
@@ -106,7 +106,7 @@ export function registerGetAttachment(
       const hiddenName = hiddenAttachmentSegment(relPath);
       if (hiddenName) {
         return error(
-          `Refusing to fetch hidden attachment "${displayAttachmentValue(relPath)}" via get_attachment.`
+          `Refusing to fetch hidden attachment "${escapeControlChars(relPath)}" via get_attachment.`
         );
       }
 
@@ -118,7 +118,7 @@ export function registerGetAttachment(
         lowerPath.endsWith(".base")
       ) {
         return error(
-          `Refusing to fetch "${displayAttachmentValue(relPath)}" via get_attachment - use get_note / read_canvas / read_base instead.`
+          `Refusing to fetch "${escapeControlChars(relPath)}" via get_attachment - use get_note / read_canvas / read_base instead.`
         );
       }
 
@@ -126,7 +126,7 @@ export function registerGetAttachment(
       const blockedExt = getBlockedExtension(relPath);
       if (blockedExt) {
         return error(
-          `Blocked: "${displayAttachmentValue(relPath)}" has a dangerous extension (${displayAttachmentValue(blockedExt)}). ` +
+          `Blocked: "${escapeControlChars(relPath)}" has a dangerous extension (${escapeControlChars(blockedExt)}). ` +
             `Executable file types are not served as attachments.`
         );
       }
@@ -140,7 +140,7 @@ export function registerGetAttachment(
         // error; anything else is unexpected and rethrown to the seam.
         if ((err as Error).message === `Not a regular file: ${relPath}`) {
           return error(
-            `Attachment "${displayAttachmentValue(relPath)}" is not a regular file.`
+            `Attachment "${escapeControlChars(relPath)}" is not a regular file.`
           );
         }
         throw err;
@@ -156,12 +156,12 @@ export function registerGetAttachment(
         const stat = await handle.stat();
         if (!stat.isFile()) {
           return error(
-            `Attachment "${displayAttachmentValue(relPath)}" is not a regular file.`
+            `Attachment "${escapeControlChars(relPath)}" is not a regular file.`
           );
         }
         if (stat.size > limit) {
           return error(
-            `Attachment "${displayAttachmentValue(relPath)}" is ${stat.size.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`
+            `Attachment "${escapeControlChars(relPath)}" is ${stat.size.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`
           );
         }
         bytes = await handle.readFile();
@@ -170,14 +170,14 @@ export function registerGetAttachment(
       }
       if (bytes.byteLength > limit) {
         return error(
-          `Attachment "${displayAttachmentValue(relPath)}" is ${bytes.byteLength.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`
+          `Attachment "${escapeControlChars(relPath)}" is ${bytes.byteLength.toLocaleString()} bytes - over the ${limit.toLocaleString()}-byte limit. Pass maxBytes to override (hard cap ${ABSOLUTE_GET_ATTACHMENT_LIMIT.toLocaleString()}).`
         );
       }
       const attachmentSize = bytes.byteLength;
       const mime = detectMimeType(relPath);
       const category = categorizeMimeType(mime);
       const basename = path.basename(relPath);
-      const displayedBasename = displayAttachmentValue(basename);
+      const displayedBasename = escapeControlChars(basename);
 
       // SEC-8: SVG files can contain embedded <script> tags and event
       // handlers, making them an XSS vector. Return SVG content as

--- a/src/tools/attachments/list_attachments.ts
+++ b/src/tools/attachments/list_attachments.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { listAttachments } from "../../lib/vault.js";
 import { defineTool, text, richText } from "../../lib/tool-seam.js";
-import { displayAttachmentValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 
 /** Group attachments by their lower-cased extension for the summary line. */
 function summarizeByExtension(paths: readonly string[]): Map<string, number> {
@@ -65,7 +65,7 @@ export function registerListAttachments(
       if (filtered.length === 0) {
         return text(
           extension
-            ? `No attachments with extension "${displayAttachmentValue(extension)}".`
+            ? `No attachments with extension "${escapeControlChars(extension)}".`
             : "No attachments in this vault."
         );
       }
@@ -78,7 +78,7 @@ export function registerListAttachments(
 
       return richText(trustLabel, (b) => {
         b.trusted(
-          `${filtered.length} attachment(s)${extension ? ` (.${displayAttachmentValue(extension.replace(/^\./, ""))})` : ""}${filtered.length > limit ? ` (showing first ${limit})` : ""}:`
+          `${filtered.length} attachment(s)${extension ? ` (.${escapeControlChars(extension.replace(/^\./, ""))})` : ""}${filtered.length > limit ? ` (showing first ${limit})` : ""}:`
         );
         b.trusted("");
         if (hasExtensionBreakdown) {
@@ -89,7 +89,7 @@ export function registerListAttachments(
           b.untrusted(
             "list_attachments extensions",
             entries
-              .map(([ext, n]) => `${displayAttachmentValue(ext)}  ${n}`)
+              .map(([ext, n]) => `${escapeControlChars(ext)}  ${n}`)
               .join("\n"),
             "  "
           );
@@ -97,7 +97,7 @@ export function registerListAttachments(
         }
         b.untrusted(
           "list_attachments paths",
-          truncated.map((p) => `- ${displayAttachmentValue(p)}`).join("\n")
+          truncated.map((p) => `- ${escapeControlChars(p)}`).join("\n")
         );
       });
     }

--- a/src/tools/attachments/shared.ts
+++ b/src/tools/attachments/shared.ts
@@ -7,7 +7,6 @@ import { escapeControlChars } from "../../lib/errors.js";
 // sanitization. What remains here are the attachment group's own helpers.
 
 /** Escape control characters in a value before embedding it in a display string. */
-const displayAttachmentValue = escapeControlChars;
 
 function vaultResourceUri(relPath: string): string {
   return `vault://${relPath.replace(/\\/g, "/").split("/").map(encodeURIComponent).join("/")}`;
@@ -24,4 +23,4 @@ function safeResourceMimeType(mime: string): string {
   return ACTIVE_TEXT_MIME_TYPES.has(mime.toLowerCase()) ? "text/plain" : mime;
 }
 
-export { displayAttachmentValue, vaultResourceUri, safeResourceMimeType };
+export { escapeControlChars, vaultResourceUri, safeResourceMimeType };

--- a/src/tools/bases/list-bases.ts
+++ b/src/tools/bases/list-bases.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { listBaseFiles } from "../../lib/vault.js";
 import { defineTool, text, richText } from "../../lib/tool-seam.js";
-import { displayBaseValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 
 export function registerListBases(server: McpServer, vaultPath: string): void {
   defineTool(
@@ -25,8 +25,11 @@ export function registerListBases(server: McpServer, vaultPath: string): void {
       return richText("list_bases paths", (b) => {
         b.trusted(`Found ${bases.length} Base file(s):`);
         b.trusted("");
-        b.untrusted("list_bases paths", bases.map(displayBaseValue).join("\n"));
+        b.untrusted(
+          "list_bases paths",
+          bases.map(escapeControlChars).join("\n")
+        );
       });
-    },
+    }
   );
 }

--- a/src/tools/bases/query-base.ts
+++ b/src/tools/bases/query-base.ts
@@ -6,7 +6,7 @@ import { readAllCached } from "../../lib/index-cache.js";
 import { extractWikilinks } from "../../lib/markdown.js";
 import { log } from "../../lib/logger.js";
 import { defineTool, richText } from "../../lib/tool-seam.js";
-import { displayBaseValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 
 export function registerQueryBase(server: McpServer, vaultPath: string): void {
   defineTool(
@@ -16,7 +16,7 @@ export function registerQueryBase(server: McpServer, vaultPath: string): void {
       name: "query_base",
       title: "Query Base",
       description:
-        "Run a Base file's filters against the vault and return matching note paths. Optionally pick a named view to apply that view's filters and ordering on top of the base-level filters. Supported filter syntax (subset of Obsidian's full DSL): chained methods `file.hasTag(\"tag\")`, `file.hasProperty(\"key\")`, `file.inFolder(\"path\")`, `file.linksTo(\"target\")`, `file.name.contains(\"x\")`/`.startsWith`/`.endsWith`/`.equals`, plus `.isEmpty`/`.isNotEmpty` on any value; legacy function form `taggedWith(file, \"tag\")`; comparisons `key == \"val\"`, `key != x`, `key contains x`, `>=`, `<=`, `>`, `<`; combinators `and:`, `or:`, `not:`. Recognized file properties: file.name, file.basename, file.folder, file.ext, file.path, file.size, file.ctime, file.mtime, file.tags, file.properties, file.links, file.embeds, file.backlinks. Unsupported clauses are reported as warnings and treated as no-match.",
+        'Run a Base file\'s filters against the vault and return matching note paths. Optionally pick a named view to apply that view\'s filters and ordering on top of the base-level filters. Supported filter syntax (subset of Obsidian\'s full DSL): chained methods `file.hasTag("tag")`, `file.hasProperty("key")`, `file.inFolder("path")`, `file.linksTo("target")`, `file.name.contains("x")`/`.startsWith`/`.endsWith`/`.equals`, plus `.isEmpty`/`.isNotEmpty` on any value; legacy function form `taggedWith(file, "tag")`; comparisons `key == "val"`, `key != x`, `key contains x`, `>=`, `<=`, `>`, `<`; combinators `and:`, `or:`, `not:`. Recognized file properties: file.name, file.basename, file.folder, file.ext, file.path, file.size, file.ctime, file.mtime, file.tags, file.properties, file.links, file.embeds, file.backlinks. Unsupported clauses are reported as warnings and treated as no-match.',
       annotations: {
         readOnlyHint: true,
         idempotentHint: true,
@@ -33,7 +33,9 @@ export function registerQueryBase(server: McpServer, vaultPath: string): void {
           .string()
           .max(5000)
           .optional()
-          .describe("Optional view name (or view type) to apply on top of the base-level filters."),
+          .describe(
+            "Optional view name (or view type) to apply on top of the base-level filters."
+          ),
         limit: z
           .number()
           .int()
@@ -41,7 +43,9 @@ export function registerQueryBase(server: McpServer, vaultPath: string): void {
           .max(1000)
           .optional()
           .default(100)
-          .describe("Maximum number of matching notes to return (1-1000, default: 100)."),
+          .describe(
+            "Maximum number of matching notes to return (1-1000, default: 100)."
+          ),
         includeFrontmatter: z
           .boolean()
           .optional()
@@ -57,13 +61,17 @@ export function registerQueryBase(server: McpServer, vaultPath: string): void {
       // note individually. readAllCached stat()'s each path and only re-reads
       // files whose mtime has moved, which makes repeat queries near-instant.
       const readFailures: string[] = [];
-      const { contents, stats } = await readAllCached(vaultPath, notes, (relPath, err) => {
-        readFailures.push(relPath);
-        log.warn("query_base: note read failed", {
-          note: relPath,
-          err,
-        });
-      });
+      const { contents, stats } = await readAllCached(
+        vaultPath,
+        notes,
+        (relPath, err) => {
+          readFailures.push(relPath);
+          log.warn("query_base: note read failed", {
+            note: relPath,
+            err,
+          });
+        }
+      );
       const validRows = notes
         .filter((notePath) => contents.has(notePath))
         .map((notePath) => {
@@ -74,19 +82,15 @@ export function registerQueryBase(server: McpServer, vaultPath: string): void {
           // Without this, row.links is undefined and link filters fail
           // closed with a warning.
           const linkInfos = extractWikilinks(content);
-          row.links = linkInfos
-            .filter((l) => !l.isEmbed)
-            .map((l) => l.target);
-          row.embeds = linkInfos
-            .filter((l) => l.isEmbed)
-            .map((l) => l.target);
+          row.links = linkInfos.filter((l) => !l.isEmbed).map((l) => l.target);
+          row.embeds = linkInfos.filter((l) => l.isEmbed).map((l) => l.target);
           return row;
         });
       const result = queryBase(validRows, doc, view);
       const allWarnings = [...warnings, ...result.warnings];
       if (readFailures.length > 0) {
         allWarnings.push(
-          `Could not read ${readFailures.length} note(s); they were excluded from results.`,
+          `Could not read ${readFailures.length} note(s); they were excluded from results.`
         );
       }
       const truncated = result.rows.slice(0, limit);
@@ -97,43 +101,50 @@ export function registerQueryBase(server: McpServer, vaultPath: string): void {
 
       return richText(itemTrustLabel, (b) => {
         b.trusted("Base:");
-        b.untrusted("query_base base path", displayBaseValue(basePath), "  ");
-        if (view) b.trusted(`View: ${displayBaseValue(view)}`);
+        b.untrusted("query_base base path", escapeControlChars(basePath), "  ");
+        if (view) b.trusted(`View: ${escapeControlChars(view)}`);
         b.trusted(
-          `Matched ${result.rows.length} note(s)${result.rows.length > limit ? ` (showing first ${limit})` : ""}`,
+          `Matched ${result.rows.length} note(s)${result.rows.length > limit ? ` (showing first ${limit})` : ""}`
         );
         if (allWarnings.length > 0) {
           b.trusted("");
           b.trusted("Warnings:");
           b.untrusted(
             "query_base warnings",
-            allWarnings.map((w) => `- ${displayBaseValue(w)}`).join("\n"),
-            "  ",
+            allWarnings.map((w) => `- ${escapeControlChars(w)}`).join("\n"),
+            "  "
           );
         }
         b.trusted("");
         if (includeFrontmatter) {
           for (const row of truncated) {
-            b.untrusted("query_base row path", `- ${displayBaseValue(row.path)}`);
+            b.untrusted(
+              "query_base row path",
+              `- ${escapeControlChars(row.path)}`
+            );
             if (Object.keys(row.frontmatter).length > 0) {
               const frontmatterLines: string[] = [];
               for (const [k, v] of Object.entries(row.frontmatter)) {
-                frontmatterLines.push(`${displayBaseValue(k)}: ${JSON.stringify(v)}`);
+                frontmatterLines.push(
+                  `${escapeControlChars(k)}: ${JSON.stringify(v)}`
+                );
               }
               b.untrusted(
                 "query_base row frontmatter",
                 frontmatterLines.join("\n"),
-                "    ",
+                "    "
               );
             }
           }
         } else if (truncated.length > 0) {
           b.untrusted(
             "query_base result paths",
-            truncated.map((row) => `- ${displayBaseValue(row.path)}`).join("\n"),
+            truncated
+              .map((row) => `- ${escapeControlChars(row.path)}`)
+              .join("\n")
           );
         }
       });
-    },
+    }
   );
 }

--- a/src/tools/bases/read-base.ts
+++ b/src/tools/bases/read-base.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { readBaseFile } from "../../lib/vault.js";
 import { parseBaseFile } from "../../lib/bases.js";
 import { defineTool, untrustedText } from "../../lib/tool-seam.js";
-import { displayBaseValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 
 export function registerReadBase(server: McpServer, vaultPath: string): void {
   defineTool(
@@ -31,20 +31,25 @@ export function registerReadBase(server: McpServer, vaultPath: string): void {
     async ({ path: basePath }) => {
       const raw = await readBaseFile(vaultPath, basePath);
       const { doc, warnings } = parseBaseFile(raw);
-      const lines: string[] = [`Base: ${displayBaseValue(basePath)}`, ""];
+      const lines: string[] = [`Base: ${escapeControlChars(basePath)}`, ""];
       if (warnings.length > 0) {
         lines.push("Parse warnings:");
-        for (const w of warnings) lines.push(`  - ${displayBaseValue(w)}`);
+        for (const w of warnings) lines.push(`  - ${escapeControlChars(w)}`);
         lines.push("");
       }
       lines.push("Filters:");
-      lines.push("  " + JSON.stringify(doc.filters ?? null, null, 2).split("\n").join("\n  "));
+      lines.push(
+        "  " +
+          JSON.stringify(doc.filters ?? null, null, 2)
+            .split("\n")
+            .join("\n  ")
+      );
       lines.push("");
       if (doc.properties) {
         lines.push(`Properties (${Object.keys(doc.properties).length}):`);
         for (const [key, spec] of Object.entries(doc.properties)) {
           lines.push(
-            `  - ${displayBaseValue(key)}${spec.displayName ? ` (display: ${displayBaseValue(spec.displayName)})` : ""}`,
+            `  - ${escapeControlChars(key)}${spec.displayName ? ` (display: ${escapeControlChars(spec.displayName)})` : ""}`
           );
         }
         lines.push("");
@@ -53,10 +58,12 @@ export function registerReadBase(server: McpServer, vaultPath: string): void {
         lines.push(`Views (${doc.views.length}):`);
         for (const v of doc.views) {
           const nm = v.name ?? "(unnamed)";
-          lines.push(`  - ${displayBaseValue(nm)} [type: ${displayBaseValue(v.type)}]`);
+          lines.push(
+            `  - ${escapeControlChars(nm)} [type: ${escapeControlChars(v.type)}]`
+          );
         }
       }
       return untrustedText("read_base document", lines.join("\n"));
-    },
+    }
   );
 }

--- a/src/tools/bases/shared.ts
+++ b/src/tools/bases/shared.ts
@@ -1,4 +1,4 @@
 import { escapeControlChars } from "../../lib/errors.js";
 
 /** Escape control characters before embedding values in Base tool display text. */
-export const displayBaseValue = escapeControlChars;
+export { escapeControlChars };

--- a/src/tools/canvas/add-canvas-edge.ts
+++ b/src/tools/canvas/add-canvas-edge.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { updateCanvasFile } from "../../lib/vault.js";
 import { defineTool, text, error } from "../../lib/tool-seam.js";
 import type { CanvasData } from "../../types.js";
-import { displayCanvasValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 import { invalidateCanvasReadCache } from "./read-canvas.js";
 
 export function registerAddCanvasEdge(
@@ -69,7 +69,7 @@ export function registerAddCanvasEdge(
       // BUG-15: Reject self-loops early before touching the canvas file.
       if (fromNode === toNode) {
         return error(
-          `Self-loop rejected: fromNode and toNode are the same ('${displayCanvasValue(fromNode)}'). Edges must connect two different nodes.`
+          `Self-loop rejected: fromNode and toNode are the same ('${escapeControlChars(fromNode)}'). Edges must connect two different nodes.`
         );
       }
 
@@ -82,7 +82,7 @@ export function registerAddCanvasEdge(
           public nodeId: string
         ) {
           super(
-            `${side} node '${displayCanvasValue(nodeId)}' not found in canvas.`
+            `${side} node '${escapeControlChars(nodeId)}' not found in canvas.`
           );
         }
       }
@@ -92,7 +92,7 @@ export function registerAddCanvasEdge(
           public to: string
         ) {
           super(
-            `An edge from '${displayCanvasValue(from)}' to '${displayCanvasValue(to)}' already exists on the canvas.`
+            `An edge from '${escapeControlChars(from)}' to '${escapeControlChars(to)}' already exists on the canvas.`
           );
         }
       }
@@ -133,7 +133,7 @@ export function registerAddCanvasEdge(
       invalidateCanvasReadCache(vaultPath, canvasPath);
 
       return text(
-        `Edge added successfully.\nID: ${id}\nFrom: ${displayCanvasValue(fromNode)} -> To: ${displayCanvasValue(toNode)}${label ? `\nLabel: ${displayCanvasValue(label)}` : ""}`
+        `Edge added successfully.\nID: ${id}\nFrom: ${escapeControlChars(fromNode)} -> To: ${escapeControlChars(toNode)}${label ? `\nLabel: ${escapeControlChars(label)}` : ""}`
       );
     }
   );

--- a/src/tools/canvas/add-canvas-node.ts
+++ b/src/tools/canvas/add-canvas-node.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { resolveVaultPathSafe, updateCanvasFile } from "../../lib/vault.js";
 import { defineTool, text, error } from "../../lib/tool-seam.js";
 import type { CanvasNode } from "../../types.js";
-import { displayCanvasValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 import { invalidateCanvasReadCache } from "./read-canvas.js";
 
 const ALLOWED_CANVAS_LINK_PROTOCOLS = new Set(["http:", "https:"]);
@@ -14,13 +14,13 @@ function validateCanvasLinkUrl(value: string): string | null {
   try {
     parsed = new URL(value.trim());
   } catch {
-    return `Invalid URL in "${displayCanvasValue(value)}". Canvas link URLs must be absolute http:// or https:// URLs.`;
+    return `Invalid URL in "${escapeControlChars(value)}". Canvas link URLs must be absolute http:// or https:// URLs.`;
   }
   if (!ALLOWED_CANVAS_LINK_PROTOCOLS.has(parsed.protocol)) {
-    return `Invalid URL scheme in "${displayCanvasValue(value)}". Only http:// and https:// canvas link URLs are allowed.`;
+    return `Invalid URL scheme in "${escapeControlChars(value)}". Only http:// and https:// canvas link URLs are allowed.`;
   }
   if (hasUrlControlChars(value)) {
-    return `Invalid URL in "${displayCanvasValue(value)}". Control characters are not allowed in canvas link URLs.`;
+    return `Invalid URL in "${escapeControlChars(value)}". Control characters are not allowed in canvas link URLs.`;
   }
   return null;
 }
@@ -139,7 +139,7 @@ export function registerAddCanvasNode(
           await resolveVaultPathSafe(vaultPath, content);
         } catch {
           return error(
-            `Invalid file reference: "${displayCanvasValue(content)}" must be a relative path inside the vault.`
+            `Invalid file reference: "${escapeControlChars(content)}" must be a relative path inside the vault.`
           );
         }
       }

--- a/src/tools/canvas/list-canvases.ts
+++ b/src/tools/canvas/list-canvases.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { listCanvasFiles } from "../../lib/vault.js";
 import { defineTool, text, richText } from "../../lib/tool-seam.js";
-import { displayCanvasValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 
 export function registerListCanvases(
   server: McpServer,
@@ -30,7 +30,7 @@ export function registerListCanvases(
       }
 
       const formatted = files
-        .map((f, i) => `${i + 1}. ${displayCanvasValue(f)}`)
+        .map((f, i) => `${i + 1}. ${escapeControlChars(f)}`)
         .join("\n");
       return richText("list_canvases paths", (b) => {
         b.trusted(`Found ${files.length} canvas file(s):`);

--- a/src/tools/canvas/read-canvas.ts
+++ b/src/tools/canvas/read-canvas.ts
@@ -8,7 +8,7 @@ import {
   type RichTextBuilder,
 } from "../../lib/tool-seam.js";
 import type { CanvasData } from "../../types.js";
-import { displayCanvasValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 
 const CANVAS_READ_CACHE_LIMIT = 16;
 const CANVAS_SUMMARY_NODE_LIMIT = 200;
@@ -63,7 +63,7 @@ function renderCanvasSummary(
   data: CanvasData
 ): void {
   b.trusted("Canvas:");
-  b.untrusted("read_canvas path", displayCanvasValue(canvasPath), "  ");
+  b.untrusted("read_canvas path", escapeControlChars(canvasPath), "  ");
   b.trusted(`Nodes: ${data.nodes.length} | Edges: ${data.edges.length}`);
   b.trusted("");
 
@@ -89,7 +89,7 @@ function renderCanvasSummary(
       b.trusted("  Node:");
       b.untrusted(
         "read_canvas node identity",
-        `[${displayCanvasValue(node.id)}] type=${displayCanvasValue(node.type)}`,
+        `[${escapeControlChars(node.id)}] type=${escapeControlChars(node.type)}`,
         "    "
       );
       b.trusted(`    pos=${pos} size=${size}`);
@@ -97,7 +97,7 @@ function renderCanvasSummary(
         b.trusted("    content:");
         b.untrusted(
           "read_canvas node content",
-          displayCanvasValue(preview),
+          escapeControlChars(preview),
           "      "
         );
       }
@@ -105,7 +105,7 @@ function renderCanvasSummary(
         b.trusted("    color:");
         b.untrusted(
           "read_canvas node color",
-          displayCanvasValue(node.color),
+          escapeControlChars(node.color),
           "      "
         );
       }
@@ -124,8 +124,8 @@ function renderCanvasSummary(
     const visibleEdges = data.edges.slice(0, CANVAS_SUMMARY_EDGE_LIMIT);
     for (const edge of visibleEdges) {
       const sides = [
-        edge.fromSide ? `from-side=${displayCanvasValue(edge.fromSide)}` : "",
-        edge.toSide ? `to-side=${displayCanvasValue(edge.toSide)}` : "",
+        edge.fromSide ? `from-side=${escapeControlChars(edge.fromSide)}` : "",
+        edge.toSide ? `to-side=${escapeControlChars(edge.toSide)}` : "",
       ]
         .filter(Boolean)
         .join(" ");
@@ -133,14 +133,14 @@ function renderCanvasSummary(
       b.trusted("  Edge:");
       b.untrusted(
         "read_canvas edge endpoints",
-        `${displayCanvasValue(edge.fromNode)} -> ${displayCanvasValue(edge.toNode)}${sideInfo}`,
+        `${escapeControlChars(edge.fromNode)} -> ${escapeControlChars(edge.toNode)}${sideInfo}`,
         "    "
       );
       if (edge.label) {
         b.trusted("    label:");
         b.untrusted(
           "read_canvas edge label",
-          displayCanvasValue(edge.label),
+          escapeControlChars(edge.label),
           "      "
         );
       }

--- a/src/tools/canvas/shared.ts
+++ b/src/tools/canvas/shared.ts
@@ -6,6 +6,4 @@ import { escapeControlChars } from "../../lib/errors.js";
 // seam owns error sanitization. What remains here is the canvas group's own
 // escaping helper.
 
-export function displayCanvasValue(value: string): string {
-  return escapeControlChars(value);
-}
+export { escapeControlChars };

--- a/src/tools/links/find_broken_links.ts
+++ b/src/tools/links/find_broken_links.ts
@@ -5,7 +5,7 @@ import { defineTool, text, richText } from "../../lib/tool-seam.js";
 import type { BrokenLink } from "../../types.js";
 import {
   buildLinkGraph,
-  displayLinkValue,
+  escapeControlChars,
   untrustedLinkTarget,
 } from "./shared.js";
 
@@ -63,7 +63,7 @@ export function registerFindBrokenLinks(
 
       if (brokenBySource.size === 0) {
         const scopeStr = folder
-          ? ` in folder: ${displayLinkValue(folder)}`
+          ? ` in folder: ${escapeControlChars(folder)}`
           : "";
         return text(`No broken links found${scopeStr}`);
       }
@@ -73,7 +73,7 @@ export function registerFindBrokenLinks(
         totalBroken += brokenLinks.length;
       }
 
-      const scopeStr = folder ? ` (folder: ${displayLinkValue(folder)})` : "";
+      const scopeStr = folder ? ` (folder: ${escapeControlChars(folder)})` : "";
 
       return richText("find_broken_links paths and targets", (b) => {
         b.trusted(`Broken links report${scopeStr}\n`);
@@ -84,7 +84,7 @@ export function registerFindBrokenLinks(
           b.trusted("Source:");
           b.untrusted(
             "find_broken_links source path",
-            displayLinkValue(sourcePath),
+            escapeControlChars(sourcePath),
             "  "
           );
           for (const bl of brokenLinks) {

--- a/src/tools/links/get_backlinks.ts
+++ b/src/tools/links/get_backlinks.ts
@@ -5,7 +5,7 @@ import {
   buildLinkGraph,
   resolveGraphInputPath,
   findLineWithLink,
-  displayLinkValue,
+  escapeControlChars,
   resolveWikilinkWithIndex,
 } from "./shared.js";
 
@@ -43,7 +43,7 @@ export function registerGetBacklinks(
 
       if (!resolvedTarget) {
         return error(
-          `No note found matching path: ${displayLinkValue(targetPath)}`
+          `No note found matching path: ${escapeControlChars(targetPath)}`
         );
       }
 
@@ -53,7 +53,7 @@ export function registerGetBacklinks(
           b.trusted("No backlinks found for:");
           b.untrusted(
             "get_backlinks target path",
-            displayLinkValue(resolvedTarget),
+            escapeControlChars(resolvedTarget),
             "  "
           );
         });
@@ -109,7 +109,7 @@ export function registerGetBacklinks(
         b.trusted("Backlinks to:");
         b.untrusted(
           "get_backlinks target path",
-          displayLinkValue(resolvedTarget),
+          escapeControlChars(resolvedTarget),
           "  "
         );
         b.trusted(`Found: ${deduped.length} backlink(s)\n`);
@@ -118,7 +118,7 @@ export function registerGetBacklinks(
           b.trusted("Source:");
           b.untrusted(
             "get_backlinks source path",
-            `${displayLinkValue(r.source)}${lineStr}`,
+            `${escapeControlChars(r.source)}${lineStr}`,
             "  "
           );
           if (r.context) {
@@ -130,7 +130,7 @@ export function registerGetBacklinks(
             // is unchanged — a purely visual delta, no trust impact.
             b.untrusted(
               "get_backlinks context",
-              displayLinkValue(r.context),
+              escapeControlChars(r.context),
               "  "
             );
           }

--- a/src/tools/links/get_graph_neighbors.ts
+++ b/src/tools/links/get_graph_neighbors.ts
@@ -5,7 +5,7 @@ import { defineTool, richText, error } from "../../lib/tool-seam.js";
 import {
   buildLinkGraph,
   resolveGraphInputPath,
-  displayLinkValue,
+  escapeControlChars,
 } from "./shared.js";
 
 export function registerGetGraphNeighbors(
@@ -69,7 +69,7 @@ export function registerGetGraphNeighbors(
 
       if (!resolvedStart) {
         return error(
-          `No note found matching path: ${displayLinkValue(startPath)}`
+          `No note found matching path: ${escapeControlChars(startPath)}`
         );
       }
 
@@ -138,7 +138,7 @@ export function registerGetGraphNeighbors(
           b.trusted("No neighbors found for:");
           b.untrusted(
             "get_graph_neighbors start path",
-            displayLinkValue(resolvedStart),
+            escapeControlChars(resolvedStart),
             "  "
           );
           b.trusted(`(depth: ${depth}, direction: ${direction})`);
@@ -155,7 +155,7 @@ export function registerGetGraphNeighbors(
       }
 
       const truncatedStr = truncated ? " (TRUNCATED)" : "";
-      const pathTreeLines = [displayLinkValue(resolvedStart)];
+      const pathTreeLines = [escapeControlChars(resolvedStart)];
 
       const sortedDepths = [...byDepth.keys()].sort((a, b) => a - b);
       for (const d of sortedDepths) {
@@ -171,7 +171,7 @@ export function registerGetGraphNeighbors(
                 ? "→"
                 : "↔";
           pathTreeLines.push(
-            `${indent}${arrow} ${displayLinkValue(neighbor.path)} (depth ${d})`
+            `${indent}${arrow} ${escapeControlChars(neighbor.path)} (depth ${d})`
           );
         }
       }
@@ -180,7 +180,7 @@ export function registerGetGraphNeighbors(
         b.trusted("Graph neighbors of:");
         b.untrusted(
           "get_graph_neighbors start path",
-          displayLinkValue(resolvedStart),
+          escapeControlChars(resolvedStart),
           "  "
         );
         b.trusted(

--- a/src/tools/links/get_outlinks.ts
+++ b/src/tools/links/get_outlinks.ts
@@ -4,7 +4,7 @@ import { defineTool, richText, error } from "../../lib/tool-seam.js";
 import {
   buildLinkGraph,
   resolveGraphInputPath,
-  displayLinkValue,
+  escapeControlChars,
   untrustedLinkTarget,
 } from "./shared.js";
 
@@ -45,7 +45,7 @@ export function registerGetOutlinks(
       const resolvedSource = resolveGraphInputPath(graph, notePath);
       if (!resolvedSource) {
         return error(
-          `No note found matching path: ${displayLinkValue(notePath)}`
+          `No note found matching path: ${escapeControlChars(notePath)}`
         );
       }
 
@@ -56,7 +56,7 @@ export function registerGetOutlinks(
           b.trusted("No outgoing links found in:");
           b.untrusted(
             "get_outlinks source path",
-            displayLinkValue(resolvedSource),
+            escapeControlChars(resolvedSource),
             "  "
           );
         });
@@ -69,7 +69,7 @@ export function registerGetOutlinks(
         b.trusted("Outgoing links from:");
         b.untrusted(
           "get_outlinks source path",
-          displayLinkValue(resolvedSource),
+          escapeControlChars(resolvedSource),
           "  "
         );
         b.trusted(
@@ -82,7 +82,7 @@ export function registerGetOutlinks(
             b.trusted("  Resolved path:");
             b.untrusted(
               "get_outlinks resolved path",
-              `${displayLinkValue(r.resolvedPath ?? "")}${r.isEmbed ? " (embed)" : ""}`,
+              `${escapeControlChars(r.resolvedPath ?? "")}${r.isEmbed ? " (embed)" : ""}`,
               "    "
             );
             untrustedLinkTarget(b, "get_outlinks target", r.target, "    ");

--- a/src/tools/links/shared.ts
+++ b/src/tools/links/shared.ts
@@ -431,9 +431,7 @@ export function findLineWithLink(
   return { line: 0, content: "" };
 }
 
-export function displayLinkValue(value: string): string {
-  return escapeControlChars(value);
-}
+export { escapeControlChars };
 
 // Group render helpers that emit through the seam's richText builder — the seam
 // owns the actual BEGIN/END wrapping and the block-level trust `_meta`. These
@@ -447,7 +445,7 @@ export function untrustedLinkTarget(
   indent: string
 ): void {
   b.trusted(`${indent}Target:`);
-  b.untrusted(label, displayLinkValue(target), `${indent}  `);
+  b.untrusted(label, escapeControlChars(target), `${indent}  `);
 }
 
 /** Append `rows` as one wrapped untrusted block, or nothing when empty. Emitting
@@ -460,7 +458,7 @@ export function untrustedLinkPathRows(
   indent = ""
 ): void {
   if (rows.length === 0) return;
-  b.untrusted(label, rows.map(displayLinkValue).join("\n"), indent);
+  b.untrusted(label, rows.map(escapeControlChars).join("\n"), indent);
 }
 
 export { resolveWikilinkWithIndex };

--- a/src/tools/prompts.ts
+++ b/src/tools/prompts.ts
@@ -2,8 +2,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { escapeControlChars } from "../lib/errors.js";
 
-const displayPromptValue = escapeControlChars;
-
 /**
  * MCP prompts the server exposes to clients. Each prompt is a starter
  * conversation template; clients render them in their slash-command palette
@@ -42,10 +40,12 @@ export function registerPrompts(server: McpServer): void {
               `Review my Obsidian daily note${date ? ` for ${date}` : " for today"}.`,
               "",
               "Steps:",
-              "1. Call get_daily_note" + (date ? ` with date="${date}"` : "") + ".",
+              "1. Call get_daily_note" +
+                (date ? ` with date="${date}"` : "") +
+                ".",
               "2. Summarize what I worked on (1-3 bullet points).",
               "3. List any unchecked tasks (`- [ ] …`) with the section they came from.",
-              "4. Identify wikilinks in the note. Call get_recent_notes with since=\"7d\" and limit=200 once to get the set of notes touched in the last 7 days. Any linked note NOT in that set is a candidate to revisit. List up to 5 such links. Do not call get_note per link.",
+              '4. Identify wikilinks in the note. Call get_recent_notes with since="7d" and limit=200 once to get the set of notes touched in the last 7 days. Any linked note NOT in that set is a candidate to revisit. List up to 5 such links. Do not call get_note per link.',
               "5. Surface any inline #tags new to today's note that aren't used elsewhere (call get_tags once to compare).",
               "",
               "Keep it tight: a paragraph plus three short lists. No restating the whole note.",
@@ -53,7 +53,7 @@ export function registerPrompts(server: McpServer): void {
           },
         },
       ],
-    }),
+    })
   );
 
   server.registerPrompt(
@@ -92,7 +92,7 @@ export function registerPrompts(server: McpServer): void {
           },
         },
       ],
-    }),
+    })
   );
 
   server.registerPrompt(
@@ -107,7 +107,9 @@ export function registerPrompts(server: McpServer): void {
           .max(10)
           .regex(/^\d+$/, "must be a non-negative integer")
           .optional()
-          .describe("Days since last modification to qualify as stale (default: 90)"),
+          .describe(
+            "Days since last modification to qualify as stale (default: 90)"
+          ),
         folder: z
           .string()
           .max(500)
@@ -122,10 +124,10 @@ export function registerPrompts(server: McpServer): void {
           content: {
             type: "text" as const,
             text: [
-              `Find stale notes${folder ? ` in folder "${displayPromptValue(folder)}"` : ""} (untouched ${days ?? "90"}+ days).`,
+              `Find stale notes${folder ? ` in folder "${escapeControlChars(folder)}"` : ""} (untouched ${days ?? "90"}+ days).`,
               "",
               "Steps:",
-              `1. Call get_recent_notes with limit=1000${folder ? ` and folder="${displayPromptValue(folder)}"` : ""} (no \`since\` filter) to get every note ordered by most-recent-mtime first. Each row already includes an ISO timestamp, so no need to call get_note per row. The stalest notes sit at the bottom of the list.`,
+              `1. Call get_recent_notes with limit=1000${folder ? ` and folder="${escapeControlChars(folder)}"` : ""} (no \`since\` filter) to get every note ordered by most-recent-mtime first. Each row already includes an ISO timestamp, so no need to call get_note per row. The stalest notes sit at the bottom of the list.`,
               `2. Filter to notes whose mtime is older than ${days ?? "90"} days. Cap the candidate set at 25. (Optional cross-check: call get_recent_notes a second time with since="${days ?? "90"}d"; anything NOT in that set is stale.)`,
               "3. Call find_orphans once and find_broken_links once. Use the returned paths as lookup sets; do not call get_note per candidate.",
               "4. Group the (already capped) candidates into three buckets using the two lookup sets:",
@@ -140,7 +142,7 @@ export function registerPrompts(server: McpServer): void {
           },
         },
       ],
-    }),
+    })
   );
 
   server.registerPrompt(
@@ -154,12 +156,16 @@ export function registerPrompts(server: McpServer): void {
           .string()
           .max(500)
           .optional()
-          .describe("Single note path. Omit and pass `tag` instead to scan tagged notes."),
+          .describe(
+            "Single note path. Omit and pass `tag` instead to scan tagged notes."
+          ),
         tag: z
           .string()
           .max(200)
           .optional()
-          .describe("Tag to scan (e.g. 'project'). Pulls action items from every note with this tag."),
+          .describe(
+            "Tag to scan (e.g. 'project'). Pulls action items from every note with this tag."
+          ),
       },
     },
     ({ path, tag }) => ({
@@ -170,16 +176,16 @@ export function registerPrompts(server: McpServer): void {
             type: "text" as const,
             text: [
               path
-                ? `Extract action items from "${displayPromptValue(path)}".`
+                ? `Extract action items from "${escapeControlChars(path)}".`
                 : tag
-                  ? `Extract action items from every note tagged #${displayPromptValue(tag.replace(/^#/, ""))}.`
+                  ? `Extract action items from every note tagged #${escapeControlChars(tag.replace(/^#/, ""))}.`
                   : "Extract action items from the active note.",
               "",
               "Steps:",
               path
-                ? `1. Call get_note with path="${displayPromptValue(path)}".`
+                ? `1. Call get_note with path="${escapeControlChars(path)}".`
                 : tag
-                  ? `1. Call search_by_tag with tag="${displayPromptValue(tag)}". If it returns more than 20 notes, ask the user to narrow the tag before fanning out. Otherwise call get_note on each of the (capped at 20) results.`
+                  ? `1. Call search_by_tag with tag="${escapeControlChars(tag)}". If it returns more than 20 notes, ask the user to narrow the tag before fanning out. Otherwise call get_note on each of the (capped at 20) results.`
                   : "1. Ask the user which note(s) to scan (cap at 20), then call get_note for each.",
               `2. For each note, parse all unchecked task lines (\`- [ ] …\`).`,
               `3. Group by note (or by section heading where they appear).`,
@@ -190,7 +196,7 @@ export function registerPrompts(server: McpServer): void {
           },
         },
       ],
-    }),
+    })
   );
 
   server.registerPrompt(
@@ -200,8 +206,16 @@ export function registerPrompts(server: McpServer): void {
       description:
         "Generate a Map of Content (MOC) note from a tag or folder: a curated index linking the most important notes with one-line descriptions.",
       argsSchema: {
-        tag: z.string().max(200).optional().describe("Tag to gather notes from."),
-        folder: z.string().max(500).optional().describe("Folder to gather notes from."),
+        tag: z
+          .string()
+          .max(200)
+          .optional()
+          .describe("Tag to gather notes from."),
+        folder: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("Folder to gather notes from."),
       },
     },
     ({ tag, folder }) => ({
@@ -211,17 +225,17 @@ export function registerPrompts(server: McpServer): void {
           content: {
             type: "text" as const,
             text: [
-              `Build a Map of Content (MOC) for ${tag ? `tag #${displayPromptValue(tag.replace(/^#/, ""))}` : folder ? `folder "${displayPromptValue(folder)}"` : "the requested scope"}.`,
+              `Build a Map of Content (MOC) for ${tag ? `tag #${escapeControlChars(tag.replace(/^#/, ""))}` : folder ? `folder "${escapeControlChars(folder)}"` : "the requested scope"}.`,
               "",
               "Steps:",
               tag
-                ? `1. Call search_by_tag with tag="${displayPromptValue(tag)}".`
+                ? `1. Call search_by_tag with tag="${escapeControlChars(tag)}".`
                 : folder
-                  ? `1. Call list_notes with folder="${displayPromptValue(folder)}".`
+                  ? `1. Call list_notes with folder="${escapeControlChars(folder)}".`
                   : "1. Ask the user for tag or folder.",
               "2. Cap the candidate set at 40 notes (sample evenly across the result if there are more, or ask the user to narrow scope). For each capped candidate, call get_note with `lines: '1-15'` to keep token usage low.",
               "3. Cluster the notes into 3-7 groups by theme. For each cluster, write a one-line description and 5-15 wikilinks.",
-              "4. Surface notes with no obvious cluster as a final \"Misc\" group.",
+              '4. Surface notes with no obvious cluster as a final "Misc" group.',
               "5. Propose a filename like `MOCs/<topic>.md` and offer to create_note with the assembled content.",
               "",
               "Output format: A complete markdown body with H2 headers per cluster and bulleted wikilinks. Conservative; don't invent links.",
@@ -229,6 +243,6 @@ export function registerPrompts(server: McpServer): void {
           },
         },
       ],
-    }),
+    })
   );
 }

--- a/src/tools/read/get_daily_note.ts
+++ b/src/tools/read/get_daily_note.ts
@@ -15,7 +15,7 @@ import {
   richText,
   untrustedText,
 } from "../../lib/tool-seam.js";
-import { displayReadValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 
 export function registerGetDailyNoteTool(
   server: McpServer,
@@ -50,12 +50,12 @@ export function registerGetDailyNoteTool(
 
       if (!/^\d{4}-\d{2}-\d{2}$/.test(targetDate)) {
         return error(
-          `Invalid date format: "${displayReadValue(targetDate)}". Use YYYY-MM-DD.`
+          `Invalid date format: "${escapeControlChars(targetDate)}". Use YYYY-MM-DD.`
         );
       }
       const parsed = parseLocalDateOnly(targetDate);
       if (!parsed) {
-        return error(`Invalid date: "${displayReadValue(targetDate)}".`);
+        return error(`Invalid date: "${escapeControlChars(targetDate)}".`);
       }
 
       // Build the filename using moment-style tokens (YYYY, MMM, ddd, etc).
@@ -79,9 +79,9 @@ export function registerGetDailyNoteTool(
         return asError(
           richText(pathLabel, (b) => {
             b.trusted(
-              `Daily note not found for ${displayReadValue(targetDate)}.`
+              `Daily note not found for ${escapeControlChars(targetDate)}.`
             );
-            b.untrusted(pathLabel, displayReadValue(notePath));
+            b.untrusted(pathLabel, escapeControlChars(notePath));
           })
         );
       }
@@ -89,8 +89,8 @@ export function registerGetDailyNoteTool(
       const { data: dailyFrontmatter, content: dailyBody } =
         parseFrontmatter(content);
       const header: string[] = [
-        `Daily Note: ${displayReadValue(targetDate)}`,
-        `Path: ${displayReadValue(notePath)}`,
+        `Daily Note: ${escapeControlChars(targetDate)}`,
+        `Path: ${escapeControlChars(notePath)}`,
         "",
       ];
 
@@ -98,7 +98,7 @@ export function registerGetDailyNoteTool(
         header.push("--- Frontmatter ---");
         for (const [key, value] of Object.entries(dailyFrontmatter)) {
           header.push(
-            `${displayReadValue(key)}: ${displayReadValue(JSON.stringify(value) ?? "")}`
+            `${escapeControlChars(key)}: ${escapeControlChars(JSON.stringify(value) ?? "")}`
           );
         }
         header.push("--- End Frontmatter ---");

--- a/src/tools/read/get_note.ts
+++ b/src/tools/read/get_note.ts
@@ -8,7 +8,7 @@ import {
   stripBlockId,
 } from "../../lib/sections.js";
 import { defineTool, error, untrustedText } from "../../lib/tool-seam.js";
-import { displayReadValue, parseRequestedLineRange } from "./shared.js";
+import { escapeControlChars, parseRequestedLineRange } from "./shared.js";
 
 export function registerGetNoteTool(
   server: McpServer,
@@ -62,7 +62,7 @@ export function registerGetNoteTool(
       if (!section && !block && lines) {
         const parsedRange = parseRequestedLineRange(lines);
         if (!parsedRange) {
-          return error(`Invalid lines format: "${displayReadValue(lines)}"`);
+          return error(`Invalid lines format: "${escapeControlChars(lines)}"`);
         }
         const range = await readNoteLineRange(
           vaultPath,
@@ -91,7 +91,7 @@ export function registerGetNoteTool(
         const found = findSection(content, headingPath);
         if (!found) {
           return error(
-            `Section not found: "${displayReadValue(section)}" in ${displayReadValue(notePath)}`
+            `Section not found: "${escapeControlChars(section)}" in ${escapeControlChars(notePath)}`
           );
         }
         return untrustedText(
@@ -104,7 +104,7 @@ export function registerGetNoteTool(
         const found = findBlockById(content, block);
         if (!found) {
           return error(
-            `Block not found: "^${displayReadValue(block)}" in ${displayReadValue(notePath)}`
+            `Block not found: "^${escapeControlChars(block)}" in ${escapeControlChars(notePath)}`
           );
         }
         return untrustedText(
@@ -117,7 +117,7 @@ export function registerGetNoteTool(
         const allLines = content.split("\n");
         const parsedRange = parseRequestedLineRange(lines);
         if (!parsedRange)
-          return error(`Invalid lines format: "${displayReadValue(lines)}"`);
+          return error(`Invalid lines format: "${escapeControlChars(lines)}"`);
         if (parsedRange.start > allLines.length) {
           return error(
             `Line ${parsedRange.start} is past end of file (${allLines.length} lines)`
@@ -138,7 +138,7 @@ export function registerGetNoteTool(
         header.push("--- Frontmatter ---");
         for (const [key, value] of Object.entries(frontmatterData)) {
           header.push(
-            `${displayReadValue(key)}: ${displayReadValue(JSON.stringify(value) ?? "")}`
+            `${escapeControlChars(key)}: ${escapeControlChars(JSON.stringify(value) ?? "")}`
           );
         }
         header.push("--- End Frontmatter ---");
@@ -147,7 +147,7 @@ export function registerGetNoteTool(
 
       const tags = extractTags(content);
       if (tags.length > 0) {
-        header.push(`Tags: ${tags.map(displayReadValue).join(", ")}`);
+        header.push(`Tags: ${tags.map(escapeControlChars).join(", ")}`);
         header.push("");
       }
 

--- a/src/tools/read/get_recent_notes.ts
+++ b/src/tools/read/get_recent_notes.ts
@@ -7,7 +7,7 @@ import {
 } from "../../lib/vault.js";
 import { mapConcurrent } from "../../lib/concurrency.js";
 import { defineTool, error, richText, text } from "../../lib/tool-seam.js";
-import { displayReadValue, parseSince } from "./shared.js";
+import { escapeControlChars, parseSince } from "./shared.js";
 
 /** Maximum number of concurrent file I/O operations for parallel vault scans. */
 const MAX_CONCURRENT_OPS = 16;
@@ -58,7 +58,7 @@ export function registerGetRecentNotesTool(
       const sinceMs = since ? parseSince(since) : null;
       if (since && sinceMs === null) {
         return error(
-          `Invalid 'since' value: "${displayReadValue(since)}". Use ISO date or relative span like '7d', '24h', '2w'.`
+          `Invalid 'since' value: "${escapeControlChars(since)}". Use ISO date or relative span like '7d', '24h', '2w'.`
         );
       }
       const notes = await listNotes(vaultPath, folder);
@@ -93,7 +93,7 @@ export function registerGetRecentNotesTool(
       if (top.length === 0) {
         return text(
           since
-            ? `No notes modified since ${displayReadValue(since)}.`
+            ? `No notes modified since ${escapeControlChars(since)}.`
             : "No notes in the vault."
         );
       }
@@ -101,11 +101,11 @@ export function registerGetRecentNotesTool(
       const rowLines: string[] = [];
       for (const r of top) {
         const iso = new Date(r.mtimeMs).toISOString();
-        rowLines.push(`- ${displayReadValue(r.path)}  (${iso})`);
+        rowLines.push(`- ${escapeControlChars(r.path)}  (${iso})`);
       }
       return richText("get_recent_notes paths", (b) => {
         b.trusted(
-          `${rows.length} note(s)${since ? ` modified since ${displayReadValue(since)}` : ""}${rows.length > limit ? ` (showing first ${limit})` : ""}:`
+          `${rows.length} note(s)${since ? ` modified since ${escapeControlChars(since)}` : ""}${rows.length > limit ? ` (showing first ${limit})` : ""}:`
         );
         b.trusted("");
         if (rowLines.length > 0) {

--- a/src/tools/read/get_vault_stats.ts
+++ b/src/tools/read/get_vault_stats.ts
@@ -5,7 +5,7 @@ import { readAllCached } from "../../lib/index-cache.js";
 import { log } from "../../lib/logger.js";
 import { parseFrontmatter, extractTags } from "../../lib/markdown.js";
 import { defineTool, richText, text } from "../../lib/tool-seam.js";
-import { displayReadValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 
 export function registerGetVaultStatsTool(
   server: McpServer,
@@ -39,7 +39,7 @@ export function registerGetVaultStatsTool(
       if (notes.length === 0) {
         return text(
           folder
-            ? `No notes in "${displayReadValue(folder)}"`
+            ? `No notes in "${escapeControlChars(folder)}"`
             : "Vault is empty."
         );
       }
@@ -80,7 +80,7 @@ export function registerGetVaultStatsTool(
       const untaggedPct = ((untagged / notes.length) * 100).toFixed(1);
       return richText("get_vault_stats most recent path", (b) => {
         b.trusted(
-          `Vault stats${folder ? ` (folder: ${displayReadValue(folder)})` : ""}`
+          `Vault stats${folder ? ` (folder: ${escapeControlChars(folder)})` : ""}`
         );
         b.trusted("");
         b.trusted(`  Notes:           ${notes.length}`);
@@ -94,7 +94,7 @@ export function registerGetVaultStatsTool(
           b.trusted("  Most recent:");
           b.untrusted(
             "get_vault_stats most recent path",
-            `${displayReadValue(mostRecent.path)} (${new Date(mostRecent.mtimeMs).toISOString()})`,
+            `${escapeControlChars(mostRecent.path)} (${new Date(mostRecent.mtimeMs).toISOString()})`,
             "    "
           );
         } else {

--- a/src/tools/read/list_notes.ts
+++ b/src/tools/read/list_notes.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { listNotes } from "../../lib/vault.js";
 import { defineTool, richText } from "../../lib/tool-seam.js";
-import { displayReadValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 
 export function registerListNotesTool(
   server: McpServer,
@@ -48,13 +48,13 @@ export function registerListNotesTool(
 
       return richText("list_notes paths", (b) => {
         b.trusted(
-          `Found ${totalCount} note(s)${folder ? ` in "${displayReadValue(folder)}"` : ""}${totalCount > limit ? ` (showing first ${limit})` : ""}:`
+          `Found ${totalCount} note(s)${folder ? ` in "${escapeControlChars(folder)}"` : ""}${totalCount > limit ? ` (showing first ${limit})` : ""}:`
         );
         b.trusted("");
         if (limited.length > 0) {
           b.untrusted(
             "list_notes paths",
-            limited.map(displayReadValue).join("\n")
+            limited.map(escapeControlChars).join("\n")
           );
         }
       });

--- a/src/tools/read/resolve_alias.ts
+++ b/src/tools/read/resolve_alias.ts
@@ -6,7 +6,7 @@ import { readAllCached } from "../../lib/index-cache.js";
 import { log } from "../../lib/logger.js";
 import { extractAliases } from "../../lib/markdown.js";
 import { defineTool, error, richText, text } from "../../lib/tool-seam.js";
-import { displayReadValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 
 export function registerResolveAliasTool(
   server: McpServer,
@@ -78,7 +78,7 @@ export function registerResolveAliasTool(
       const total = aliasMatches.length + basenameMatches.length;
       if (total === 0) {
         return text(
-          `No alias or basename match for "${displayReadValue(name)}"`
+          `No alias or basename match for "${escapeControlChars(name)}"`
         );
       }
 
@@ -87,13 +87,13 @@ export function registerResolveAliasTool(
           ? "resolve_alias alias paths"
           : "resolve_alias basename paths",
         (b) => {
-          b.trusted(`Matches for "${displayReadValue(name)}":`);
+          b.trusted(`Matches for "${escapeControlChars(name)}":`);
           b.trusted("");
           if (aliasMatches.length > 0) {
             b.trusted(`Alias matches (${aliasMatches.length}):`);
             b.untrusted(
               "resolve_alias alias paths",
-              aliasMatches.map((p) => `- ${displayReadValue(p)}`).join("\n"),
+              aliasMatches.map((p) => `- ${escapeControlChars(p)}`).join("\n"),
               "  "
             );
           }
@@ -102,7 +102,9 @@ export function registerResolveAliasTool(
             b.trusted(`Basename matches (${basenameMatches.length}):`);
             b.untrusted(
               "resolve_alias basename paths",
-              basenameMatches.map((p) => `- ${displayReadValue(p)}`).join("\n"),
+              basenameMatches
+                .map((p) => `- ${escapeControlChars(p)}`)
+                .join("\n"),
               "  "
             );
           }

--- a/src/tools/read/search_by_frontmatter.ts
+++ b/src/tools/read/search_by_frontmatter.ts
@@ -6,7 +6,7 @@ import { log } from "../../lib/logger.js";
 import { parseFrontmatter } from "../../lib/markdown.js";
 import { defineTool, richText, text } from "../../lib/tool-seam.js";
 import {
-  displayReadValue,
+  escapeControlChars,
   frontmatterValueForProperty,
   toSearchableString,
 } from "./shared.js";
@@ -95,7 +95,7 @@ export function registerSearchByFrontmatterTool(
 
       if (allMatches.length === 0) {
         return text(
-          `No notes found with frontmatter "${displayReadValue(property)}" matching "${displayReadValue(value)}"`
+          `No notes found with frontmatter "${escapeControlChars(property)}" matching "${escapeControlChars(value)}"`
         );
       }
 
@@ -105,20 +105,20 @@ export function registerSearchByFrontmatterTool(
 
       return richText("search_by_frontmatter paths and values", (b) => {
         b.trusted(
-          `Found ${totalMatches} note(s) where "${displayReadValue(property)}" matches "${displayReadValue(value)}"${truncated ? ` (showing first ${maxResults})` : ""}:`
+          `Found ${totalMatches} note(s) where "${escapeControlChars(property)}" matches "${escapeControlChars(value)}"${truncated ? ` (showing first ${maxResults})` : ""}:`
         );
         b.trusted("");
         for (const match of matches) {
           b.trusted("Result path:");
           b.untrusted(
             "search_by_frontmatter result path",
-            displayReadValue(match.path),
+            escapeControlChars(match.path),
             "  "
           );
           const frontmatterLines: string[] = [];
           for (const [key, val] of Object.entries(match.frontmatter)) {
             frontmatterLines.push(
-              `${displayReadValue(key)}: ${displayReadValue(JSON.stringify(val) ?? "")}`
+              `${escapeControlChars(key)}: ${escapeControlChars(JSON.stringify(val) ?? "")}`
             );
           }
           if (frontmatterLines.length > 0) {

--- a/src/tools/read/search_notes.ts
+++ b/src/tools/read/search_notes.ts
@@ -4,7 +4,7 @@ import { searchInContents, listNotes } from "../../lib/vault.js";
 import { readAllCached } from "../../lib/index-cache.js";
 import { log } from "../../lib/logger.js";
 import { defineTool, richText, text } from "../../lib/tool-seam.js";
-import { displayReadValue } from "./shared.js";
+import { escapeControlChars } from "./shared.js";
 
 export function registerSearchNotesTool(
   server: McpServer,
@@ -75,26 +75,26 @@ export function registerSearchNotesTool(
       });
 
       if (results.length === 0) {
-        return text(`No results found for "${displayReadValue(query)}"`);
+        return text(`No results found for "${escapeControlChars(query)}"`);
       }
 
       return richText("search_notes paths and snippets", (b) => {
         b.trusted(
-          `Found ${results.length} result(s) for "${displayReadValue(query)}":`
+          `Found ${results.length} result(s) for "${escapeControlChars(query)}":`
         );
         b.trusted("");
         for (const result of results) {
           b.trusted("Result path:");
           b.untrusted(
             "search_notes result path",
-            displayReadValue(result.relativePath),
+            escapeControlChars(result.relativePath),
             "  "
           );
           for (const match of result.matches) {
             b.trusted(`  Line ${match.line}:`);
             b.untrusted(
               "search_notes snippet",
-              displayReadValue(match.content),
+              escapeControlChars(match.content),
               "    "
             );
           }

--- a/src/tools/read/shared.ts
+++ b/src/tools/read/shared.ts
@@ -6,9 +6,7 @@ import { escapeControlChars } from "../../lib/errors.js";
 // / `error`, and the seam owns error sanitization. What remains here are the
 // read group's own parsing/escaping helpers.
 
-export function displayReadValue(value: string): string {
-  return escapeControlChars(value);
-}
+export { escapeControlChars };
 
 export function frontmatterValueForProperty(
   data: Record<string, unknown>,

--- a/src/tools/sections/edit_block.ts
+++ b/src/tools/sections/edit_block.ts
@@ -5,7 +5,7 @@ import { findBlockById } from "../../lib/sections.js";
 import { defineTool, text } from "../../lib/tool-seam.js";
 import {
   SECTION_EDIT_PAYLOAD_MAX_CHARS,
-  displaySectionValue,
+  escapeControlChars,
   assertReadableEditTarget,
   invalidateSectionListCache,
 } from "./shared.js";
@@ -64,7 +64,7 @@ export function registerEditBlockTool(
       });
       invalidateSectionListCache(vaultPath, notePath);
       return text(
-        `Updated block ^${displaySectionValue(block)} in ${displaySectionValue(notePath)}`
+        `Updated block ^${escapeControlChars(block)} in ${escapeControlChars(notePath)}`
       );
     }
   );

--- a/src/tools/sections/insert_at_section.ts
+++ b/src/tools/sections/insert_at_section.ts
@@ -5,7 +5,7 @@ import { findSection, insertAfterHeading } from "../../lib/sections.js";
 import { defineTool, richText, error } from "../../lib/tool-seam.js";
 import {
   SECTION_EDIT_PAYLOAD_MAX_CHARS,
-  displaySectionValue,
+  escapeControlChars,
   richResolvedHeading,
   assertReadableEditTarget,
   invalidateSectionListCache,
@@ -79,7 +79,7 @@ export function registerInsertAtSectionTool(
       invalidateSectionListCache(vaultPath, notePath);
       return richText("insert_at_section resolved heading", (b) => {
         b.trusted(
-          `Inserted ${Buffer.byteLength(content, "utf-8")} bytes (${position}) in ${displaySectionValue(notePath)}`
+          `Inserted ${Buffer.byteLength(content, "utf-8")} bytes (${position}) in ${escapeControlChars(notePath)}`
         );
         richResolvedHeading(
           b,

--- a/src/tools/sections/replace_in_note.ts
+++ b/src/tools/sections/replace_in_note.ts
@@ -7,7 +7,7 @@ import {
   FIND_MAX_LEN,
   SECTION_EDIT_PAYLOAD_MAX_CHARS,
   NOTE_INPUT_MAX_LEN,
-  displaySectionValue,
+  escapeControlChars,
   assertReadableEditTarget,
   invalidateSectionListCache,
   hasUnsafeRepeatedGroup,
@@ -82,12 +82,12 @@ export function registerReplaceInNoteTool(
         for (const ch of f) {
           if (!ALLOWED_FLAGS.has(ch)) {
             return error(
-              `Error replacing in note: invalid regex flag '${displaySectionValue(ch)}'. Allowed flags: g, i, m, s, u, y.`
+              `Error replacing in note: invalid regex flag '${escapeControlChars(ch)}'. Allowed flags: g, i, m, s, u, y.`
             );
           }
           if (seen.has(ch)) {
             return error(
-              `Error replacing in note: duplicate regex flag '${displaySectionValue(ch)}'.`
+              `Error replacing in note: duplicate regex flag '${escapeControlChars(ch)}'.`
             );
           }
           seen.add(ch);
@@ -140,8 +140,8 @@ export function registerReplaceInNoteTool(
       invalidateSectionListCache(vaultPath, notePath);
       return text(
         count === 0
-          ? `No matches in ${displaySectionValue(notePath)} - file unchanged.`
-          : `Replaced ${count} match(es) in ${displaySectionValue(notePath)}.`
+          ? `No matches in ${escapeControlChars(notePath)} - file unchanged.`
+          : `Replaced ${count} match(es) in ${escapeControlChars(notePath)}.`
       );
     }
   );

--- a/src/tools/sections/shared.ts
+++ b/src/tools/sections/shared.ts
@@ -25,7 +25,7 @@ export interface SectionListCacheEntry {
 export const sectionListCache = new Map<string, SectionListCacheEntry>();
 
 /** Escape control characters before embedding values in section-tool display text. */
-export const displaySectionValue = escapeControlChars;
+export { escapeControlChars };
 
 /** Append the "Resolved heading:" line plus the heading as a wrapped untrusted
  *  block. Shared by insert_at_section and update_section, whose success
@@ -36,7 +36,7 @@ export function richResolvedHeading(
   heading: string
 ): void {
   b.trusted("Resolved heading:");
-  b.untrusted(label, displaySectionValue(heading), "  ");
+  b.untrusted(label, escapeControlChars(heading), "  ");
 }
 
 export async function assertReadableEditTarget(
@@ -377,14 +377,14 @@ export async function getSectionListSignature(
 export function renderSectionList(notePath: string, content: string): string {
   const headings = parseHeadings(content);
   if (headings.length === 0)
-    return `No headings in ${displaySectionValue(notePath)}`;
+    return `No headings in ${escapeControlChars(notePath)}`;
   const lines = [
-    `${headings.length} heading(s) in ${displaySectionValue(notePath)}:`,
+    `${headings.length} heading(s) in ${escapeControlChars(notePath)}:`,
     "",
   ];
   for (const h of headings) {
     lines.push(
-      `${"  ".repeat(h.level - 1)}${"#".repeat(h.level)} ${displaySectionValue(h.text)}`
+      `${"  ".repeat(h.level - 1)}${"#".repeat(h.level)} ${escapeControlChars(h.text)}`
     );
   }
   return lines.join("\n");

--- a/src/tools/sections/update_section.ts
+++ b/src/tools/sections/update_section.ts
@@ -5,7 +5,7 @@ import { findSection, replaceSectionBody } from "../../lib/sections.js";
 import { defineTool, richText, error } from "../../lib/tool-seam.js";
 import {
   SECTION_EDIT_PAYLOAD_MAX_CHARS,
-  displaySectionValue,
+  escapeControlChars,
   richResolvedHeading,
   assertReadableEditTarget,
   invalidateSectionListCache,
@@ -71,7 +71,7 @@ export function registerUpdateSectionTool(
       invalidateSectionListCache(vaultPath, notePath);
       return richText("update_section resolved heading", (b) => {
         b.trusted(
-          `Updated section in ${displaySectionValue(notePath)} (${bodyBytes} bytes of new body)`
+          `Updated section in ${escapeControlChars(notePath)} (${bodyBytes} bytes of new body)`
         );
         richResolvedHeading(
           b,

--- a/src/tools/semantic/find_similar_notes.ts
+++ b/src/tools/semantic/find_similar_notes.ts
@@ -17,7 +17,7 @@ import {
 } from "../../lib/embedding-store.js";
 import { defineTool, text, richText, error } from "../../lib/tool-seam.js";
 import {
-  displaySemanticValue,
+  escapeControlChars,
   semanticPathBlock,
   semanticHeadingBlock,
 } from "./shared.js";
@@ -182,7 +182,7 @@ export function registerFindSimilarNotesTool(
       const ownChunks = getNoteEmbeddings(vaultPath, notePath);
       if (ownChunks.length === 0) {
         return error(
-          `No embeddings found for "${displaySemanticValue(notePath)}". Run \`index_vault\` first (or check the path is correct).`
+          `No embeddings found for "${escapeControlChars(notePath)}". Run \`index_vault\` first (or check the path is correct).`
         );
       }
 
@@ -243,7 +243,7 @@ export function registerFindSimilarNotesTool(
       if (await pruneStaleStoredNote(vaultPath, notePath)) {
         await saveStore(vaultPath);
         return error(
-          `No current embeddings found for "${displaySemanticValue(notePath)}". Run \`index_vault\` to refresh it.`
+          `No current embeddings found for "${escapeControlChars(notePath)}". Run \`index_vault\` to refresh it.`
         );
       }
       const queryVector = buildSimilarNotesQueryVector(ownChunks);
@@ -263,12 +263,12 @@ export function registerFindSimilarNotesTool(
 
       if (ranked.length === 0) {
         return text(
-          `No similar notes found for "${displaySemanticValue(notePath)}".`
+          `No similar notes found for "${escapeControlChars(notePath)}".`
         );
       }
       return richText("find_similar_notes paths and headings", (b) => {
         b.trusted(
-          `${ranked.length} note(s) similar to ${displaySemanticValue(notePath)}:`
+          `${ranked.length} note(s) similar to ${escapeControlChars(notePath)}:`
         );
         b.trusted("");
         for (const r of ranked) {

--- a/src/tools/semantic/index_vault.ts
+++ b/src/tools/semantic/index_vault.ts
@@ -28,7 +28,7 @@ import {
   MISSING_PROVIDER_HINT,
   INDEX_VAULT_CONFIRMATION,
   EMBED_BATCH_SIZE,
-  displaySemanticValue,
+  escapeControlChars,
 } from "./shared.js";
 
 interface IndexProgress {
@@ -118,7 +118,7 @@ export function registerIndexVaultTool(
         }
         if (confirm !== INDEX_VAULT_CONFIRMATION) {
           return error(
-            `index_vault sends readable note chunks to the configured embedding provider (${displaySemanticValue(provider.id)}/${displaySemanticValue(provider.model)}). ` +
+            `index_vault sends readable note chunks to the configured embedding provider (${escapeControlChars(provider.id)}/${escapeControlChars(provider.model)}). ` +
               `Set confirm to "${INDEX_VAULT_CONFIRMATION}" to proceed.`
           );
         }
@@ -137,7 +137,7 @@ export function registerIndexVaultTool(
         if (notes.length === 0) {
           return text(
             folder
-              ? `No notes in "${displaySemanticValue(folder)}" to index.`
+              ? `No notes in "${escapeControlChars(folder)}" to index.`
               : "Vault is empty — nothing to index."
           );
         }
@@ -311,7 +311,7 @@ export function registerIndexVaultTool(
         // (matching the prior untrustedVaultTextResult-vs-textResult split).
         return richText("index_vault failed notes", (b) => {
           b.trusted(
-            `Indexed${folder ? ` "${displaySemanticValue(folder)}"` : ""} via ${displaySemanticValue(provider.id)}/${displaySemanticValue(provider.model)}`
+            `Indexed${folder ? ` "${escapeControlChars(folder)}"` : ""} via ${escapeControlChars(provider.id)}/${escapeControlChars(provider.model)}`
           );
           b.trusted(`  Notes scanned:   ${stats.notesScanned}`);
           b.trusted(`  Notes embedded:  ${stats.notesEmbedded}`);
@@ -324,7 +324,7 @@ export function registerIndexVaultTool(
             for (const f of stats.failed.slice(0, 5)) {
               b.untrusted(
                 "index_vault failed note",
-                `- ${displaySemanticValue(f.path)}: ${sanitizeError(f.error)}`,
+                `- ${escapeControlChars(f.path)}: ${sanitizeError(f.error)}`,
                 "    "
               );
             }

--- a/src/tools/semantic/search_semantic.ts
+++ b/src/tools/semantic/search_semantic.ts
@@ -19,7 +19,7 @@ import {
 import { defineTool, text, richText, error } from "../../lib/tool-seam.js";
 import {
   MISSING_PROVIDER_HINT,
-  displaySemanticValue,
+  escapeControlChars,
   semanticPathBlock,
   semanticHeadingBlock,
 } from "./shared.js";
@@ -218,12 +218,12 @@ export function registerSearchSemanticTool(
           canReadStoredEmbeddingNote(vaultPath, notePath),
       });
       if (hits.length === 0) {
-        return text(`No matches for "${displaySemanticValue(query)}".`);
+        return text(`No matches for "${escapeControlChars(query)}".`);
       }
 
       return richText("search_semantic vault text", (b) => {
         b.trusted(
-          `${hits.length} match(es) for "${displaySemanticValue(query)}":`
+          `${hits.length} match(es) for "${escapeControlChars(query)}":`
         );
         b.trusted("");
         for (const hit of hits) {
@@ -236,7 +236,7 @@ export function registerSearchSemanticTool(
           }
           if (includeSnippet) {
             const snippet = hit.text.replace(/\s+/g, " ").trim().slice(0, 200);
-            const clipped = `${displaySemanticValue(snippet)}${hit.text.length > 200 ? "..." : ""}`;
+            const clipped = `${escapeControlChars(snippet)}${hit.text.length > 200 ? "..." : ""}`;
             b.untrusted("semantic snippet", clipped, "    ");
           }
         }

--- a/src/tools/semantic/shared.ts
+++ b/src/tools/semantic/shared.ts
@@ -14,10 +14,8 @@ const MISSING_PROVIDER_HINT =
 const INDEX_VAULT_CONFIRMATION = "send-vault-text-to-embedding-provider";
 const EMBED_BATCH_SIZE = 16;
 
-const displaySemanticValue = escapeControlChars;
-
 function displayHeadingPath(path: readonly string[]): string {
-  return path.map(displaySemanticValue).join(" / ");
+  return path.map(escapeControlChars).join(" / ");
 }
 
 /** Append the note path as a wrapped untrusted block. */
@@ -27,7 +25,7 @@ function semanticPathBlock(
   notePath: string,
   indent = "    "
 ): void {
-  b.untrusted(label, displaySemanticValue(notePath), indent);
+  b.untrusted(label, escapeControlChars(notePath), indent);
 }
 
 /** Append the heading path (joined) as a wrapped untrusted block. */
@@ -42,7 +40,7 @@ export {
   MISSING_PROVIDER_HINT,
   INDEX_VAULT_CONFIRMATION,
   EMBED_BATCH_SIZE,
-  displaySemanticValue,
+  escapeControlChars,
   displayHeadingPath,
   semanticPathBlock,
   semanticHeadingBlock,

--- a/src/tools/tags/list_tags.ts
+++ b/src/tools/tags/list_tags.ts
@@ -6,7 +6,7 @@ import { log } from "../../lib/logger.js";
 import { defineTool, richText } from "../../lib/tool-seam.js";
 
 import type { TagInfo } from "../../types.js";
-import { displayTagValue, getCachedTagIndex } from "./shared.js";
+import { escapeControlChars, getCachedTagIndex } from "./shared.js";
 
 export function registerListTags(server: McpServer, vaultPath: string): void {
   defineTool(
@@ -64,7 +64,7 @@ export function registerListTags(server: McpServer, vaultPath: string): void {
       const tagLines: string[] = [];
       for (const info of tagInfos) {
         tagLines.push(
-          `#${displayTagValue(info.tag)} (${info.count} ${info.count === 1 ? "note" : "notes"})`
+          `#${escapeControlChars(info.tag)} (${info.count} ${info.count === 1 ? "note" : "notes"})`
         );
       }
 

--- a/src/tools/tags/rename_tag.ts
+++ b/src/tools/tags/rename_tag.ts
@@ -15,8 +15,6 @@ import { makeProgressReporter } from "../../lib/progress.js";
 import { log } from "../../lib/logger.js";
 import { defineTool, richText, text, error } from "../../lib/tool-seam.js";
 
-import { displayTagValue } from "./shared.js";
-
 export function registerRenameTag(server: McpServer, vaultPath: string): void {
   defineTool(
     server,
@@ -78,14 +76,14 @@ export function registerRenameTag(server: McpServer, vaultPath: string): void {
       if (!dryRun) {
         if (confirmTag?.trim() !== newName) {
           return error(
-            `Vault-wide tag rewriting to #${displayTagValue(newName)} requires confirmTag="${displayTagValue(newName)}". ` +
+            `Vault-wide tag rewriting to #${escapeControlChars(newName)} requires confirmTag="${escapeControlChars(newName)}". ` +
               "Set dryRun=true to preview without writing."
           );
         }
         const confirmation = await elicitTextConfirmation(server, {
           tool: "rename_tag",
           message:
-            `Rename #${displayTagValue(oldName)} to #${displayTagValue(newName)} across the vault? ` +
+            `Rename #${escapeControlChars(oldName)} to #${escapeControlChars(newName)} across the vault? ` +
             "This can rewrite many notes. Type the new tag name to confirm.",
           fieldName: "confirmTag",
           fieldDescription:
@@ -94,12 +92,12 @@ export function registerRenameTag(server: McpServer, vaultPath: string): void {
         });
         if (confirmation.status === "cancelled") {
           return text(
-            `Rename of #${displayTagValue(oldName)} to #${displayTagValue(newName)} cancelled.`
+            `Rename of #${escapeControlChars(oldName)} to #${escapeControlChars(newName)} cancelled.`
           );
         }
         if (confirmation.status === "mismatch") {
           return error(
-            `Confirmation tag did not match #${displayTagValue(newName)}; rename aborted.`
+            `Confirmation tag did not match #${escapeControlChars(newName)}; rename aborted.`
           );
         }
       }
@@ -187,7 +185,7 @@ export function registerRenameTag(server: McpServer, vaultPath: string): void {
 
       return richText("rename_tag failed notes", (b) => {
         b.trusted(
-          `${verb} #${displayTagValue(oldName)} → #${displayTagValue(newName)}${hierarchical ? " (and nested sub-tags)" : ""}`
+          `${verb} #${escapeControlChars(oldName)} → #${escapeControlChars(newName)}${hierarchical ? " (and nested sub-tags)" : ""}`
         );
         b.trusted(`  Files affected: ${updatedFiles}`);
         b.trusted(`  Inline #tag occurrences: ${totalInline}`);

--- a/src/tools/tags/search_by_tag.ts
+++ b/src/tools/tags/search_by_tag.ts
@@ -5,7 +5,7 @@ import { readAllCached } from "../../lib/index-cache.js";
 import { log } from "../../lib/logger.js";
 import { defineTool, richText, text } from "../../lib/tool-seam.js";
 
-import { displayTagValue, getCachedTagIndex } from "./shared.js";
+import { escapeControlChars, getCachedTagIndex } from "./shared.js";
 
 export function registerSearchByTag(
   server: McpServer,
@@ -91,7 +91,9 @@ export function registerSearchByTag(
         });
 
       if (matchingNotes.length === 0) {
-        return text(`No notes found with tag #${displayTagValue(searchTag)}`);
+        return text(
+          `No notes found with tag #${escapeControlChars(searchTag)}`
+        );
       }
 
       return richText(
@@ -100,7 +102,7 @@ export function registerSearchByTag(
           : "search_by_tag paths",
         (b) => {
           b.trusted(
-            `Found ${matchingNotes.length} ${matchingNotes.length === 1 ? "note" : "notes"} with tag #${displayTagValue(searchTag)}`
+            `Found ${matchingNotes.length} ${matchingNotes.length === 1 ? "note" : "notes"} with tag #${escapeControlChars(searchTag)}`
           );
           b.trusted("");
 
@@ -108,14 +110,14 @@ export function registerSearchByTag(
             b.trusted("Path:");
             b.untrusted(
               "search_by_tag result path",
-              displayTagValue(note.path),
+              escapeControlChars(note.path),
               "  "
             );
             if (note.preview) {
               b.trusted("  Preview:");
               b.untrusted(
                 "search_by_tag preview",
-                displayTagValue(note.preview),
+                escapeControlChars(note.preview),
                 "    "
               );
               b.trusted("");

--- a/src/tools/tags/shared.ts
+++ b/src/tools/tags/shared.ts
@@ -19,9 +19,7 @@ export interface TagIndexCacheEntry {
 
 export const tagIndexCache = new Map<string, TagIndexCacheEntry>();
 
-export function displayTagValue(value: string): string {
-  return escapeControlChars(value);
-}
+export { escapeControlChars };
 
 export function tagIndexFingerprint(
   notes: readonly string[],

--- a/src/tools/write/append_to_note.ts
+++ b/src/tools/write/append_to_note.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { appendToNote } from "../../lib/vault.js";
 import { defineTool, text } from "../../lib/tool-seam.js";
-import { displayWriteValue, ensureMdExtension } from "./shared.js";
+import { escapeControlChars, ensureMdExtension } from "./shared.js";
 
 export function registerAppendToNote(
   server: McpServer,
@@ -41,7 +41,7 @@ export function registerAppendToNote(
     async ({ path: notePath, content }) => {
       const resolvedPath = ensureMdExtension(notePath);
       await appendToNote(vaultPath, resolvedPath, content);
-      return text(`Appended content to '${displayWriteValue(resolvedPath)}'.`);
+      return text(`Appended content to '${escapeControlChars(resolvedPath)}'.`);
     }
   );
 }

--- a/src/tools/write/create_daily_note.ts
+++ b/src/tools/write/create_daily_note.ts
@@ -5,7 +5,7 @@ import { getDailyNoteConfig } from "../../config.js";
 import { sanitizeError } from "../../lib/errors.js";
 import { defineTool, richText, error, asError } from "../../lib/tool-seam.js";
 import { formatMomentDate, parseLocalDateOnly } from "../../lib/dates.js";
-import { displayWriteValue, ensureMdExtension } from "./shared.js";
+import { escapeControlChars, ensureMdExtension } from "./shared.js";
 
 export function registerCreateDailyNote(
   server: McpServer,
@@ -107,7 +107,7 @@ export function registerCreateDailyNote(
               b.trusted("Error: Daily note already exists.");
               b.untrusted(
                 "create_daily_note path",
-                displayWriteValue(notePath)
+                escapeControlChars(notePath)
               );
             })
           );
@@ -116,7 +116,7 @@ export function registerCreateDailyNote(
       }
       return richText("create_daily_note path", (b) => {
         b.trusted("Created daily note.");
-        b.untrusted("create_daily_note path", displayWriteValue(notePath));
+        b.untrusted("create_daily_note path", escapeControlChars(notePath));
       });
     }
   );

--- a/src/tools/write/create_note.ts
+++ b/src/tools/write/create_note.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { writeNote } from "../../lib/vault.js";
 import { defineTool, text, error } from "../../lib/tool-seam.js";
 import {
-  displayWriteValue,
+  escapeControlChars,
   ensureMdExtension,
   buildFrontmatterContent,
   isPlainObject,
@@ -49,7 +49,7 @@ export function registerCreateNote(server: McpServer, vaultPath: string): void {
     },
     async ({ path: notePath, content, frontmatter }) => {
       const resolvedPath = ensureMdExtension(notePath);
-      const displayedPath = displayWriteValue(resolvedPath);
+      const displayedPath = escapeControlChars(resolvedPath);
 
       let finalContent: string;
 

--- a/src/tools/write/delete_note.ts
+++ b/src/tools/write/delete_note.ts
@@ -4,7 +4,7 @@ import { deleteNote } from "../../lib/vault.js";
 import { sanitizeError } from "../../lib/errors.js";
 import { defineTool, text, error, richText } from "../../lib/tool-seam.js";
 import { log } from "../../lib/logger.js";
-import { displayWriteValue, ensureMdExtension } from "./shared.js";
+import { escapeControlChars, ensureMdExtension } from "./shared.js";
 
 export function registerDeleteNote(server: McpServer, vaultPath: string): void {
   defineTool(
@@ -61,7 +61,7 @@ export function registerDeleteNote(server: McpServer, vaultPath: string): void {
       // recoverable, so no confirmation is needed for those.
       if (permanent && !confirm) {
         return error(
-          `Permanent deletion of "${displayWriteValue(resolvedPath)}" requires confirm=true. ` +
+          `Permanent deletion of "${escapeControlChars(resolvedPath)}" requires confirm=true. ` +
             "This is a destructive, irreversible operation. Set confirm to true to proceed, " +
             "or omit permanent (or set it to false) to move the note to the vault's .trash folder instead."
         );
@@ -90,7 +90,7 @@ export function registerDeleteNote(server: McpServer, vaultPath: string): void {
         try {
           const elicit = await server.server.elicitInput({
             message:
-              `Permanently delete "${displayWriteValue(resolvedPath)}" from the vault?` +
+              `Permanently delete "${escapeControlChars(resolvedPath)}" from the vault?` +
               (removeReferences
                 ? " References across the vault will also be stripped."
                 : "") +
@@ -109,7 +109,7 @@ export function registerDeleteNote(server: McpServer, vaultPath: string): void {
           });
           if (elicit.action !== "accept") {
             return text(
-              `Deletion of "${displayWriteValue(resolvedPath)}" cancelled.`
+              `Deletion of "${escapeControlChars(resolvedPath)}" cancelled.`
             );
           }
           // An accept with no content (or a missing field) is treated as
@@ -125,7 +125,7 @@ export function registerDeleteNote(server: McpServer, vaultPath: string): void {
             confirmed === ""
           ) {
             return text(
-              `Deletion of "${displayWriteValue(resolvedPath)}" cancelled (no confirmation provided).`
+              `Deletion of "${escapeControlChars(resolvedPath)}" cancelled (no confirmation provided).`
             );
           }
           if (
@@ -133,7 +133,7 @@ export function registerDeleteNote(server: McpServer, vaultPath: string): void {
             confirmed.trim() !== resolvedPath
           ) {
             return error(
-              `Confirmation path did not match "${displayWriteValue(resolvedPath)}"; deletion aborted.`
+              `Confirmation path did not match "${escapeControlChars(resolvedPath)}"; deletion aborted.`
             );
           }
         } catch (err) {
@@ -148,7 +148,7 @@ export function registerDeleteNote(server: McpServer, vaultPath: string): void {
       const method = permanent ? "permanently deleted" : "moved to trash";
 
       return richText("delete_note failed referrers", (b) => {
-        b.trusted(`Note '${displayWriteValue(resolvedPath)}' ${method}.`);
+        b.trusted(`Note '${escapeControlChars(resolvedPath)}' ${method}.`);
         if (removeReferences && permanent) {
           const updated = result.updatedReferrers.length;
           b.trusted(
@@ -164,7 +164,7 @@ export function registerDeleteNote(server: McpServer, vaultPath: string): void {
             for (const f of result.failedReferrers.slice(0, MAX_DISPLAY)) {
               b.untrusted(
                 "delete_note failed referrer",
-                `- ${displayWriteValue(f.path)}: ${sanitizeError(f.error)}`,
+                `- ${escapeControlChars(f.path)}: ${sanitizeError(f.error)}`,
                 "  "
               );
             }

--- a/src/tools/write/move_note.ts
+++ b/src/tools/write/move_note.ts
@@ -4,7 +4,7 @@ import { moveNote } from "../../lib/vault.js";
 import { sanitizeError } from "../../lib/errors.js";
 import { defineTool, text, error, richText } from "../../lib/tool-seam.js";
 import { elicitTextConfirmation } from "../../lib/confirmation.js";
-import { displayWriteValue, ensureMdExtension } from "./shared.js";
+import { escapeControlChars, ensureMdExtension } from "./shared.js";
 
 export function registerMoveNote(server: McpServer, vaultPath: string): void {
   defineTool(
@@ -58,14 +58,14 @@ export function registerMoveNote(server: McpServer, vaultPath: string): void {
       if (updateLinks !== false) {
         if (confirmPath?.trim() !== resolvedNew) {
           return error(
-            `Reference rewriting for "${displayWriteValue(resolvedOld)}" requires confirmPath="${displayWriteValue(resolvedNew)}". ` +
+            `Reference rewriting for "${escapeControlChars(resolvedOld)}" requires confirmPath="${escapeControlChars(resolvedNew)}". ` +
               "Set updateLinks=false to move without rewriting references."
           );
         }
         const confirmation = await elicitTextConfirmation(server, {
           tool: "move_note",
           message:
-            `Move "${displayWriteValue(resolvedOld)}" to "${displayWriteValue(resolvedNew)}" and update references across the vault? ` +
+            `Move "${escapeControlChars(resolvedOld)}" to "${escapeControlChars(resolvedNew)}" and update references across the vault? ` +
             "This can rewrite many notes. Type the destination path to confirm.",
           fieldName: "confirmPath",
           fieldDescription:
@@ -73,11 +73,13 @@ export function registerMoveNote(server: McpServer, vaultPath: string): void {
           expectedValue: resolvedNew,
         });
         if (confirmation.status === "cancelled") {
-          return text(`Move of "${displayWriteValue(resolvedOld)}" cancelled.`);
+          return text(
+            `Move of "${escapeControlChars(resolvedOld)}" cancelled.`
+          );
         }
         if (confirmation.status === "mismatch") {
           return error(
-            `Confirmation path did not match "${displayWriteValue(resolvedNew)}"; move aborted.`
+            `Confirmation path did not match "${escapeControlChars(resolvedNew)}"; move aborted.`
           );
         }
       }
@@ -87,7 +89,7 @@ export function registerMoveNote(server: McpServer, vaultPath: string): void {
 
       return richText("move_note failed referrers", (b) => {
         b.trusted(
-          `Moved note from '${displayWriteValue(resolvedOld)}' to '${displayWriteValue(resolvedNew)}'.`
+          `Moved note from '${escapeControlChars(resolvedOld)}' to '${escapeControlChars(resolvedNew)}'.`
         );
         if (updateLinks !== false) {
           const updated = result.updatedReferrers.length;
@@ -109,7 +111,7 @@ export function registerMoveNote(server: McpServer, vaultPath: string): void {
             for (const f of result.failedReferrers.slice(0, MAX_DISPLAY)) {
               b.untrusted(
                 "move_note failed referrer",
-                `- ${displayWriteValue(f.path)}: ${sanitizeError(f.error)}`,
+                `- ${escapeControlChars(f.path)}: ${sanitizeError(f.error)}`,
                 "  "
               );
             }

--- a/src/tools/write/prepend_to_note.ts
+++ b/src/tools/write/prepend_to_note.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { prependToNote } from "../../lib/vault.js";
 import { defineTool, text } from "../../lib/tool-seam.js";
-import { displayWriteValue, ensureMdExtension } from "./shared.js";
+import { escapeControlChars, ensureMdExtension } from "./shared.js";
 
 export function registerPrependToNote(
   server: McpServer,
@@ -41,7 +41,9 @@ export function registerPrependToNote(
     async ({ path: notePath, content }) => {
       const resolvedPath = ensureMdExtension(notePath);
       await prependToNote(vaultPath, resolvedPath, content);
-      return text(`Prepended content to '${displayWriteValue(resolvedPath)}'.`);
+      return text(
+        `Prepended content to '${escapeControlChars(resolvedPath)}'.`
+      );
     }
   );
 }

--- a/src/tools/write/shared.ts
+++ b/src/tools/write/shared.ts
@@ -1,7 +1,7 @@
 import { escapeControlChars } from "../../lib/errors.js";
 import { updateFrontmatter } from "../../lib/markdown.js";
 
-export const displayWriteValue = escapeControlChars;
+export { escapeControlChars };
 
 export function ensureMdExtension(filePath: string): string {
   return /\.md$/i.test(filePath) ? filePath : `${filePath}.md`;

--- a/src/tools/write/update_frontmatter.ts
+++ b/src/tools/write/update_frontmatter.ts
@@ -4,7 +4,7 @@ import { updateNote } from "../../lib/vault.js";
 import { updateFrontmatter } from "../../lib/markdown.js";
 import { defineTool, text, error } from "../../lib/tool-seam.js";
 import {
-  displayWriteValue,
+  escapeControlChars,
   ensureMdExtension,
   isPlainObject,
 } from "./shared.js";
@@ -64,7 +64,7 @@ export function registerUpdateFrontmatter(
       );
 
       return text(
-        `Updated frontmatter of '${displayWriteValue(resolvedPath)}' with ${Object.keys(props).length} properties.`
+        `Updated frontmatter of '${escapeControlChars(resolvedPath)}' with ${Object.keys(props).length} properties.`
       );
     }
   );


### PR DESCRIPTION
Final follow-up sweep for the tool-seam migration ([ADR 0001](docs/adr/0001-tool-seam.md)), now that all 9 groups are through the seam.

1. **Collapse the 11 `display*Value` aliases** (one per group + `index.ts`/`prompts.ts`) to the single canonical `escapeControlChars`. Each was a byte-identical pass-through whose name implied group-specific escaping it never did.
2. **Rewrite `TOOL_AUTHORING §4`**: drop the migration banner + old recipe; document `defineTool` + the `ToolResult` vocabulary, the escaping-vs-wrapping rule, and the error model as the norm.
3. **Flip ADR 0001 status to complete.**

Pure rename + docs, no behaviour change. typecheck/lint/build clean; **984 tests pass unchanged** (the byte-preservation proof, since `escapeControlChars` IS every former alias). Closes #252.