### PR TITLE
refactor(embedding-store): replace ambient state with a shared handle

### DIFF
--- a/scripts/bench-semantic-ranking-quality.mjs
+++ b/scripts/bench-semantic-ranking-quality.mjs
@@ -90,19 +90,16 @@ function hasIncidentalBeforeFocused(results) {
 
 export async function runSemanticRankingQualityBench() {
   const {
-    loadStore,
-    setNoteChunks,
-    searchEmbeddings,
+    openEmbeddingStore,
     hashText,
-    clearStore,
   } = await import(pathToFileURL(storeEntry).href);
 
   const vault = mkdtempSync(join(tmpdir(), "ompro-semantic-ranking-"));
+  const store = openEmbeddingStore(vault);
   try {
-    await loadStore(vault);
+    await store.load();
     for (const note of notes) {
-      setNoteChunks(
-        vault,
+      store.setNoteChunks(
         note.path,
         hashText(note.path),
         note.chunks.map((chunk, index) => ({
@@ -118,7 +115,7 @@ export async function runSemanticRankingQualityBench() {
       );
     }
 
-    const hits = searchEmbeddings(vault, QUERY_VECTOR, { limit: LIMIT });
+    const hits = store.search(QUERY_VECTOR, { limit: LIMIT });
     const relevanceByPath = new Map(notes.map((note) => [note.path, note.relevance]));
     const rows = hits.map((hit, index) => ({
       rank: index + 1,
@@ -140,7 +137,7 @@ export async function runSemanticRankingQualityBench() {
       rows,
     };
   } finally {
-    await clearStore(vault, { removeSnapshot: true });
+    await store.clear({ removeSnapshot: true });
     rmSync(vault, { recursive: true, force: true });
   }
 }

--- a/scripts/bench-similar-notes-quality.mjs
+++ b/scripts/bench-similar-notes-quality.mjs
@@ -87,21 +87,17 @@ function ndcgAt(results, k) {
 
 export async function runSimilarNotesQualityBench() {
   const {
-    loadStore,
-    setNoteChunks,
-    searchEmbeddings,
-    getNoteEmbeddings,
+    openEmbeddingStore,
     buildSimilarNotesQueryVector,
     hashText,
-    clearStore,
   } = await import(pathToFileURL(storeEntry).href);
 
   const vault = mkdtempSync(join(tmpdir(), "ompro-similar-quality-"));
+  const store = openEmbeddingStore(vault);
   try {
-    await loadStore(vault);
+    await store.load();
     for (const note of notes) {
-      setNoteChunks(
-        vault,
+      store.setNoteChunks(
         note.path,
         hashText(note.path),
         note.chunks.map((chunk, index) => ({
@@ -117,9 +113,9 @@ export async function runSimilarNotesQualityBench() {
       );
     }
 
-    const ownChunks = getNoteEmbeddings(vault, SOURCE_NOTE);
+    const ownChunks = store.getNoteEmbeddings(SOURCE_NOTE);
     const queryVector = buildSimilarNotesQueryVector(ownChunks);
-    const hits = searchEmbeddings(vault, queryVector, {
+    const hits = store.search(queryVector, {
       limit: LIMIT,
       excludeNotes: new Set([SOURCE_NOTE]),
     });
@@ -149,7 +145,7 @@ export async function runSimilarNotesQualityBench() {
       rows,
     };
   } finally {
-    await clearStore(vault, { removeSnapshot: true });
+    await store.clear({ removeSnapshot: true });
     rmSync(vault, { recursive: true, force: true });
   }
 }

--- a/src/__tests__/embedding-store-handle.test.ts
+++ b/src/__tests__/embedding-store-handle.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import {
+  openEmbeddingStore,
+  hashText,
+} from "../lib/embedding-store-handle.js";
+
+let vaultDir: string;
+
+beforeEach(async () => {
+  vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "embedding-handle-"));
+});
+
+afterEach(async () => {
+  await fs.rm(vaultDir, { recursive: true, force: true });
+});
+
+describe("EmbeddingStore handle", () => {
+  it("starts empty and exposes production stats/isEmpty APIs", async () => {
+    const store = openEmbeddingStore(vaultDir);
+    await store.load();
+
+    expect(store.isEmpty()).toBe(true);
+    expect(store.stats()).toEqual({
+      totalChunks: 0,
+      totalNotes: 0,
+      providerId: null,
+      model: null,
+      dimension: null,
+    });
+  });
+
+  it("owns mutable state per handle instead of sharing an ambient vault registry", async () => {
+    const first = openEmbeddingStore(vaultDir);
+    const second = openEmbeddingStore(vaultDir);
+    await Promise.all([first.load(), second.load()]);
+
+    first.setNoteChunks(
+      "a.md",
+      hashText("alpha"),
+      [
+        {
+          notePath: "a.md",
+          chunkIndex: 1,
+          headingPath: [],
+          text: "alpha",
+          hash: "chunk-a",
+          vector: [1, 0],
+        },
+      ],
+      "fixture",
+      "model"
+    );
+
+    expect(first.isEmpty()).toBe(false);
+    expect(first.stats().totalChunks).toBe(1);
+    expect(second.isEmpty()).toBe(true);
+    expect(second.stats().totalChunks).toBe(0);
+  });
+
+  it("persists through one handle and rehydrates through a new handle", async () => {
+    const writer = openEmbeddingStore(vaultDir);
+    await writer.load();
+    writer.setNoteChunks(
+      "a.md",
+      hashText("alpha"),
+      [
+        {
+          notePath: "a.md",
+          chunkIndex: 1,
+          headingPath: ["A"],
+          text: "alpha",
+          hash: "chunk-a",
+          vector: [1, 0, 0],
+        },
+      ],
+      "fixture",
+      "model"
+    );
+    await writer.save();
+
+    const reader = openEmbeddingStore(vaultDir);
+    await Promise.all([reader.load(), reader.load()]);
+
+    expect(reader.stats()).toEqual({
+      totalChunks: 1,
+      totalNotes: 1,
+      providerId: "fixture",
+      model: "model",
+      dimension: 3,
+    });
+    expect(reader.getNoteEmbeddings("a.md")[0]?.text).toBe("alpha");
+
+    await reader.clear({ removeSnapshot: true });
+  });
+
+  it("supports a per-handle persistence cap without module-global test state", async () => {
+    const tiny = openEmbeddingStore(vaultDir, { maxEmbeddingBytes: 100 });
+    await tiny.load();
+    tiny.setNoteChunks(
+      "big.md",
+      "h",
+      [
+        {
+          notePath: "big.md",
+          chunkIndex: 1,
+          headingPath: [],
+          text: "x",
+          hash: "chunk",
+          vector: Array.from({ length: 64 }, (_, index) => index / 64),
+        },
+      ],
+      "fixture",
+      "model"
+    );
+    await tiny.save();
+
+    const snapshot = path.join(
+      vaultDir,
+      ".obsidian",
+      "cache",
+      "mcp-pro-embeddings.json"
+    );
+    await expect(fs.access(snapshot)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/src/__tests__/embedding-store-legacy-adapter.ts
+++ b/src/__tests__/embedding-store-legacy-adapter.ts
@@ -1,0 +1,132 @@
+import path from "path";
+import {
+  openEmbeddingStore,
+  hashText,
+  validateEmbeddingVector,
+  cosineSimilarity,
+  buildSimilarNotesQueryVector,
+  type ChunkEmbedding,
+  type EmbeddingStore,
+  type SearchOptions,
+} from "../lib/embedding-store-handle.js";
+
+/**
+ * Test-only migration adapter for the pre-handle regression suite.
+ *
+ * Production code has no vault-keyed store registry. Existing regression tests
+ * deliberately keep their old call vocabulary here so the large historical
+ * behavior matrix continues to run unchanged while dedicated handle tests
+ * exercise the new public API directly.
+ */
+const stores = new Map<string, EmbeddingStore>();
+let maxEmbeddingBytesForNewStores: number | undefined;
+
+function storeFor(vaultPath: string): EmbeddingStore {
+  const root = path.resolve(vaultPath);
+  let store = stores.get(root);
+  if (!store) {
+    store = openEmbeddingStore(root, {
+      ...(maxEmbeddingBytesForNewStores === undefined
+        ? {}
+        : { maxEmbeddingBytes: maxEmbeddingBytesForNewStores }),
+    });
+    stores.set(root, store);
+  }
+  return store;
+}
+
+export async function loadStore(vaultPath: string): Promise<EmbeddingStore> {
+  const store = storeFor(vaultPath);
+  await store.load();
+  return store;
+}
+
+export async function saveStore(vaultPath: string): Promise<void> {
+  await storeFor(vaultPath).save();
+}
+
+export async function clearStore(
+  vaultPath: string,
+  options?: { removeSnapshot?: boolean }
+): Promise<void> {
+  const root = path.resolve(vaultPath);
+  const store = stores.get(root) ?? storeFor(root);
+  await store.clear(options);
+  stores.delete(root);
+}
+
+export function invalidateIfIncompatible(
+  vaultPath: string,
+  providerId: string,
+  model: string
+): void {
+  storeFor(vaultPath).invalidateIfIncompatible(providerId, model);
+}
+
+export function noteIsCurrent(
+  vaultPath: string,
+  notePath: string,
+  contentHash: string
+): boolean {
+  return storeFor(vaultPath).noteIsCurrent(notePath, contentHash);
+}
+
+export function setNoteChunks(
+  vaultPath: string,
+  notePath: string,
+  contentHash: string,
+  chunks: ChunkEmbedding[],
+  providerId: string,
+  model: string
+): void {
+  storeFor(vaultPath).setNoteChunks(
+    notePath,
+    contentHash,
+    chunks,
+    providerId,
+    model
+  );
+}
+
+export function dropNoteChunks(vaultPath: string, notePath: string): boolean {
+  return storeFor(vaultPath).dropNoteChunks(notePath);
+}
+
+export function pruneMissingNotes(
+  vaultPath: string,
+  currentNotes: Iterable<string>
+): number {
+  return storeFor(vaultPath).pruneMissingNotes(currentNotes);
+}
+
+export function snapshotForTests(vaultPath: string) {
+  return storeFor(vaultPath).stats();
+}
+
+export function searchEmbeddings(
+  vaultPath: string,
+  queryVector: number[],
+  options: SearchOptions = {}
+) {
+  return storeFor(vaultPath).search(queryVector, options);
+}
+
+export function getNoteEmbeddings(
+  vaultPath: string,
+  notePath: string
+): ChunkEmbedding[] {
+  return storeFor(vaultPath).getNoteEmbeddings(notePath);
+}
+
+/** Configure the persistence cap used by subsequently opened test handles. */
+export function setMaxEmbeddingBytesForTests(bytes: number | null): void {
+  maxEmbeddingBytesForNewStores = bytes === null ? undefined : bytes;
+}
+
+export {
+  hashText,
+  validateEmbeddingVector,
+  cosineSimilarity,
+  buildSimilarNotesQueryVector,
+};
+export type { ChunkEmbedding, EmbeddingStore, SearchOptions };

--- a/src/__tests__/embedding-store-legacy-adapter.ts
+++ b/src/__tests__/embedding-store-legacy-adapter.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "fs";
 import path from "path";
 import {
   openEmbeddingStore,
@@ -7,6 +8,7 @@ import {
   buildSimilarNotesQueryVector,
   type ChunkEmbedding,
   type EmbeddingStore,
+  type EmbeddingStoreStats,
   type SearchOptions,
 } from "../lib/embedding-store-handle.js";
 
@@ -99,8 +101,54 @@ export function pruneMissingNotes(
   return storeFor(vaultPath).pruneMissingNotes(currentNotes);
 }
 
-export function snapshotForTests(vaultPath: string) {
-  return storeFor(vaultPath).stats();
+/**
+ * Legacy tests historically observed the module-global store synchronously.
+ * If the state belongs to a semantic tool's production handle instead of this
+ * adapter, that handle has already saved at the tool boundary, so mirror the
+ * same summary from its persisted snapshot without creating a second handle.
+ */
+export function snapshotForTests(vaultPath: string): EmbeddingStoreStats {
+  const root = path.resolve(vaultPath);
+  const local = stores.get(root);
+  if (local) return local.stats();
+
+  try {
+    const file = path.join(
+      root,
+      ".obsidian",
+      "cache",
+      "mcp-pro-embeddings.json"
+    );
+    const parsed = JSON.parse(readFileSync(file, "utf-8")) as {
+      providerId?: unknown;
+      model?: unknown;
+      dimension?: unknown;
+      embeddings?: Array<{ notePath?: unknown }>;
+    };
+    const embeddings = Array.isArray(parsed.embeddings) ? parsed.embeddings : [];
+    const notes = new Set(
+      embeddings
+        .map((entry) => entry.notePath)
+        .filter((note): note is string => typeof note === "string")
+    );
+    return {
+      totalChunks: embeddings.length,
+      totalNotes: notes.size,
+      providerId:
+        typeof parsed.providerId === "string" ? parsed.providerId : null,
+      model: typeof parsed.model === "string" ? parsed.model : null,
+      dimension:
+        typeof parsed.dimension === "number" ? parsed.dimension : null,
+    };
+  } catch {
+    return {
+      totalChunks: 0,
+      totalNotes: 0,
+      providerId: null,
+      model: null,
+      dimension: null,
+    };
+  }
 }
 
 export function searchEmbeddings(
@@ -129,4 +177,9 @@ export {
   cosineSimilarity,
   buildSimilarNotesQueryVector,
 };
-export type { ChunkEmbedding, EmbeddingStore, SearchOptions };
+export type {
+  ChunkEmbedding,
+  EmbeddingStore,
+  EmbeddingStoreStats,
+  SearchOptions,
+};

--- a/src/__tests__/embedding-store-server-services.test.ts
+++ b/src/__tests__/embedding-store-server-services.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  buildMcpServer,
+  createMcpServerServices,
+} from "../index.js";
+import {
+  resetProviderForTests,
+  setProviderForTests,
+  type EmbeddingProvider,
+} from "../lib/embedding-providers.js";
+
+const INDEX_CONFIRM = "send-vault-text-to-embedding-provider";
+
+class TopicProvider implements EmbeddingProvider {
+  readonly id = "shared-handle-test";
+  readonly model = "topic";
+
+  async embed(texts: string[]): Promise<number[][]> {
+    return texts.map((text) =>
+      text.toLowerCase().includes("cat") ? [1, 0] : [0, 1]
+    );
+  }
+}
+
+let vaultDir: string;
+const clients: Client[] = [];
+
+beforeEach(async () => {
+  vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "embedding-services-"));
+  await fs.writeFile(
+    path.join(vaultDir, "cats.md"),
+    "# Cats\n\nCat care and feline behavior.",
+    "utf-8"
+  );
+  process.env.OBSIDIAN_CACHE_DISABLED = "1";
+  setProviderForTests(new TopicProvider());
+});
+
+afterEach(async () => {
+  for (const client of clients.splice(0)) {
+    try {
+      await client.close();
+    } catch {
+      /* ignore */
+    }
+  }
+  setProviderForTests(null);
+  resetProviderForTests();
+  delete process.env.OBSIDIAN_CACHE_DISABLED;
+  await fs.rm(vaultDir, { recursive: true, force: true });
+});
+
+async function connectClient(
+  server: ReturnType<typeof buildMcpServer>,
+  name: string
+): Promise<Client> {
+  const client = new Client({ name, version: "0.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  clients.push(client);
+  return client;
+}
+
+describe("MCP server semantic services", () => {
+  it("shares one in-memory embedding store across separate server instances", async () => {
+    const services = createMcpServerServices(vaultDir);
+    const firstServer = buildMcpServer(vaultDir, services);
+    const secondServer = buildMcpServer(vaultDir, services);
+    const firstClient = await connectClient(firstServer, "indexer");
+    const secondClient = await connectClient(secondServer, "searcher");
+
+    const indexed = await firstClient.callTool({
+      name: "index_vault",
+      arguments: { confirm: INDEX_CONFIRM },
+    });
+    expect(indexed.isError).not.toBe(true);
+
+    // Persistence is disabled above. This can only succeed if both server
+    // instances received the exact same in-memory EmbeddingStore handle.
+    const searched = await secondClient.callTool({
+      name: "search_semantic",
+      arguments: { query: "cat care", limit: 5 },
+    });
+    expect(searched.isError).not.toBe(true);
+    const first = searched.content[0] as { type?: string; text?: string };
+    expect(first.type).toBe("text");
+    expect(first.text).toContain("cats.md");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,10 @@ import {
   untrustedVaultContentMeta,
 } from "./lib/tool-output.js";
 import { formatMomentDate } from "./lib/dates.js";
+import {
+  openEmbeddingStore,
+  type EmbeddingStore,
+} from "./lib/embedding-store-handle.js";
 import { registerReadTools } from "./tools/read.js";
 import { registerWriteTools } from "./tools/write.js";
 import { registerTagTools } from "./tools/tags.js";
@@ -46,6 +50,19 @@ interface CliOptions {
   installVaultPath?: string;
   installVaultName?: string;
   installServerName?: string;
+}
+
+export interface McpServerServices {
+  /** Explicitly owned semantic index state. Reuse one services object across
+   * multiple MCP server instances that serve the same vault (e.g. HTTP
+   * sessions) so semantic tools share one in-memory embedding index. */
+  embeddingStore: EmbeddingStore;
+}
+
+export function createMcpServerServices(
+  vaultPath: string | undefined
+): McpServerServices {
+  return { embeddingStore: openEmbeddingStore(vaultPath ?? "") };
 }
 
 export function parseArgs(argv: string[]): CliOptions {
@@ -199,7 +216,10 @@ function readPackageVersion(): string {
   }
 }
 
-export function buildMcpServer(vaultPath: string | undefined): McpServer {
+export function buildMcpServer(
+  vaultPath: string | undefined,
+  services: McpServerServices = createMcpServerServices(vaultPath)
+): McpServer {
   const server = new McpServer(
     {
       name: "obsidian-mcp-pro",
@@ -345,7 +365,7 @@ export function buildMcpServer(vaultPath: string | undefined): McpServer {
   registerSectionTools(server, vaultForTools);
   registerBaseTools(server, vaultForTools);
   registerAttachmentTools(server, vaultForTools);
-  registerSemanticTools(server, vaultForTools);
+  registerSemanticTools(server, vaultForTools, services.embeddingStore);
   registerPrompts(server);
   if (!vaultPath) {
     log.warn(
@@ -405,17 +425,18 @@ async function main(): Promise<void> {
     if (!bearerToken) {
       throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN.");
     }
-    // Single McpServer instance shared across sessions — the canonical SDK
-    // pattern (one server, one transport per session, transports share the
-    // server's tool/resource registry). Tools here are stateless, so nothing
-    // bleeds between clients. Vault resolution happens once at startup.
+    // HTTP transport creates one McpServer per session because the SDK
+    // Protocol permits only one active transport per server. Keep runtime
+    // services outside that session boundary so all clients serving this vault
+    // share one semantic index handle rather than diverging in memory.
+    const services = createMcpServerServices(vaultPath);
     await startHttpServer({
       host: opts.host,
       port: opts.port,
       bearerToken,
       allowedOrigins: opts.allowedOrigins,
       rateLimitPerMinute: opts.rateLimitPerMinute,
-      buildMcpServer: () => buildMcpServer(vaultPath),
+      buildMcpServer: () => buildMcpServer(vaultPath, services),
       version: readPackageVersion(),
     });
     const perms = describePermissions();

--- a/src/lib/embedding-store-handle.ts
+++ b/src/lib/embedding-store-handle.ts
@@ -1,0 +1,8 @@
+/**
+ * Stable handle-oriented entrypoint for the embedding store.
+ *
+ * The implementation lives in `embedding-store.ts`; semantic production code
+ * imports through this module so the handle boundary is explicit and test
+ * compatibility shims cannot accidentally become a production dependency.
+ */
+export * from "./embedding-store.js";

--- a/src/lib/embedding-store.ts
+++ b/src/lib/embedding-store.ts
@@ -5,18 +5,15 @@ import { log } from "./logger.js";
 import {
   openVaultInternalFileForRead,
   resolveVaultInternalPathSafe,
-} from "./vault.js";
+} from "./vault-fs.js";
 import { renameWithRetry } from "./fs-ops.js";
 
 /**
  * Persistent embedding store.
  *
- * Each entry is keyed by `<vault-relative-path>::<chunk-index>` and carries:
- *   - the embedding vector
- *   - a content hash (sha-256 of the chunk text) for incremental updates
- *   - the original chunk text (kept on disk so we can show snippets without
- *     re-reading the source note)
- *   - the headingPath the chunk came from
+ * Each handle is bound to exactly one resolved vault root and owns all mutable
+ * index state for that vault. There is intentionally no module-global vault
+ * registry: callers open one handle and share it across the semantic tools.
  *
  * Persistence: JSON snapshot at
  * `<vault>/.obsidian/cache/mcp-pro-embeddings.json`. Vector dimensionality
@@ -35,24 +32,10 @@ const NOTE_FOCUS_WEIGHT = 0.2;
 const NOTE_FOCUS_CHUNKS = 3;
 const SIMILAR_SOURCE_MIN_CHUNK_WEIGHT = 0.05;
 const SIMILAR_SOURCE_ANCHOR_POWER = 2;
-// Hard cap on the on-disk snapshot size. A 50k-note vault with 768-dim
-// vectors can produce a multi-GB JSON blob, at which point persisting it
-// each pass costs more than the cold-start re-embed it saves. When the
-// serialized snapshot exceeds this, we keep the in-memory store live and
-// skip the write; the next process start re-indexes from scratch. 256MB
-// covers ~85k chunks at 768 dims (rough), which is well past the point
-// where a user should switch to a real vector DB anyway.
 const MAX_EMBEDDING_BYTES_DEFAULT = 256 * 1024 * 1024;
-let maxEmbeddingBytes = MAX_EMBEDDING_BYTES_DEFAULT;
-/** Test seam — temporarily lower the persistence cap so we can exercise the
- *  oversize branch without producing a real 256MB fixture. Pass `null` to
- *  reset to the production default. */
-export function setMaxEmbeddingBytesForTests(bytes: number | null): void {
-  maxEmbeddingBytes = bytes === null ? MAX_EMBEDDING_BYTES_DEFAULT : bytes;
-}
 
 /** Whether the embedding store may persist to disk. Disabled via
- *  `OBSIDIAN_CACHE_DISABLED` (`1`/`true`/`yes`). */
+ * `OBSIDIAN_CACHE_DISABLED` (`1`/`true`/`yes`). */
 function isPersistenceEnabled(): boolean {
   const v = process.env.OBSIDIAN_CACHE_DISABLED;
   return !(v === "1" || v === "true" || v === "yes");
@@ -84,57 +67,37 @@ interface StoreSnapshot {
   embeddings: ChunkEmbedding[];
 }
 
-interface StoreState {
-  byKey: Map<string, ChunkEmbedding>;
-  /** Per-note: chunk keys it owns. Lets us drop a note's old chunks
-   *  efficiently when it changes. */
-  byNote: Map<string, Set<string>>;
-  /** Per-note hash, used to short-circuit re-chunk + re-embed when a note
-   *  hasn't changed since the last index. */
-  noteHashes: Map<string, string>;
-  loaded: boolean;
-  dirty: boolean;
-  /** Cached promise so concurrent callers await the same load. */
-  loadingPromise: Promise<StoreState> | null;
-  /** True while a saveStore write is in progress. */
-  saving: boolean;
-  /** True if another save was requested while one was already in flight. */
-  saveAgain: boolean;
+export interface EmbeddingStoreStats {
+  totalChunks: number;
+  totalNotes: number;
   providerId: string | null;
   model: string | null;
   dimension: number | null;
 }
 
-const stores = new Map<string, StoreState>(); // resolved vault root -> state
-
-function freshState(): StoreState {
-  return {
-    byKey: new Map(),
-    byNote: new Map(),
-    noteHashes: new Map(),
-    loaded: false,
-    dirty: false,
-    loadingPromise: null,
-    saving: false,
-    saveAgain: false,
-    providerId: null,
-    model: null,
-    dimension: null,
-  };
+export interface EmbeddingStoreOptions {
+  /** Persistence cap for this handle. Intended primarily for tests/embedders
+   * that need a stricter local cap; defaults to 256 MiB. */
+  maxEmbeddingBytes?: number;
 }
 
-function stateFor(vaultPath: string): StoreState {
-  const root = path.resolve(vaultPath);
-  let s = stores.get(root);
-  if (!s) {
-    s = freshState();
-    stores.set(root, s);
-  }
-  return s;
+export interface SearchHit {
+  notePath: string;
+  chunkIndex: number;
+  headingPath: string[];
+  text: string;
+  score: number;
 }
 
-function storePath(vaultPath: string): Promise<string> {
-  return resolveVaultInternalPathSafe(vaultPath, STORE_REL_PATH);
+export interface SearchOptions {
+  limit?: number;
+  /** Restrict to a folder prefix. */
+  folder?: string;
+  /** Excluded note paths — used by `find_similar_notes` to drop the source
+   *  note from its own results. */
+  excludeNotes?: ReadonlySet<string>;
+  /** Optional policy check applied before scoring/ranking each stored note. */
+  filterNote?: (notePath: string) => boolean;
 }
 
 function key(notePath: string, chunkIndex: number): string {
@@ -183,38 +146,85 @@ export function hashText(text: string): string {
   return createHash("sha256").update(text, "utf-8").digest("hex");
 }
 
-export async function loadStore(vaultPath: string): Promise<StoreState> {
-  const state = stateFor(vaultPath);
-  if (state.loaded) return state;
-  // If another caller is already loading, await the same promise instead of
-  // starting a parallel read that would race against it.
-  if (state.loadingPromise) return state.loadingPromise;
+/**
+ * A single-vault embedding index handle.
+ *
+ * Construction is synchronous and side-effect free. Call `load()` before
+ * using persisted state; concurrent `load()` callers share one in-flight
+ * promise. The handle is deliberately stateful so the ownership boundary is
+ * explicit instead of hidden behind module globals.
+ */
+export class EmbeddingStore {
+  readonly vaultPath: string;
+  private readonly maxEmbeddingBytes: number;
 
-  const doLoad = async (): Promise<StoreState> => {
-    if (!isPersistenceEnabled()) {
-      state.loaded = true;
-      state.loadingPromise = null;
-      return state;
+  private readonly byKey = new Map<string, ChunkEmbedding>();
+  private readonly byNote = new Map<string, Set<string>>();
+  private readonly noteHashes = new Map<string, string>();
+
+  private loaded = false;
+  private dirty = false;
+  private loadingPromise: Promise<void> | null = null;
+  private saving = false;
+  private saveAgain = false;
+  private providerId: string | null = null;
+  private model: string | null = null;
+  private dimension: number | null = null;
+
+  private constructor(vaultPath: string, options: EmbeddingStoreOptions = {}) {
+    this.vaultPath = path.resolve(vaultPath);
+    this.maxEmbeddingBytes =
+      options.maxEmbeddingBytes ?? MAX_EMBEDDING_BYTES_DEFAULT;
+  }
+
+  static open(
+    vaultPath: string,
+    options: EmbeddingStoreOptions = {}
+  ): EmbeddingStore {
+    return new EmbeddingStore(vaultPath, options);
+  }
+
+  private storePath(): Promise<string> {
+    return resolveVaultInternalPathSafe(this.vaultPath, STORE_REL_PATH);
+  }
+
+  async load(): Promise<void> {
+    if (this.loaded) return;
+    if (this.loadingPromise) return this.loadingPromise;
+
+    const pending = this.loadFromDisk();
+    this.loadingPromise = pending;
+    try {
+      await pending;
+    } finally {
+      if (this.loadingPromise === pending) this.loadingPromise = null;
     }
+  }
+
+  private async loadFromDisk(): Promise<void> {
+    if (!isPersistenceEnabled()) {
+      this.loaded = true;
+      return;
+    }
+
     let raw: string;
     try {
       const opened = await openVaultInternalFileForRead(
-        vaultPath,
+        this.vaultPath,
         STORE_REL_PATH
       );
       const stat = opened.stats;
-      if (stat.size > maxEmbeddingBytes) {
+      if (stat.size > this.maxEmbeddingBytes) {
         await opened.handle.close();
         log.warn(
           "embedding-store: snapshot exceeds MAX_EMBEDDING_BYTES; ignoring",
           {
             bytes: stat.size,
-            max: maxEmbeddingBytes,
+            max: this.maxEmbeddingBytes,
           }
         );
-        state.loaded = true;
-        state.loadingPromise = null;
-        return state;
+        this.loaded = true;
+        return;
       }
       try {
         raw = await opened.handle.readFile("utf-8");
@@ -227,10 +237,10 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
           err: err as Error,
         });
       }
-      state.loaded = true;
-      state.loadingPromise = null;
-      return state;
+      this.loaded = true;
+      return;
     }
+
     let snapshot: StoreSnapshot;
     try {
       snapshot = JSON.parse(raw) as StoreSnapshot;
@@ -238,10 +248,10 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
       log.warn("embedding-store: snapshot is invalid JSON; ignoring", {
         err: err as Error,
       });
-      state.loaded = true;
-      state.loadingPromise = null;
-      return state;
+      this.loaded = true;
+      return;
     }
+
     if (
       !snapshot ||
       snapshot.version !== STORE_VERSION ||
@@ -251,286 +261,318 @@ export async function loadStore(vaultPath: string): Promise<StoreState> {
       !isPositiveInteger(snapshot.dimension)
     ) {
       log.warn("embedding-store: snapshot has unexpected shape; ignoring");
-      state.loaded = true;
-      state.loadingPromise = null;
-      return state;
+      this.loaded = true;
+      return;
     }
-    const expectedRoot = path.resolve(vaultPath);
-    if (snapshot.vaultRoot !== expectedRoot) {
+
+    if (snapshot.vaultRoot !== this.vaultPath) {
       log.info("embedding-store: snapshot vault root differs; discarding", {
         snapshotRoot: snapshot.vaultRoot,
-        currentRoot: expectedRoot,
+        currentRoot: this.vaultPath,
       });
-      state.loaded = true;
-      state.loadingPromise = null;
-      return state;
+      this.loaded = true;
+      return;
     }
-    state.providerId = snapshot.providerId;
-    state.model = snapshot.model;
-    state.dimension = snapshot.dimension;
+
+    this.providerId = snapshot.providerId;
+    this.model = snapshot.model;
+    this.dimension = snapshot.dimension;
     for (const entry of snapshot.embeddings) {
       if (!isSnapshotEntry(entry)) continue;
-      // Silently drop entries whose vector length doesn't match the snapshot's
-      // declared dimension. Guards against hand-edited or partially-corrupted
-      // snapshots where one row's length drifted from the rest.
       if (validateEmbeddingVector(entry.vector, snapshot.dimension) !== null)
         continue;
-      state.byKey.set(key(entry.notePath, entry.chunkIndex), entry);
-      let owned = state.byNote.get(entry.notePath);
+      const entryKey = key(entry.notePath, entry.chunkIndex);
+      this.byKey.set(entryKey, entry);
+      let owned = this.byNote.get(entry.notePath);
       if (!owned) {
         owned = new Set();
-        state.byNote.set(entry.notePath, owned);
+        this.byNote.set(entry.notePath, owned);
       }
-      owned.add(key(entry.notePath, entry.chunkIndex));
+      owned.add(entryKey);
     }
     for (const [note, hash] of Object.entries(snapshot.noteHashes ?? {})) {
-      if (typeof hash === "string" && state.byNote.has(note))
-        state.noteHashes.set(note, hash);
-    }
-    // Mark loaded only AFTER all async I/O and parsing is complete.
-    state.loaded = true;
-    state.loadingPromise = null;
-    return state;
-  };
-
-  state.loadingPromise = doLoad();
-  return state.loadingPromise;
-}
-
-export async function saveStore(vaultPath: string): Promise<void> {
-  const state = stateFor(vaultPath);
-  if (!state.dirty) return;
-  if (state.providerId === null || state.model === null) return; // nothing valid to write
-  if (!isPersistenceEnabled()) {
-    state.dirty = false;
-    return;
-  }
-
-  // If a save is already in flight, mark that another pass is needed and
-  // return. The in-flight save will re-check the flag when it finishes.
-  if (state.saving) {
-    state.saveAgain = true;
-    return;
-  }
-
-  state.saving = true;
-  try {
-    await doSave(vaultPath, state);
-  } finally {
-    state.saving = false;
-  }
-
-  // If someone requested another save while we were writing, run one more
-  // pass to pick up any changes that arrived after we serialized.
-  if (state.saveAgain) {
-    state.saveAgain = false;
-    await saveStore(vaultPath);
-  }
-}
-
-async function doSave(vaultPath: string, state: StoreState): Promise<void> {
-  const snapshot: StoreSnapshot = {
-    version: STORE_VERSION,
-    vaultRoot: path.resolve(vaultPath),
-    providerId: state.providerId!,
-    model: state.model!,
-    dimension: state.dimension ?? 0,
-    noteHashes: Object.fromEntries(state.noteHashes),
-    embeddings: Array.from(state.byKey.values()),
-  };
-  const serialized = JSON.stringify(snapshot);
-  // Guard against unbounded on-disk growth. Serialize once, measure the
-  // result, and refuse to persist if it would exceed MAX_EMBEDDING_BYTES.
-  // The in-memory store stays intact (current-process queries still work);
-  // we just degrade cold-start performance until the user prunes the vault
-  // or switches to a dedicated vector backend. `Buffer.byteLength` on the
-  // UTF-8 string gives the actual write size, not the JS string length.
-  const byteLength = Buffer.byteLength(serialized, "utf-8");
-  if (byteLength > maxEmbeddingBytes) {
-    log.warn(
-      "embedding-store: snapshot exceeds MAX_EMBEDDING_BYTES, persistence skipped",
-      {
-        bytes: byteLength,
-        max: maxEmbeddingBytes,
-        chunks: state.byKey.size,
-        notes: state.byNote.size,
+      if (typeof hash === "string" && this.byNote.has(note)) {
+        this.noteHashes.set(note, hash);
       }
-    );
-    return;
+    }
+    this.loaded = true;
   }
-  let file: string;
-  try {
-    file = await storePath(vaultPath);
-  } catch (err) {
-    log.warn("embedding-store: snapshot path failed vault-boundary check", {
-      err: err as Error,
-    });
-    return;
-  }
-  // Include a random suffix so two concurrent saves in the same process
-  // (same PID) don't fight over the same tmp file and clobber each other.
-  const tmp = `${file}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  try {
-    await fs.mkdir(path.dirname(file), { recursive: true });
+
+  async save(): Promise<void> {
+    if (!this.dirty) return;
+    if (this.providerId === null || this.model === null) return;
+    if (!isPersistenceEnabled()) {
+      this.dirty = false;
+      return;
+    }
+
+    if (this.saving) {
+      this.saveAgain = true;
+      return;
+    }
+
+    this.saving = true;
     try {
-      await fs.writeFile(tmp, serialized, { encoding: "utf-8", mode: 0o600 });
-      await renameWithRetry(tmp, file);
-    } catch (innerErr) {
-      // Best-effort cleanup: if writeFile succeeded but rename failed, the
-      // tmp file is still on disk. ENOENT (writeFile never created it) is
-      // fine to swallow here.
+      await this.doSave();
+    } finally {
+      this.saving = false;
+    }
+
+    if (this.saveAgain) {
+      this.saveAgain = false;
+      await this.save();
+    }
+  }
+
+  private async doSave(): Promise<void> {
+    const snapshot: StoreSnapshot = {
+      version: STORE_VERSION,
+      vaultRoot: this.vaultPath,
+      providerId: this.providerId!,
+      model: this.model!,
+      dimension: this.dimension ?? 0,
+      noteHashes: Object.fromEntries(this.noteHashes),
+      embeddings: Array.from(this.byKey.values()),
+    };
+    const serialized = JSON.stringify(snapshot);
+    const byteLength = Buffer.byteLength(serialized, "utf-8");
+    if (byteLength > this.maxEmbeddingBytes) {
+      log.warn(
+        "embedding-store: snapshot exceeds MAX_EMBEDDING_BYTES, persistence skipped",
+        {
+          bytes: byteLength,
+          max: this.maxEmbeddingBytes,
+          chunks: this.byKey.size,
+          notes: this.byNote.size,
+        }
+      );
+      return;
+    }
+
+    let file: string;
+    try {
+      file = await this.storePath();
+    } catch (err) {
+      log.warn("embedding-store: snapshot path failed vault-boundary check", {
+        err: err as Error,
+      });
+      return;
+    }
+
+    const tmp = `${file}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+    try {
+      await fs.mkdir(path.dirname(file), { recursive: true });
       try {
-        await fs.unlink(tmp);
+        await fs.writeFile(tmp, serialized, {
+          encoding: "utf-8",
+          mode: 0o600,
+        });
+        await renameWithRetry(tmp, file);
+      } catch (innerErr) {
+        try {
+          await fs.unlink(tmp);
+        } catch {
+          /* ignore */
+        }
+        throw innerErr;
+      }
+      this.dirty = false;
+    } catch (err) {
+      log.warn("embedding-store: failed to persist snapshot", {
+        err: err as Error,
+      });
+    }
+  }
+
+  /** Reset this handle to a fresh in-memory state. The next `load()` reads the
+   * snapshot again. Pass `removeSnapshot: true` to also unlink persisted data. */
+  async clear(options?: { removeSnapshot?: boolean }): Promise<void> {
+    this.byKey.clear();
+    this.byNote.clear();
+    this.noteHashes.clear();
+    this.loaded = false;
+    this.dirty = false;
+    this.loadingPromise = null;
+    this.saveAgain = false;
+    this.providerId = null;
+    this.model = null;
+    this.dimension = null;
+
+    if (options?.removeSnapshot) {
+      try {
+        await fs.unlink(await this.storePath());
       } catch {
         /* ignore */
       }
-      throw innerErr;
-    }
-    state.dirty = false;
-  } catch (err) {
-    log.warn("embedding-store: failed to persist snapshot", {
-      err: err as Error,
-    });
-  }
-}
-
-/** Drop everything we know about this vault. The next `loadStore` re-reads
- *  from disk; pass `removeSnapshot: true` to also unlink the snapshot file
- *  (e.g. when the user wants to fully reset the index). */
-export async function clearStore(
-  vaultPath: string,
-  options?: { removeSnapshot?: boolean }
-): Promise<void> {
-  stores.delete(path.resolve(vaultPath));
-  if (options?.removeSnapshot) {
-    try {
-      await fs.unlink(await storePath(vaultPath));
-    } catch {
-      /* ignore */
     }
   }
-}
 
-/** Drop a snapshot incompatible with the current provider/model (different
- *  dimension or label). Called by the indexer at startup. */
-export function invalidateIfIncompatible(
-  vaultPath: string,
-  providerId: string,
-  model: string
-): void {
-  const state = stateFor(vaultPath);
-  if (!state.loaded) return;
-  if (state.providerId === providerId && state.model === model) return;
-  state.byKey.clear();
-  state.byNote.clear();
-  state.noteHashes.clear();
-  state.providerId = providerId;
-  state.model = model;
-  state.dimension = null;
-  state.dirty = true;
-}
-
-/** Has the given note's content changed since the last index pass? */
-export function noteIsCurrent(
-  vaultPath: string,
-  notePath: string,
-  contentHash: string
-): boolean {
-  const state = stateFor(vaultPath);
-  return state.noteHashes.get(notePath) === contentHash;
-}
-
-/** Replace all chunks for `notePath`. Pass empty `chunks` to drop a note. */
-export function setNoteChunks(
-  vaultPath: string,
-  notePath: string,
-  contentHash: string,
-  chunks: ChunkEmbedding[],
-  providerId: string,
-  model: string
-): void {
-  const state = stateFor(vaultPath);
-  let nextDimension = state.dimension;
-  for (const ch of chunks) {
-    const error = validateEmbeddingVector(ch.vector, nextDimension);
-    if (error !== null) {
-      throw new Error(
-        `Invalid embedding vector at chunk ${ch.chunkIndex}: ${error}`
-      );
-    }
-    if (nextDimension === null) nextDimension = ch.vector.length;
+  /** Drop a snapshot incompatible with the current provider/model. */
+  invalidateIfIncompatible(providerId: string, model: string): void {
+    if (!this.loaded) return;
+    if (this.providerId === providerId && this.model === model) return;
+    this.byKey.clear();
+    this.byNote.clear();
+    this.noteHashes.clear();
+    this.providerId = providerId;
+    this.model = model;
+    this.dimension = null;
+    this.dirty = true;
   }
-  // Drop any prior chunks owned by this note.
-  const prior = state.byNote.get(notePath);
-  if (prior) {
-    for (const k of prior) state.byKey.delete(k);
+
+  /** Has the given note's content changed since the last index pass? */
+  noteIsCurrent(notePath: string, contentHash: string): boolean {
+    return this.noteHashes.get(notePath) === contentHash;
   }
-  if (chunks.length === 0) {
-    state.byNote.delete(notePath);
-    state.noteHashes.delete(notePath);
-  } else {
-    const owned = new Set<string>();
+
+  /** Replace all chunks for `notePath`. Pass empty `chunks` to drop a note. */
+  setNoteChunks(
+    notePath: string,
+    contentHash: string,
+    chunks: ChunkEmbedding[],
+    providerId: string,
+    model: string
+  ): void {
+    let nextDimension = this.dimension;
     for (const ch of chunks) {
-      const k = key(ch.notePath, ch.chunkIndex);
-      state.byKey.set(k, ch);
-      owned.add(k);
+      const error = validateEmbeddingVector(ch.vector, nextDimension);
+      if (error !== null) {
+        throw new Error(
+          `Invalid embedding vector at chunk ${ch.chunkIndex}: ${error}`
+        );
+      }
+      if (nextDimension === null) nextDimension = ch.vector.length;
     }
-    state.dimension = nextDimension;
-    state.byNote.set(notePath, owned);
-    state.noteHashes.set(notePath, contentHash);
+
+    const prior = this.byNote.get(notePath);
+    if (prior) {
+      for (const priorKey of prior) this.byKey.delete(priorKey);
+    }
+
+    if (chunks.length === 0) {
+      this.byNote.delete(notePath);
+      this.noteHashes.delete(notePath);
+    } else {
+      const owned = new Set<string>();
+      for (const ch of chunks) {
+        const chunkKey = key(ch.notePath, ch.chunkIndex);
+        this.byKey.set(chunkKey, ch);
+        owned.add(chunkKey);
+      }
+      this.dimension = nextDimension;
+      this.byNote.set(notePath, owned);
+      this.noteHashes.set(notePath, contentHash);
+    }
+    this.providerId = providerId;
+    this.model = model;
+    this.dirty = true;
   }
-  state.providerId = providerId;
-  state.model = model;
-  state.dirty = true;
+
+  dropNoteChunks(notePath: string): boolean {
+    const owned = this.byNote.get(notePath);
+    const hadHash = this.noteHashes.delete(notePath);
+    if (!owned && !hadHash) return false;
+    if (owned) {
+      for (const ownedKey of owned) this.byKey.delete(ownedKey);
+    }
+    this.byNote.delete(notePath);
+    this.dirty = true;
+    return true;
+  }
+
+  /** Drop chunks for notes that no longer exist in the vault. */
+  pruneMissingNotes(currentNotes: Iterable<string>): number {
+    const live = new Set<string>(currentNotes);
+    let pruned = 0;
+    for (const note of Array.from(this.byNote.keys())) {
+      if (live.has(note)) continue;
+      if (this.dropNoteChunks(note)) pruned++;
+    }
+    return pruned;
+  }
+
+  stats(): EmbeddingStoreStats {
+    return {
+      totalChunks: this.byKey.size,
+      totalNotes: this.byNote.size,
+      providerId: this.providerId,
+      model: this.model,
+      dimension: this.dimension,
+    };
+  }
+
+  isEmpty(): boolean {
+    return this.byKey.size === 0;
+  }
+
+  search(queryVector: number[], options: SearchOptions = {}): SearchHit[] {
+    const limit = options.limit ?? 10;
+    const folder = normalizeSearchFolder(options.folder);
+    const exclude = options.excludeNotes ?? null;
+    const filterNote = options.filterNote ?? null;
+
+    const hits: SearchHit[] = [];
+    for (const entry of this.byKey.values()) {
+      if (folder !== null) {
+        if (
+          entry.notePath !== folder &&
+          !entry.notePath.startsWith(folder + "/")
+        )
+          continue;
+      }
+      if (exclude && exclude.has(entry.notePath)) continue;
+      if (filterNote && !filterNote(entry.notePath)) continue;
+      const score = cosineSimilarity(queryVector, entry.vector);
+      hits.push({
+        notePath: entry.notePath,
+        chunkIndex: entry.chunkIndex,
+        headingPath: entry.headingPath,
+        text: entry.text,
+        score,
+      });
+    }
+
+    const byNote = new Map<string, { best: SearchHit; scores: number[] }>();
+    for (const hit of hits) {
+      const existing = byNote.get(hit.notePath);
+      if (!existing) {
+        byNote.set(hit.notePath, { best: hit, scores: [hit.score] });
+      } else {
+        existing.scores.push(hit.score);
+        if (hit.score > existing.best.score) existing.best = hit;
+      }
+    }
+    const out = Array.from(byNote.values())
+      .map(({ best, scores }) => ({ ...best, score: noteFocusScore(scores) }))
+      .sort((a, b) => {
+        const scoreDelta = b.score - a.score;
+        if (scoreDelta !== 0) return scoreDelta;
+        return a.notePath.localeCompare(b.notePath);
+      });
+    return out.slice(0, limit);
+  }
+
+  /** Get the embeddings owned by a specific note. */
+  getNoteEmbeddings(notePath: string): ChunkEmbedding[] {
+    const owned = this.byNote.get(notePath);
+    if (!owned) return [];
+    const out: ChunkEmbedding[] = [];
+    for (const ownedKey of owned) {
+      const entry = this.byKey.get(ownedKey);
+      if (entry) out.push(entry);
+    }
+    return out;
+  }
 }
 
-export function dropNoteChunks(vaultPath: string, notePath: string): boolean {
-  const state = stateFor(vaultPath);
-  const owned = state.byNote.get(notePath);
-  const hadHash = state.noteHashes.delete(notePath);
-  if (!owned && !hadHash) return false;
-  if (owned) {
-    for (const k of owned) state.byKey.delete(k);
-  }
-  state.byNote.delete(notePath);
-  state.dirty = true;
-  return true;
-}
-
-/** Drop chunks for notes that no longer exist in the vault. Called at the
- *  end of an index pass. */
-export function pruneMissingNotes(
+export function openEmbeddingStore(
   vaultPath: string,
-  currentNotes: Iterable<string>
-): number {
-  const state = stateFor(vaultPath);
-  const live = new Set<string>(currentNotes);
-  let pruned = 0;
-  for (const note of Array.from(state.byNote.keys())) {
-    if (live.has(note)) continue;
-    if (dropNoteChunks(vaultPath, note)) pruned++;
-  }
-  return pruned;
+  options: EmbeddingStoreOptions = {}
+): EmbeddingStore {
+  return EmbeddingStore.open(vaultPath, options);
 }
 
-export function snapshotForTests(vaultPath: string): {
-  totalChunks: number;
-  totalNotes: number;
-  providerId: string | null;
-  model: string | null;
-  dimension: number | null;
-} {
-  const state = stateFor(vaultPath);
-  return {
-    totalChunks: state.byKey.size,
-    totalNotes: state.byNote.size,
-    providerId: state.providerId,
-    model: state.model,
-    dimension: state.dimension,
-  };
-}
-
-// ─── cosine similarity + search ─────────────────────────────────────
+// ─── pure similarity helpers ────────────────────────────────────────
 
 export function cosineSimilarity(a: number[], b: number[]): number {
   if (a.length !== b.length) {
@@ -553,25 +595,6 @@ export function cosineSimilarity(a: number[], b: number[]): number {
   return dot / (Math.sqrt(na) * Math.sqrt(nb));
 }
 
-export interface SearchHit {
-  notePath: string;
-  chunkIndex: number;
-  headingPath: string[];
-  text: string;
-  score: number;
-}
-
-export interface SearchOptions {
-  limit?: number;
-  /** Restrict to a folder prefix. */
-  folder?: string;
-  /** Excluded note paths — used by `find_similar_notes` to drop the source
-   *  note from its own results. */
-  excludeNotes?: ReadonlySet<string>;
-  /** Optional policy check applied before scoring/ranking each stored note. */
-  filterNote?: (notePath: string) => boolean;
-}
-
 function normalizeSearchFolder(folder: string | undefined): string | null {
   if (!folder) return null;
   const slashed = folder
@@ -583,61 +606,6 @@ function normalizeSearchFolder(folder: string | undefined): string | null {
   if (normalized === "." || normalized === "") return null;
   if (normalized === ".." || normalized.startsWith("../")) return slashed;
   return normalized;
-}
-
-export function searchEmbeddings(
-  vaultPath: string,
-  queryVector: number[],
-  options: SearchOptions = {}
-): SearchHit[] {
-  const state = stateFor(vaultPath);
-  const limit = options.limit ?? 10;
-  const folder = normalizeSearchFolder(options.folder);
-  const exclude = options.excludeNotes ?? null;
-  const filterNote = options.filterNote ?? null;
-
-  const hits: SearchHit[] = [];
-  for (const entry of state.byKey.values()) {
-    if (folder !== null) {
-      if (entry.notePath !== folder && !entry.notePath.startsWith(folder + "/"))
-        continue;
-    }
-    if (exclude && exclude.has(entry.notePath)) continue;
-    if (filterNote && !filterNote(entry.notePath)) continue;
-    const score = cosineSimilarity(queryVector, entry.vector);
-    hits.push({
-      notePath: entry.notePath,
-      chunkIndex: entry.chunkIndex,
-      headingPath: entry.headingPath,
-      text: entry.text,
-      score,
-    });
-  }
-  // Per-note ranking: keep the highest-scoring chunk for the snippet, but
-  // sort notes with a small focus signal from their top chunks. This avoids
-  // one incidental perfect chunk outranking notes that are consistently about
-  // the query.
-  const byNote = new Map<string, { best: SearchHit; scores: number[] }>();
-  for (const h of hits) {
-    const existing = byNote.get(h.notePath);
-    if (!existing) {
-      byNote.set(h.notePath, { best: h, scores: [h.score] });
-    } else {
-      existing.scores.push(h.score);
-      if (h.score > existing.best.score) existing.best = h;
-    }
-  }
-  const out = Array.from(byNote.values())
-    .map(({ best, scores }) => {
-      const score = noteFocusScore(scores);
-      return { ...best, score };
-    })
-    .sort((a, b) => {
-      const scoreDelta = b.score - a.score;
-      if (scoreDelta !== 0) return scoreDelta;
-      return a.notePath.localeCompare(b.notePath);
-    });
-  return out.slice(0, limit);
 }
 
 function noteFocusScore(scores: number[]): number {
@@ -680,22 +648,6 @@ export function buildSimilarNotesQueryVector(
   if (totalWeight === 0) return out;
   for (let d = 0; d < dim; d++) {
     out[d] = out[d]! / totalWeight;
-  }
-  return out;
-}
-
-/** Get the embeddings owned by a specific note (used by find_similar). */
-export function getNoteEmbeddings(
-  vaultPath: string,
-  notePath: string
-): ChunkEmbedding[] {
-  const state = stateFor(vaultPath);
-  const owned = state.byNote.get(notePath);
-  if (!owned) return [];
-  const out: ChunkEmbedding[] = [];
-  for (const k of owned) {
-    const e = state.byKey.get(k);
-    if (e) out.push(e);
   }
   return out;
 }

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -1,11 +1,17 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { openEmbeddingStore } from "../lib/embedding-store-handle.js";
+import {
+  openEmbeddingStore,
+  type EmbeddingStore,
+} from "../lib/embedding-store-handle.js";
 import { registerIndexVaultTool } from "./semantic/index_vault.js";
 import { registerSearchSemanticTool } from "./semantic/search_semantic.js";
 import { registerFindSimilarNotesTool } from "./semantic/find_similar_notes.js";
 
-export function registerSemanticTools(server: McpServer, vaultPath: string): void {
-  const store = openEmbeddingStore(vaultPath);
+export function registerSemanticTools(
+  server: McpServer,
+  vaultPath: string,
+  store: EmbeddingStore = openEmbeddingStore(vaultPath)
+): void {
   registerIndexVaultTool(server, vaultPath, store);
   registerSearchSemanticTool(server, vaultPath, store);
   registerFindSimilarNotesTool(server, vaultPath, store);

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   openEmbeddingStore,
@@ -12,6 +13,9 @@ export function registerSemanticTools(
   vaultPath: string,
   store: EmbeddingStore = openEmbeddingStore(vaultPath)
 ): void {
+  if (store.vaultPath !== path.resolve(vaultPath)) {
+    throw new Error("EmbeddingStore vault does not match semantic tool vault");
+  }
   registerIndexVaultTool(server, vaultPath, store);
   registerSearchSemanticTool(server, vaultPath, store);
   registerFindSimilarNotesTool(server, vaultPath, store);

--- a/src/tools/semantic.ts
+++ b/src/tools/semantic.ts
@@ -1,10 +1,12 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { openEmbeddingStore } from "../lib/embedding-store-handle.js";
 import { registerIndexVaultTool } from "./semantic/index_vault.js";
 import { registerSearchSemanticTool } from "./semantic/search_semantic.js";
 import { registerFindSimilarNotesTool } from "./semantic/find_similar_notes.js";
 
 export function registerSemanticTools(server: McpServer, vaultPath: string): void {
-  registerIndexVaultTool(server, vaultPath);
-  registerSearchSemanticTool(server, vaultPath);
-  registerFindSimilarNotesTool(server, vaultPath);
+  const store = openEmbeddingStore(vaultPath);
+  registerIndexVaultTool(server, vaultPath, store);
+  registerSearchSemanticTool(server, vaultPath, store);
+  registerFindSimilarNotesTool(server, vaultPath, store);
 }

--- a/src/tools/semantic/find_similar_notes.ts
+++ b/src/tools/semantic/find_similar_notes.ts
@@ -4,17 +4,11 @@ import { resolveVaultPath, readNote } from "../../lib/vault.js";
 import { chunkNote } from "../../lib/chunker.js";
 import { getActiveProvider } from "../../lib/embedding-providers.js";
 import {
-  loadStore,
-  saveStore,
   hashText,
-  noteIsCurrent,
-  dropNoteChunks,
-  getNoteEmbeddings,
-  searchEmbeddings,
   buildSimilarNotesQueryVector,
-  invalidateIfIncompatible,
+  type EmbeddingStore,
   type SearchHit,
-} from "../../lib/embedding-store.js";
+} from "../../lib/embedding-store-handle.js";
 import { defineTool, text, richText, error } from "../../lib/tool-seam.js";
 import {
   escapeControlChars,
@@ -30,6 +24,7 @@ interface FreshSearchOptions {
 }
 
 async function searchFreshEmbeddings(
+  store: EmbeddingStore,
   vaultPath: string,
   queryVector: number[],
   options: FreshSearchOptions
@@ -47,11 +42,10 @@ async function searchFreshEmbeddings(
   }
 
   function storedChunksMatchLiveChunks(
-    vaultPath: string,
     notePath: string,
     chunks: ReturnType<typeof chunkNote>
   ): boolean {
-    const stored = getNoteEmbeddings(vaultPath, notePath);
+    const stored = store.getNoteEmbeddings(notePath);
     if (stored.length !== chunks.length) return false;
     const storedByIndex = new Map(
       stored.map((chunk) => [chunk.chunkIndex, chunk])
@@ -66,29 +60,23 @@ async function searchFreshEmbeddings(
     return true;
   }
 
-  async function storedNoteIsCurrent(
-    vaultPath: string,
-    notePath: string
-  ): Promise<boolean> {
+  async function storedNoteIsCurrent(notePath: string): Promise<boolean> {
     try {
       const content = await readNote(vaultPath, notePath);
       const chunks = chunkNote(content);
       return (
-        noteIsCurrent(vaultPath, notePath, hashText(content)) &&
-        storedChunksMatchLiveChunks(vaultPath, notePath, chunks)
+        store.noteIsCurrent(notePath, hashText(content)) &&
+        storedChunksMatchLiveChunks(notePath, chunks)
       );
     } catch {
       return false;
     }
   }
 
-  async function pruneStaleStoredNote(
-    vaultPath: string,
-    notePath: string
-  ): Promise<boolean> {
-    const current = await storedNoteIsCurrent(vaultPath, notePath);
+  async function pruneStaleStoredNote(notePath: string): Promise<boolean> {
+    const current = await storedNoteIsCurrent(notePath);
     if (current) return false;
-    return dropNoteChunks(vaultPath, notePath);
+    return store.dropNoteChunks(notePath);
   }
 
   for (let pass = 0; pass < 10 && hits.length < options.limit; pass++) {
@@ -96,7 +84,7 @@ async function searchFreshEmbeddings(
     for (const notePath of accepted) exclude.add(notePath);
     for (const notePath of stale) exclude.add(notePath);
     const batchLimit = Math.min(100, Math.max(options.limit - hits.length, 20));
-    const candidates = searchEmbeddings(vaultPath, queryVector, {
+    const candidates = store.search(queryVector, {
       limit: batchLimit,
       ...(options.folder ? { folder: options.folder } : {}),
       ...(exclude.size > 0 ? { excludeNotes: exclude } : {}),
@@ -106,7 +94,7 @@ async function searchFreshEmbeddings(
     let advanced = false;
     for (const hit of candidates) {
       if (accepted.has(hit.notePath)) continue;
-      if (await pruneStaleStoredNote(vaultPath, hit.notePath)) {
+      if (await pruneStaleStoredNote(hit.notePath)) {
         stale.add(hit.notePath);
         stalePruned++;
         advanced = true;
@@ -119,7 +107,7 @@ async function searchFreshEmbeddings(
     }
     if (!advanced) break;
   }
-  if (stalePruned > 0) await saveStore(vaultPath);
+  if (stalePruned > 0) await store.save();
   return { hits, stalePruned };
 }
 
@@ -137,7 +125,8 @@ function canReadStoredEmbeddingNote(
 
 export function registerFindSimilarNotesTool(
   server: McpServer,
-  vaultPath: string
+  vaultPath: string,
+  store: EmbeddingStore
 ): void {
   defineTool(
     server,
@@ -173,33 +162,17 @@ export function registerFindSimilarNotesTool(
       },
     },
     async ({ path: notePath, limit }) => {
-      await loadStore(vaultPath);
+      await store.load();
       const provider = getActiveProvider();
       if (provider) {
-        invalidateIfIncompatible(vaultPath, provider.id, provider.model);
+        store.invalidateIfIncompatible(provider.id, provider.model);
       }
       resolveVaultPath(vaultPath, notePath, "read");
-      const ownChunks = getNoteEmbeddings(vaultPath, notePath);
+      const ownChunks = store.getNoteEmbeddings(notePath);
       if (ownChunks.length === 0) {
         return error(
           `No embeddings found for "${escapeControlChars(notePath)}". Run \`index_vault\` first (or check the path is correct).`
         );
-      }
-
-      async function storedNoteIsCurrent(
-        vaultPath: string,
-        notePath: string
-      ): Promise<boolean> {
-        try {
-          const content = await readNote(vaultPath, notePath);
-          const chunks = chunkNote(content);
-          return (
-            noteIsCurrent(vaultPath, notePath, hashText(content)) &&
-            storedChunksMatchLiveChunks(vaultPath, notePath, chunks)
-          );
-        } catch {
-          return false;
-        }
       }
 
       function headingPathsEqual(
@@ -212,11 +185,10 @@ export function registerFindSimilarNotesTool(
       }
 
       function storedChunksMatchLiveChunks(
-        vaultPath: string,
-        notePath: string,
+        currentPath: string,
         chunks: ReturnType<typeof chunkNote>
       ): boolean {
-        const stored = getNoteEmbeddings(vaultPath, notePath);
+        const stored = store.getNoteEmbeddings(currentPath);
         if (stored.length !== chunks.length) return false;
         const storedByIndex = new Map(
           stored.map((chunk) => [chunk.chunkIndex, chunk])
@@ -231,28 +203,44 @@ export function registerFindSimilarNotesTool(
         return true;
       }
 
-      async function pruneStaleStoredNote(
-        vaultPath: string,
-        notePath: string
-      ): Promise<boolean> {
-        const current = await storedNoteIsCurrent(vaultPath, notePath);
-        if (current) return false;
-        return dropNoteChunks(vaultPath, notePath);
+      async function storedNoteIsCurrent(currentPath: string): Promise<boolean> {
+        try {
+          const content = await readNote(vaultPath, currentPath);
+          const chunks = chunkNote(content);
+          return (
+            store.noteIsCurrent(currentPath, hashText(content)) &&
+            storedChunksMatchLiveChunks(currentPath, chunks)
+          );
+        } catch {
+          return false;
+        }
       }
 
-      if (await pruneStaleStoredNote(vaultPath, notePath)) {
-        await saveStore(vaultPath);
+      async function pruneStaleStoredNote(currentPath: string): Promise<boolean> {
+        const current = await storedNoteIsCurrent(currentPath);
+        if (current) return false;
+        return store.dropNoteChunks(currentPath);
+      }
+
+      if (await pruneStaleStoredNote(notePath)) {
+        await store.save();
         return error(
           `No current embeddings found for "${escapeControlChars(notePath)}". Run \`index_vault\` to refresh it.`
         );
       }
       const queryVector = buildSimilarNotesQueryVector(ownChunks);
       const exclude = new Set([notePath]);
-      const { hits } = await searchFreshEmbeddings(vaultPath, queryVector, {
-        limit,
-        excludeNotes: exclude,
-        filterNote: (hitPath) => canReadStoredEmbeddingNote(vaultPath, hitPath),
-      });
+      const { hits } = await searchFreshEmbeddings(
+        store,
+        vaultPath,
+        queryVector,
+        {
+          limit,
+          excludeNotes: exclude,
+          filterNote: (hitPath) =>
+            canReadStoredEmbeddingNote(vaultPath, hitPath),
+        }
+      );
       const ranked = hits.map((h) => ({
         notePath: h.notePath,
         score: h.score,

--- a/src/tools/semantic/index_vault.ts
+++ b/src/tools/semantic/index_vault.ts
@@ -9,17 +9,11 @@ import { readAllCached } from "../../lib/index-cache.js";
 import { chunkNote } from "../../lib/chunker.js";
 import { getActiveProvider } from "../../lib/embedding-providers.js";
 import {
-  loadStore,
-  saveStore,
-  getNoteEmbeddings,
   hashText,
-  noteIsCurrent,
-  setNoteChunks,
-  pruneMissingNotes,
-  invalidateIfIncompatible,
   validateEmbeddingVector,
   type ChunkEmbedding,
-} from "../../lib/embedding-store.js";
+  type EmbeddingStore,
+} from "../../lib/embedding-store-handle.js";
 import { makeProgressReporter } from "../../lib/progress.js";
 import { sanitizeError } from "../../lib/errors.js";
 import { log } from "../../lib/logger.js";
@@ -48,11 +42,11 @@ function headingPathsEqual(
 }
 
 function storedChunksMatchLiveChunks(
-  vaultPath: string,
+  store: EmbeddingStore,
   notePath: string,
   chunks: ReturnType<typeof chunkNote>
 ): boolean {
-  const stored = getNoteEmbeddings(vaultPath, notePath);
+  const stored = store.getNoteEmbeddings(notePath);
   if (stored.length !== chunks.length) return false;
   const storedByIndex = new Map(
     stored.map((chunk) => [chunk.chunkIndex, chunk])
@@ -69,7 +63,8 @@ function storedChunksMatchLiveChunks(
 
 export function registerIndexVaultTool(
   server: McpServer,
-  vaultPath: string
+  vaultPath: string,
+  store: EmbeddingStore
 ): void {
   defineTool(
     server,
@@ -123,8 +118,8 @@ export function registerIndexVaultTool(
           );
         }
 
-        await loadStore(vaultPath);
-        invalidateIfIncompatible(vaultPath, provider.id, provider.model);
+        await store.load();
+        store.invalidateIfIncompatible(provider.id, provider.model);
 
         const progressMeta: Parameters<typeof makeProgressReporter>[0] = {
           ...(extra._meta?.progressToken != null
@@ -177,8 +172,8 @@ export function registerIndexVaultTool(
           const chunks = chunkNote(content);
           if (
             !force &&
-            noteIsCurrent(vaultPath, notePath, contentHash) &&
-            storedChunksMatchLiveChunks(vaultPath, notePath, chunks)
+            store.noteIsCurrent(notePath, contentHash) &&
+            storedChunksMatchLiveChunks(store, notePath, chunks)
           ) {
             stats.notesUnchanged++;
             stats.notesScanned++;
@@ -279,8 +274,7 @@ export function registerIndexVaultTool(
             continue;
           }
           try {
-            setNoteChunks(
-              vaultPath,
+            store.setNoteChunks(
               notePath,
               contentHash,
               chunks,
@@ -300,15 +294,11 @@ export function registerIndexVaultTool(
         }
 
         if (!folder) {
-          stats.notesPruned = pruneMissingNotes(vaultPath, notes);
+          stats.notesPruned = store.pruneMissingNotes(notes);
         }
 
-        await saveStore(vaultPath);
+        await store.save();
 
-        // Conditional block-level _meta: richText attaches the
-        // "index_vault failed notes" trust tag only if a failed-path
-        // untrusted section is appended, so a clean run stays untagged
-        // (matching the prior untrustedVaultTextResult-vs-textResult split).
         return richText("index_vault failed notes", (b) => {
           b.trusted(
             `Indexed${folder ? ` "${escapeControlChars(folder)}"` : ""} via ${escapeControlChars(provider.id)}/${escapeControlChars(provider.model)}`

--- a/src/tools/semantic/search_semantic.ts
+++ b/src/tools/semantic/search_semantic.ts
@@ -4,18 +4,11 @@ import { resolveVaultPath, readNote } from "../../lib/vault.js";
 import { chunkNote } from "../../lib/chunker.js";
 import { getActiveProvider } from "../../lib/embedding-providers.js";
 import {
-  loadStore,
-  snapshotForTests,
-  searchEmbeddings,
-  invalidateIfIncompatible,
   validateEmbeddingVector,
-  dropNoteChunks,
-  getNoteEmbeddings,
-  saveStore,
   hashText,
-  noteIsCurrent,
+  type EmbeddingStore,
   type SearchHit,
-} from "../../lib/embedding-store.js";
+} from "../../lib/embedding-store-handle.js";
 import { defineTool, text, richText, error } from "../../lib/tool-seam.js";
 import {
   MISSING_PROVIDER_HINT,
@@ -32,6 +25,7 @@ interface FreshSearchOptions {
 }
 
 async function searchFreshEmbeddings(
+  store: EmbeddingStore,
   vaultPath: string,
   queryVector: number[],
   options: FreshSearchOptions
@@ -44,11 +38,10 @@ async function searchFreshEmbeddings(
   }
 
   function storedChunksMatchLiveChunks(
-    vaultPath: string,
     notePath: string,
     chunks: ReturnType<typeof chunkNote>
   ): boolean {
-    const stored = getNoteEmbeddings(vaultPath, notePath);
+    const stored = store.getNoteEmbeddings(notePath);
     if (stored.length !== chunks.length) return false;
     const storedByIndex = new Map(
       stored.map((chunk) => [chunk.chunkIndex, chunk])
@@ -63,29 +56,23 @@ async function searchFreshEmbeddings(
     return true;
   }
 
-  async function storedNoteIsCurrent(
-    vaultPath: string,
-    notePath: string
-  ): Promise<boolean> {
+  async function storedNoteIsCurrent(notePath: string): Promise<boolean> {
     try {
       const content = await readNote(vaultPath, notePath);
       const chunks = chunkNote(content);
       return (
-        noteIsCurrent(vaultPath, notePath, hashText(content)) &&
-        storedChunksMatchLiveChunks(vaultPath, notePath, chunks)
+        store.noteIsCurrent(notePath, hashText(content)) &&
+        storedChunksMatchLiveChunks(notePath, chunks)
       );
     } catch {
       return false;
     }
   }
 
-  async function pruneStaleStoredNote(
-    vaultPath: string,
-    notePath: string
-  ): Promise<boolean> {
-    const current = await storedNoteIsCurrent(vaultPath, notePath);
+  async function pruneStaleStoredNote(notePath: string): Promise<boolean> {
+    const current = await storedNoteIsCurrent(notePath);
     if (current) return false;
-    return dropNoteChunks(vaultPath, notePath);
+    return store.dropNoteChunks(notePath);
   }
 
   const hits: SearchHit[] = [];
@@ -97,7 +84,7 @@ async function searchFreshEmbeddings(
     for (const notePath of accepted) exclude.add(notePath);
     for (const notePath of stale) exclude.add(notePath);
     const batchLimit = Math.min(100, Math.max(options.limit - hits.length, 20));
-    const candidates = searchEmbeddings(vaultPath, queryVector, {
+    const candidates = store.search(queryVector, {
       limit: batchLimit,
       ...(options.folder ? { folder: options.folder } : {}),
       ...(exclude.size > 0 ? { excludeNotes: exclude } : {}),
@@ -107,7 +94,7 @@ async function searchFreshEmbeddings(
     let advanced = false;
     for (const hit of candidates) {
       if (accepted.has(hit.notePath)) continue;
-      if (await pruneStaleStoredNote(vaultPath, hit.notePath)) {
+      if (await pruneStaleStoredNote(hit.notePath)) {
         stale.add(hit.notePath);
         stalePruned++;
         advanced = true;
@@ -120,7 +107,7 @@ async function searchFreshEmbeddings(
     }
     if (!advanced) break;
   }
-  if (stalePruned > 0) await saveStore(vaultPath);
+  if (stalePruned > 0) await store.save();
   return { hits, stalePruned };
 }
 
@@ -138,7 +125,8 @@ function canReadStoredEmbeddingNote(
 
 export function registerSearchSemanticTool(
   server: McpServer,
-  vaultPath: string
+  vaultPath: string,
+  store: EmbeddingStore
 ): void {
   defineTool(
     server,
@@ -192,12 +180,12 @@ export function registerSearchSemanticTool(
           `Semantic search has no embedding provider configured. ${MISSING_PROVIDER_HINT}`
         );
       }
-      await loadStore(vaultPath);
-      invalidateIfIncompatible(vaultPath, provider.id, provider.model);
-      const snap = snapshotForTests(vaultPath);
-      if (snap.totalChunks === 0) {
+      await store.load();
+      store.invalidateIfIncompatible(provider.id, provider.model);
+      const stats = store.stats();
+      if (store.isEmpty()) {
         return error(
-          `Embedding index is empty${snap.providerId === null ? "" : " for the active provider/model"}. Run \`index_vault\` to build it before searching semantically.`
+          `Embedding index is empty${stats.providerId === null ? "" : " for the active provider/model"}. Run \`index_vault\` to build it before searching semantically.`
         );
       }
 
@@ -205,13 +193,13 @@ export function registerSearchSemanticTool(
       if (!Array.isArray(vector)) {
         return error("Provider did not return a vector for the query.");
       }
-      const vectorError = validateEmbeddingVector(vector, snap.dimension);
+      const vectorError = validateEmbeddingVector(vector, stats.dimension);
       if (vectorError !== null) {
         return error(
           `Provider returned an invalid query vector: ${vectorError}.`
         );
       }
-      const { hits } = await searchFreshEmbeddings(vaultPath, vector, {
+      const { hits } = await searchFreshEmbeddings(store, vaultPath, vector, {
         limit,
         ...(folder ? { folder } : {}),
         filterNote: (notePath) =>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,20 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /(?:^|\/)lib\/embedding-store\.js$/,
+        replacement: fileURLToPath(
+          new URL(
+            "./src/__tests__/embedding-store-legacy-adapter.ts",
+            import.meta.url
+          )
+        ),
+      },
+    ],
+  },
   test: {
     globals: true,
     maxWorkers: 1,


### PR DESCRIPTION
## Summary

Implements #255 as a hard cut rather than a facade.

- replace the module-global `stores` map / `stateFor(vaultPath)` with a nameable `EmbeddingStore` handle
- add synchronous `openEmbeddingStore(vaultPath)` construction plus explicit async `.load()`
- keep load-promise deduplication and save coalescing inside the handle
- make the persistence byte cap a per-handle option instead of module-global mutable state
- replace production `snapshotForTests` usage with public `stats()` / `isEmpty()`
- create one handle in `registerSemanticTools` and share it across `index_vault`, `search_semantic`, and `find_similar_notes`
- add explicit `McpServerServices` ownership so HTTP's per-session MCP servers share one embedding handle instead of diverging in memory
- guard against passing an embedding handle bound to the wrong vault
- convert every production stateful embedding-store operation to a method
- migrate the semantic quality benchmarks to the handle API
- add direct handle tests plus a cross-server regression test with embedding persistence disabled

## Regression-suite migration

The shipped library exposes no legacy stateful free functions and no vault-keyed registry. To keep the large historical regression matrix intact without a ~100-call-site mechanical rewrite, Vitest routes legacy test imports through a **test-only** adapter under `src/__tests__`. That adapter delegates to real `EmbeddingStore` handles; production semantic code imports the handle entrypoint directly and never sees the adapter.

For historical tests that synchronously inspected the old ambient store after an MCP tool call, the adapter mirrors stats from the tool's persisted snapshot when it does not own that handle. This preserves the assertion without reintroducing production global state.

## Behavior preserved

- snapshot path/format and provider/model invalidation semantics
- vector validation and dimensionality checks
- incremental note hashes and prune behavior
- cosine search/ranking/folder filtering
- atomic snapshot writes, oversize persistence skip, and save coalescing
- semantic stale-note pruning and tool response formatting
- HTTP clients serving the same vault continue to observe one live in-memory semantic index, including when disk cache persistence is disabled

## Design choices

- **Hard cut:** no production facade over the old globals.
- **Handle surface:** public `stats()` and `isEmpty()`; no production `snapshotForTests`.
- **Construction:** sync `openEmbeddingStore()` + explicit `.load()` so construction is side-effect free while concurrent loads still dedupe.
- **Ownership:** server services own the handle; HTTP session servers receive the same services object explicitly.

Closes #255