### PR TITLE
ci: add Node 24 PR quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Node 24 quality gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify package payload
+        run: npm run pack:check

--- a/src/__tests__/embedding-store-legacy-types.d.ts
+++ b/src/__tests__/embedding-store-legacy-types.d.ts
@@ -1,0 +1,67 @@
+import type {
+  ChunkEmbedding,
+  EmbeddingStore,
+  EmbeddingStoreStats,
+  SearchHit,
+  SearchOptions,
+} from "../lib/embedding-store.js";
+
+/**
+ * Typed half of the test-only embedding-store migration adapter.
+ *
+ * Vitest redirects legacy test imports of `lib/embedding-store.js` to
+ * `embedding-store-legacy-adapter.ts` at runtime. ESLint's typed TypeScript
+ * program does not consume Vite aliases, so without this augmentation those
+ * removed legacy exports become `error` types during linting. Keeping the
+ * declarations under `src/__tests__` makes the compatibility surface visible
+ * to test tooling without adding it back to the production declaration/API.
+ */
+declare module "../lib/embedding-store.js" {
+  export function loadStore(vaultPath: string): Promise<EmbeddingStore>;
+  export function saveStore(vaultPath: string): Promise<void>;
+  export function clearStore(
+    vaultPath: string,
+    options?: { removeSnapshot?: boolean }
+  ): Promise<void>;
+  export function invalidateIfIncompatible(
+    vaultPath: string,
+    providerId: string,
+    model: string
+  ): void;
+  export function noteIsCurrent(
+    vaultPath: string,
+    notePath: string,
+    contentHash: string
+  ): boolean;
+  export function setNoteChunks(
+    vaultPath: string,
+    notePath: string,
+    contentHash: string,
+    chunks: ChunkEmbedding[],
+    providerId: string,
+    model: string
+  ): void;
+  export function dropNoteChunks(
+    vaultPath: string,
+    notePath: string
+  ): boolean;
+  export function pruneMissingNotes(
+    vaultPath: string,
+    currentNotes: Iterable<string>
+  ): number;
+  export function snapshotForTests(
+    vaultPath: string
+  ): EmbeddingStoreStats;
+  export function searchEmbeddings(
+    vaultPath: string,
+    queryVector: number[],
+    options?: SearchOptions
+  ): SearchHit[];
+  export function getNoteEmbeddings(
+    vaultPath: string,
+    notePath: string
+  ): ChunkEmbedding[];
+  export function setMaxEmbeddingBytesForTests(
+    bytes: number | null
+  ): void;
+}

--- a/src/lib/vault-fs.ts
+++ b/src/lib/vault-fs.ts
@@ -341,14 +341,23 @@ export async function getRealVaultRoot(vaultPath: string): Promise<string> {
   try {
     return await fs.realpath(key);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-    // ENOENT: vault root doesn't exist (yet). Fall back to the resolved path
-    // so callers can proceed with creation workflows. Log so the misconfiguration
-    // is visible in server logs.
-    log.warn("Vault path does not exist, falling back to resolved path", {
-      vaultPath: key,
-    });
-    return key;
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      // Vault root doesn't exist (yet). Fall back to the resolved path so
+      // creation workflows can proceed; this path is intentionally logged as
+      // configuration context rather than surfaced in a client error.
+      log.warn("Vault path does not exist, falling back to resolved path", {
+        vaultPath: key,
+      });
+      return key;
+    }
+    if (code === "EACCES" || code === "EPERM") {
+      // `fs.realpath` includes the absolute target in its raw error message.
+      // Fail closed without attaching the original error as `cause`, because
+      // callers may surface causes and thereby leak the restricted ancestor.
+      throw new Error("Path traversal check failed");
+    }
+    throw err;
   }
 }
 

--- a/src/lib/vault-fs.ts
+++ b/src/lib/vault-fs.ts
@@ -355,6 +355,7 @@ export async function getRealVaultRoot(vaultPath: string): Promise<string> {
       // `fs.realpath` includes the absolute target in its raw error message.
       // Fail closed without attaching the original error as `cause`, because
       // callers may surface causes and thereby leak the restricted ancestor.
+      // eslint-disable-next-line preserve-caught-error -- Raw fs error contains an absolute vault path; deliberately omit it from the causal chain.
       throw new Error("Path traversal check failed");
     }
     throw err;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,21 +1,25 @@
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const legacyEmbeddingStoreAdapter = fileURLToPath(
+  new URL(
+    "./src/__tests__/embedding-store-legacy-adapter.ts",
+    import.meta.url
+  )
+);
+
 export default defineConfig({
-  resolve: {
+  test: {
     alias: [
       {
-        find: /(?:^|\/)lib\/embedding-store\.js$/,
-        replacement: fileURLToPath(
-          new URL(
-            "./src/__tests__/embedding-store-legacy-adapter.ts",
-            import.meta.url
-          )
-        ),
+        find: "../lib/embedding-store.js",
+        replacement: legacyEmbeddingStoreAdapter,
+      },
+      {
+        find: "../../lib/embedding-store.js",
+        replacement: legacyEmbeddingStoreAdapter,
       },
     ],
-  },
-  test: {
     globals: true,
     maxWorkers: 1,
     testTimeout: 30000,


### PR DESCRIPTION
## Summary

Add the repository's first automatic PR/push CI quality gate and fix the latent regressions the new gate exposed.

The deterministic Node 24 job runs:

- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run pack:check`

## CI design

- triggers on pull requests and pushes to `master`
- read-only repository permissions
- concurrency cancellation for superseded runs
- 20-minute job timeout
- npm dependency cache via `actions/setup-node`

`npm audit` deliberately remains in the release-time `npm run verify` gate rather than required PR CI so external advisory/database churn does not block unrelated code changes.

## Defects exposed and fixed by the first runs

### Legacy embedding-store test adapter

The embedding-store handle refactor had a Vitest alias that did not actually resolve the historical relative imports on Linux, so five regression suites failed to load. This PR:

- gives the legacy adapter a test-only TypeScript declaration augmentation so typed ESLint sees the same facade Vitest uses at runtime
- moves the alias to explicit `test.alias` entries for both `../lib/embedding-store.js` and `../../lib/embedding-store.js`

No legacy stateful API is restored to the production library.

### EACCES absolute-path leakage

`getRealVaultRoot()` rethrew the raw `fs.realpath` `EACCES`/`EPERM` error before the later redaction layer could run. On POSIX that exposed the restricted absolute vault ancestor in the error message. The path resolver now fails closed with a generic `Path traversal check failed` error for permission-denied root canonicalization. The caught filesystem error is intentionally omitted from the causal chain because it contains the sensitive path; the lint exception is scoped to that one security boundary.

## Validation

Final PR CI is green through the entire gate: lint, typecheck, tests, build, and package payload verification.