### PR TITLE
refactor(tools): route delete_note elicitation through confirmation seam

### DIFF
--- a/src/__tests__/handlers/delete-note-confirmation.test.ts
+++ b/src/__tests__/handlers/delete-note-confirmation.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import { createTestEnv, isError, textContent, type TestEnv } from "./harness.js";
+
+let env: TestEnv | undefined;
+
+afterEach(async () => {
+  await env?.cleanup();
+  env = undefined;
+});
+
+describe("write handlers — delete_note elicitation", () => {
+  it("permanently deletes after a matching typed confirmation", async () => {
+    env = await createTestEnv({
+      clientCapabilities: { elicitation: {} },
+      onElicit: (request) => {
+        expect(request.params.message).toContain('Permanently delete "note-c.md"');
+        expect(request.params.message).toContain("Type the note's path to confirm.");
+        return {
+          action: "accept",
+          content: { confirmPath: "note-c.md" },
+        };
+      },
+    });
+
+    const result = await env.client.callTool({
+      name: "delete_note",
+      arguments: { path: "note-c.md", permanent: true, confirm: true },
+    });
+
+    expect(isError(result)).toBe(false);
+    expect(textContent(result)).toMatch(/permanently deleted/i);
+    await expect(fs.access(path.join(env.vaultDir, "note-c.md"))).rejects.toThrow();
+  });
+
+  it("aborts when the typed confirmation path does not match", async () => {
+    env = await createTestEnv({
+      clientCapabilities: { elicitation: {} },
+      onElicit: () => ({
+        action: "accept",
+        content: { confirmPath: "note-b.md" },
+      }),
+    });
+
+    const result = await env.client.callTool({
+      name: "delete_note",
+      arguments: { path: "note-c.md", permanent: true, confirm: true },
+    });
+
+    expect(isError(result)).toBe(true);
+    expect(textContent(result)).toContain(
+      'Confirmation path did not match "note-c.md"; deletion aborted.'
+    );
+    await expect(fs.access(path.join(env.vaultDir, "note-c.md"))).resolves.toBeUndefined();
+  });
+
+  it("cancels without deleting when elicitation is dismissed", async () => {
+    env = await createTestEnv({
+      clientCapabilities: { elicitation: {} },
+      onElicit: () => ({ action: "cancel" }),
+    });
+
+    const result = await env.client.callTool({
+      name: "delete_note",
+      arguments: { path: "note-c.md", permanent: true, confirm: true },
+    });
+
+    expect(isError(result)).toBe(false);
+    expect(textContent(result)).toContain('Deletion of "note-c.md" cancelled.');
+    await expect(fs.access(path.join(env.vaultDir, "note-c.md"))).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/regression-fn-cluster.test.ts
+++ b/src/__tests__/regression-fn-cluster.test.ts
@@ -1,7 +1,4 @@
 import { describe, it, expect } from "vitest";
-import fs from "fs/promises";
-import path from "path";
-import { fileURLToPath } from "url";
 import { parseBaseFile } from "../lib/bases.js";
 
 /**
@@ -12,19 +9,7 @@ import { parseBaseFile } from "../lib/bases.js";
  *          for the remaining parse, and caps raw input at 1 MB before handing
  *          it to the parser, so a "billion laughs" / quadratic-blowup payload
  *          can no longer drive unbounded memory or CPU.
- *
- *   FN-H7: delete_note's elicitation capability gate previously checked
- *          caps.elicitation.form (a TypeScript-SDK extension). Clients
- *          that declare the spec-compliant `elicitation: {}` capability
- *          would skip the confirmation prompt and a permanent delete
- *          would proceed silently. The check is now against the parent
- *          key (caps.elicitation !== undefined) so any elicitation-
- *          capable client triggers the prompt.
  */
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const PROJECT_ROOT = path.resolve(__dirname, "..", "..");
 
 describe("FN-H6: parseBaseFile resists YAML alias bombs", () => {
   it("completes quickly on a 20-level alias bomb (no exponential blowup)", () => {
@@ -67,24 +52,5 @@ describe("FN-H6: parseBaseFile resists YAML alias bombs", () => {
     expect(warnings).toEqual([]);
     expect(doc.filters).toBeDefined();
     expect((doc.properties as { status?: { displayName?: string } })?.status?.displayName).toBe("Status");
-  });
-});
-
-describe("FN-H7: delete_note elicitation gate covers spec-compliant clients", () => {
-  it("source checks caps?.elicitation !== undefined (not the SDK-only .form sub-field)", async () => {
-    // Text-based regression. The MCP client harness in this repo doesn't
-    // let us customise the advertised client capabilities mid-test, and
-    // mocking server.server.getClientCapabilities() at the SDK boundary
-    // would couple this test to SDK internals. The narrow contract we
-    // care about is: the gate must trigger for any client that declares
-    // `elicitation: {}`, not just the SDK's `.form` extension. Asserting
-    // on the source pins that contract.
-    const src = await fs.readFile(
-      path.join(PROJECT_ROOT, "src", "tools", "write", "delete_note.ts"),
-      "utf-8",
-    );
-    expect(src).toMatch(/caps\?\.elicitation\s*!==\s*undefined/);
-    // And the old, too-narrow check is gone.
-    expect(src).not.toMatch(/caps\?\.elicitation\?\.form\b/);
   });
 });

--- a/src/tools/write/delete_note.ts
+++ b/src/tools/write/delete_note.ts
@@ -2,8 +2,8 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { deleteNote } from "../../lib/vault.js";
 import { sanitizeError } from "../../lib/errors.js";
+import { elicitTextConfirmation } from "../../lib/confirmation.js";
 import { defineTool, text, error, richText } from "../../lib/tool-seam.js";
-import { log } from "../../lib/logger.js";
 import { escapeControlChars, ensureMdExtension } from "./shared.js";
 
 export function registerDeleteNote(server: McpServer, vaultPath: string): void {
@@ -67,77 +67,34 @@ export function registerDeleteNote(server: McpServer, vaultPath: string): void {
         );
       }
 
-      // Elicit a typed confirmation before permanent deletion if the client
-      // declares elicitation support. Trash deletes (`permanent: false`)
-      // are recoverable, so we don't gate them. Errors from the elicit
-      // path (network blip, schema mismatch, client that announced
-      // elicitation but can't actually fulfil it) fall through to the
-      // delete: the tool annotation `destructiveHint: true` already gives
-      // the host a chance to confirm, so this is a defense-in-depth
-      // check, not a mandatory gate.
-      //
-      // The MCP spec defines the capability as `elicitation: {}` at the
-      // top level; `form` is a TypeScript-SDK extension. Checking only
-      // for `.form` silently skipped this gate for spec-compliant
-      // clients that declared `elicitation: {}` but not the SDK-specific
-      // `form` sub-field, letting permanent deletes proceed without any
-      // confirmation prompt. Check the parent key instead so any
-      // elicitation-capable client triggers the prompt; if the client
-      // can't actually elicit, `elicitInput` throws and the surrounding
-      // try/catch logs and falls through.
-      const caps = server.server.getClientCapabilities();
-      if (permanent && caps?.elicitation !== undefined) {
-        try {
-          const elicit = await server.server.elicitInput({
-            message:
-              `Permanently delete "${escapeControlChars(resolvedPath)}" from the vault?` +
-              (removeReferences
-                ? " References across the vault will also be stripped."
-                : "") +
-              ` This cannot be undone. Type the note's path to confirm.`,
-            requestedSchema: {
-              type: "object",
-              properties: {
-                confirmPath: {
-                  type: "string",
-                  description:
-                    "Re-type the path to confirm permanent deletion.",
-                },
-              },
-              required: ["confirmPath"],
-            },
-          });
-          if (elicit.action !== "accept") {
-            return text(
-              `Deletion of "${escapeControlChars(resolvedPath)}" cancelled.`
-            );
-          }
-          // An accept with no content (or a missing field) is treated as
-          // a cancel rather than an error: the user dismissed the form
-          // without filling it in. Only a non-matching string counts as
-          // a true confirmation failure worth surfacing as an error.
-          const content = elicit.content as
-            { confirmPath?: unknown } | undefined;
-          const confirmed = content?.confirmPath;
-          if (
-            confirmed === undefined ||
-            confirmed === null ||
-            confirmed === ""
-          ) {
-            return text(
-              `Deletion of "${escapeControlChars(resolvedPath)}" cancelled (no confirmation provided).`
-            );
-          }
-          if (
-            typeof confirmed !== "string" ||
-            confirmed.trim() !== resolvedPath
-          ) {
-            return error(
-              `Confirmation path did not match "${escapeControlChars(resolvedPath)}"; deletion aborted.`
-            );
-          }
-        } catch (err) {
-          log.warn("delete_note: elicitation skipped", { err: err as Error });
+      // Elicit a typed confirmation before permanent deletion. The shared
+      // confirmation seam owns capability detection and best-effort fallback:
+      // clients without elicitation support (or clients whose elicitation
+      // request fails) return "skipped" and fall through to the delete. The
+      // confirm=true hard gate above remains the mandatory safety latch.
+      if (permanent) {
+        const confirmation = await elicitTextConfirmation(server, {
+          tool: "delete_note",
+          message:
+            `Permanently delete "${escapeControlChars(resolvedPath)}" from the vault?` +
+            (removeReferences
+              ? " References across the vault will also be stripped."
+              : "") +
+            ` This cannot be undone. Type the note's path to confirm.`,
+          fieldName: "confirmPath",
+          fieldDescription: "Re-type the path to confirm permanent deletion.",
+          expectedValue: resolvedPath,
+        });
+
+        if (confirmation.status === "cancelled") {
+          return text(
+            `Deletion of "${escapeControlChars(resolvedPath)}" cancelled.`
+          );
+        }
+        if (confirmation.status === "mismatch") {
+          return error(
+            `Confirmation path did not match "${escapeControlChars(resolvedPath)}"; deletion aborted.`
+          );
         }
       }
 


### PR DESCRIPTION
## Summary

- route `delete_note` permanent-delete elicitation through the shared `elicitTextConfirmation` seam
- keep the existing `confirm=true` hard safety latch unchanged
- collapse declined/empty elicitation into one cancellation outcome (issue #254 Option B)
- remove the FN-H7 source-grep regression
- replace it with real MCP behavior coverage for matching confirmation, mismatch, and cancellation using spec-compliant `elicitation: {}`

## Safety / behavior

- clients without elicitation support still fall through after the mandatory `confirm=true` latch, matching existing behavior
- elicitation transport/schema failures remain best-effort and are handled by `confirmation.ts`
- mismatched typed paths abort the delete
- cancelled elicitation leaves the file untouched

Closes #254