### PR TITLE
refactor(reads): make cached batch reads part of the vault-read seam

### DIFF
--- a/src/__tests__/vault-read-seam.test.ts
+++ b/src/__tests__/vault-read-seam.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { clearCache } from "../lib/index-cache.js";
+import { readAllCached, readNote } from "../lib/vault-reads.js";
+import { searchNotes } from "../lib/vault-search.js";
+
+let vaultDir: string;
+
+beforeEach(async () => {
+  vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-read-seam-"));
+});
+
+afterEach(async () => {
+  await clearCache(vaultDir);
+  await fs.rm(vaultDir, { recursive: true, force: true });
+});
+
+async function write(relPath: string, content: string): Promise<void> {
+  const fullPath = path.join(vaultDir, relPath);
+  await fs.mkdir(path.dirname(fullPath), { recursive: true });
+  await fs.writeFile(fullPath, content, "utf-8");
+}
+
+describe("vault read seam", () => {
+  it("keeps readNote always-fresh and outside the mtime cache", async () => {
+    await write("note.md", "v1");
+    expect(await readNote(vaultDir, "note.md")).toBe("v1");
+
+    // No delay or mtime manipulation: point reads must observe the live file
+    // directly rather than relying on mtime cache semantics.
+    await write("note.md", "v2");
+    expect(await readNote(vaultDir, "note.md")).toBe("v2");
+
+    // If either point read had populated the batch cache, this would be a hit.
+    const batch = await readAllCached(vaultDir, ["note.md"]);
+    expect(batch.cacheMisses).toBe(1);
+    expect(batch.cacheHits).toBe(0);
+    expect(batch.contents.get("note.md")).toBe("v2");
+  });
+
+  it("uses the cached batch path for library searchNotes", async () => {
+    await write("a.md", "needle in alpha");
+    await write("b.md", "needle in beta");
+
+    const results = await searchNotes(vaultDir, "needle");
+    expect(results.map((result) => result.relativePath).sort()).toEqual([
+      "a.md",
+      "b.md",
+    ]);
+
+    // searchNotes should have warmed the same batch cache exposed by the seam.
+    const secondRead = await readAllCached(vaultDir, ["a.md", "b.md"]);
+    expect(secondRead.cacheHits).toBe(2);
+    expect(secondRead.cacheMisses).toBe(0);
+  });
+});

--- a/src/lib/index-cache.ts
+++ b/src/lib/index-cache.ts
@@ -5,7 +5,7 @@ import {
   getVaultRootRealPath,
   openVaultFileForRead,
   resolveVaultInternalPathSafe,
-} from "./vault.js";
+} from "./vault-fs.js";
 import { mapConcurrent } from "./concurrency.js";
 import { log } from "./logger.js";
 

--- a/src/lib/vault-reads.ts
+++ b/src/lib/vault-reads.ts
@@ -1,0 +1,21 @@
+/**
+ * Canonical vault-read seam.
+ *
+ * Point reads stay direct and always-fresh via `note-reads`. Vault-wide batch
+ * reads use the mtime cache via `index-cache`. Keeping both APIs reachable
+ * from one seam makes the semantic distinction explicit without making the
+ * pure single-note reader stateful.
+ */
+export {
+  assertMarkdownNotePath,
+  listNotes,
+  readNote,
+  readNoteLineRange,
+  type NoteLineRangeRead,
+} from "./note-reads.js";
+
+export {
+  readAllCached,
+  type CachedFileStats,
+  type ReadAllResult,
+} from "./index-cache.js";

--- a/src/lib/vault-search.ts
+++ b/src/lib/vault-search.ts
@@ -1,11 +1,6 @@
-import { mapConcurrent } from "./concurrency.js";
-import { listNotes, readNote } from "./note-reads.js";
+import { listNotes, readAllCached } from "./vault-reads.js";
 import type { SearchResult, SearchMatch } from "../types.js";
 
-// Bounded fan-out for vault-wide scans. Higher values saturate the event loop
-// on spinning disks; lower values leave SSD throughput on the table. 8 is the
-// sweet spot on a typical developer workstation.
-const SCAN_CONCURRENCY = 8;
 const SEARCH_PATH_MATCH_BOOST = 4;
 const SEARCH_HEADING_MATCH_BOOST = 4;
 const SEARCH_MATCH_COUNT_WEIGHT = 0.25;
@@ -14,11 +9,9 @@ const SEARCH_SNIPPET_MAX_CHARS = 240;
 const SEARCH_SNIPPET_OMISSION = "...";
 
 /**
- * Pure scanner: search a pre-loaded set of note contents for `query`. Used by
- * both `searchNotes` (which loads its own content) and the `search_notes`
- * tool (which loads via the mtime cache). Keeping the matching logic
- * separate from the I/O loop lets the tool avoid duplicate reads when the
- * same vault has been scanned recently.
+ * Pure scanner: search a pre-loaded set of note contents for `query`.
+ * `searchNotes` owns the vault-wide I/O path and loads those contents through
+ * the canonical cached batch-read seam.
  */
 export function searchInContents(
   notes: readonly string[],
@@ -150,22 +143,11 @@ export async function searchNotes(
 ): Promise<SearchResult[]> {
   const notes = await listNotes(vaultPath, options?.folder);
 
-  // Scan notes in parallel with bounded concurrency. Sequential iteration
-  // would pay one realpath syscall per note on every query — unusable on
-  // 10k+ note vaults. Errors are swallowed per-item (documented
-  // `mapConcurrent` contract) so one unreadable note doesn't abort the
-  // search. We intentionally do NOT log the relative note path here — it
-  // used to go to stderr and could leak vault layout into shared logs.
-  const contents = new Map<string, string>();
-  await mapConcurrent(notes, SCAN_CONCURRENCY, async (notePath) => {
-    try {
-      const content = await readNote(vaultPath, notePath);
-      contents.set(notePath, content);
-    } catch {
-      // ignore per-file failures
-    }
-    return undefined;
-  });
+  // Vault-wide search is a batch semantic: reuse unchanged note bodies across
+  // repeated scans while keeping point reads (`readNote`) direct and fresh.
+  // Per-file failures are intentionally omitted without logging note paths so
+  // one unreadable note does not abort the search or leak vault layout.
+  const { contents } = await readAllCached(vaultPath, notes);
 
   return searchInContents(notes, contents, query, options);
 }

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -5,7 +5,9 @@
  *
  * Module map (each depends only on layers above it):
  *   vault-fs      path safety · locking · atomic writes · byte guards · traversal
- *   note-reads    readNote · readNoteLineRange · listNotes
+ *   note-reads    pure point reads: readNote · readNoteLineRange · listNotes
+ *   index-cache   stateful mtime-cached batch reads
+ *   vault-reads   canonical seam exposing fresh point + cached batch reads
  *   canvas        list/read/write/update canvas files
  *   bases         Base filter engine + list/read base files
  *   link-rewriter plan/apply move + delete link rewrites
@@ -13,7 +15,9 @@
  *   vault-search  searchInContents / searchNotes
  *   vault-stats   getNoteStats / listAttachments / getAttachmentStats
  *
- * New code should import from the specific module, not this barrel.
+ * New library code should import from the specific module. Read-oriented code
+ * should prefer `vault-reads.js`, where the fresh-single vs cached-batch split
+ * is explicit and discoverable.
  */
 
 // Re-export foundation primitives so external call sites keep importing from vault.js.
@@ -34,13 +38,17 @@ export {
   type ValidatedVaultFile,
 } from "./vault-fs.js";
 
-// Re-export note-read APIs so external call sites keep importing from vault.js.
+// Re-export the canonical read seam so external call sites can discover both
+// always-fresh point reads and the cached vault-wide batch reader together.
 export {
   readNote,
   readNoteLineRange,
   listNotes,
+  readAllCached,
   type NoteLineRangeRead,
-} from "./note-reads.js";
+  type CachedFileStats,
+  type ReadAllResult,
+} from "./vault-reads.js";
 
 // Re-export canvas + bases file-type APIs so external call sites keep
 // importing from vault.js.

--- a/src/tools/read/search_notes.ts
+++ b/src/tools/read/search_notes.ts
@@ -1,8 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { searchInContents, listNotes } from "../../lib/vault.js";
-import { readAllCached } from "../../lib/index-cache.js";
-import { log } from "../../lib/logger.js";
+import { searchNotes } from "../../lib/vault.js";
 import { defineTool, richText, text } from "../../lib/tool-seam.js";
 import { escapeControlChars } from "./shared.js";
 
@@ -58,20 +56,10 @@ export function registerSearchNotesTool(
       },
     },
     async ({ query, caseSensitive, maxResults, folder }) => {
-      // Pull notes via the mtime cache so repeat searches with hot files
-      // skip re-reads. The pure matcher (`searchInContents`) does the
-      // line-level scan on the in-memory map.
-      const notes = await listNotes(vaultPath, folder);
-      const { contents } = await readAllCached(
-        vaultPath,
-        notes,
-        (note, err) => {
-          log.warn("search_notes: note read failed", { note, err });
-        }
-      );
-      const results = searchInContents(notes, contents, query, {
+      const results = await searchNotes(vaultPath, query, {
         caseSensitive,
         maxResults,
+        folder,
       });
 
       if (results.length === 0) {


### PR DESCRIPTION
## Summary

Implements the resolved design from #256 without routing single-note reads through the cache.

- add `src/lib/vault-reads.ts` as the canonical read seam
  - `readNote` / `readNoteLineRange` / `listNotes` stay direct and always-fresh
  - `readAllCached` remains the stateful mtime-cached batch path
- repoint `index-cache.ts` off the `vault.js` compatibility barrel and directly onto `vault-fs.js`, avoiding a layering cycle
- re-export the complete read seam from `vault.ts` so batch caching is discoverable alongside point reads
- rehabilitate library `searchNotes` onto `readAllCached`
- collapse the `search_notes` MCP tool onto library `searchNotes`, removing the duplicate I/O loop
- add tests pinning the semantic split:
  - point reads observe live bytes and do not seed the batch cache
  - library `searchNotes` warms and reuses the batch cache

## Design choice

This deliberately rejects transparent caching behind `readNote`. Single reads retain their existing freshness/latency semantics; caching remains a vault-wide batch semantic. The seam moves, not the semantics.

## Behavior notes

Search ranking, snippets, folder filtering, result limits, and tool response formatting are unchanged. Per-file read failures in library search remain non-fatal and are omitted without logging vault-relative paths.

Closes #256