### PR TITLE
chore(release): prepare 4.1.0

### DIFF
--- a/docs/releases/4.1.0.md
+++ b/docs/releases/4.1.0.md
@@ -1,0 +1,74 @@
+# obsidian-mcp-pro 4.1.0
+
+Planned release date: 2026-09-03
+
+## Why 4.1.0
+
+This is the first package release after 4.0.1 (published 2026-06-21). It contains the architecture and tool-surface work merged since then, including new public server-service ownership APIs, so a minor version is more appropriate than a patch release.
+
+## Highlights
+
+### Attachments: correct non-image binary resource blocks
+
+`get_attachment` now has an explicit closed media vocabulary through the shared tool seam:
+
+- images -> MCP `image` blocks
+- audio -> MCP `audio` blocks
+- PDFs, DOCX, PPTX, XLSX and other non-image binaries -> base64 MCP `resource` blocks with `vault://` URIs
+- SVG -> untrusted `text/plain` resource content for XSS safety
+
+This is the release boundary needed to resolve `obsidian-mcp-pro-plugin#2`, where PDF/DOCX attachments were rejected after being surfaced as image content by the older published package.
+
+### One tool seam for all 41 tools
+
+All nine tool groups now register through `defineTool` and the branded `ToolResult` vocabulary. Error sanitization and untrusted-content wrapping are centralized instead of copied across handlers. Attachments extended the seam with `image`, `audio`, `blobResource`, and `untrustedResource` constructors.
+
+### Vault layer decomposition and read seam
+
+The former large vault module is decomposed into layered modules (`vault-fs`, `note-reads`, `note-ops`, `vault-search`, `vault-stats`, canvas/bases), with the compatibility barrel retaining the public API.
+
+Point reads remain direct and always-fresh. Vault-wide scans use the explicit mtime-cached batch path. Library `searchNotes` and the MCP `search_notes` tool now share the same cached implementation.
+
+### Embedding store has explicit ownership
+
+Semantic index state is now owned by a nameable `EmbeddingStore` handle rather than a module-global vault map. The public handle exposes `load`, `save`, `stats`, `isEmpty`, search, indexing, invalidation, and pruning operations.
+
+`buildMcpServer` now supports explicit `McpServerServices`, allowing HTTP session servers for the same vault to share one live semantic index handle without ambient global state.
+
+### Delete confirmation seam
+
+Permanent `delete_note` elicitation now uses the shared text-confirmation seam while retaining the independent `confirm: true` hard safety latch. Regression coverage is behavior-based rather than source-grep based.
+
+### Cache cleanup
+
+The note-content mtime cache remains in-memory only. Dead persistence/flush surface was removed, and cached batch reads are now discoverable through the vault-read seam.
+
+## Compatibility
+
+- Node.js: `>=24.0.0`
+- No intended breaking change to the 4.x MCP tool names or schemas in this release.
+- Unexpected thrown tool errors use the tool seam's generic `Error:` prefix, as documented in ADR 0001.
+- `get_backlinks` no longer includes the old decorative arrow before wrapped context blocks; trust metadata and content are unchanged.
+- New programmatic API: `createMcpServerServices(vaultPath)` and the handle-oriented embedding-store surface.
+
+## Publication checklist
+
+Before publishing from the release commit:
+
+1. Regenerate lockfile root metadata so it matches `4.1.0`:
+   `npm install --package-lock-only`
+2. Run the full prepublish gate:
+   `npm run verify`
+3. Optionally run the extended local gate:
+   `npm run verify:full`
+4. Inspect the package payload:
+   `npm pack --dry-run`
+5. Publish:
+   `npm publish`
+6. Verify the registry reports `obsidian-mcp-pro@4.1.0`.
+7. Create GitHub tag/release `v4.1.0` using these notes.
+8. Upgrade `obsidian-mcp-pro-plugin` to `^4.1.0`, regenerate its lockfile, adapt it to shared `McpServerServices`, and verify attachment behavior before closing plugin issue #2.
+
+## Release gate for plugin issue #2
+
+Do not close `obsidian-mcp-pro-plugin#2` merely because this branch is merged. Close it only after `4.1.0` is published and the plugin has been rebuilt against that published package with PDF/DOCX resource-block coverage.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-mcp-pro",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "The most feature-complete MCP server for Obsidian vaults — search, read, write, tag, link analysis, graph traversal, canvas support, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Prepare `obsidian-mcp-pro` 4.1.0 as the first package release after 4.0.1.

- bump `package.json` from `4.0.1` to `4.1.0`
- add `docs/releases/4.1.0.md` with the post-4.0.1 release boundary and publication checklist
- explicitly document the attachment media/resource fix needed by `obsidian-mcp-pro-plugin#2`
- document the completed tool seam, vault/read seam, embedding-store handle, delete confirmation seam, and explicit HTTP server-services ownership

## Why a minor release

Post-4.0.1 master contains new public programmatic APIs (`createMcpServerServices`, the handle-oriented embedding-store surface) in addition to bug fixes, so `4.1.0` is a better semantic-version boundary than `4.0.2`.

## Attachment issue

Current master routes images to `image`, audio to `audio`, and PDFs/DOCX/PPTX/XLSX/other non-image binaries to base64 `resource` blocks via the attachment tool seam. That work landed after published 4.0.1, so a new package publication is required before the plugin can consume the fix.

## Publication gate

This PR prepares the repository source but does **not** claim npm publication.

Before `npm publish`:
1. run `npm install --package-lock-only` so lockfile root version metadata becomes 4.1.0
2. run `npm run verify`
3. inspect `npm pack --dry-run`
4. publish `obsidian-mcp-pro@4.1.0`
5. verify the registry version
6. create GitHub release/tag `v4.1.0`
7. upgrade the plugin to `^4.1.0`, regenerate its lockfile, use shared `McpServerServices`, and verify PDF/DOCX resource blocks

`obsidian-mcp-pro-plugin#2` should remain open until that published-package/plugin verification is complete.

## Validation note

No GitHub Actions run is expected for this repository today; the normal `prepublishOnly` gate remains `npm run verify` and must be run in the publishing environment.