### PR TITLE
Add configurable destination hosts for HTTP embedders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- HTTP embedders can configure additional destination Host header values with `HttpServerOptions.allowedHosts`, preserving the bound-address and loopback defaults and DNS-rebinding protection.
+- HTTP embedders can configure additional destination Host header values with `HttpServerOptions.allowedHosts`, preserving the bound-address and loopback defaults and DNS-rebinding protection. Entries are trimmed and validated at startup (`"*"`, empty strings, schemes, and paths are rejected). `/mcp` Host denials return 403 with a warn log (host, method, path, ip — never the bearer). Matching is case-sensitive exact `Host` (IPv6 keeps brackets; no IDN normalization).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- HTTP embedders can configure additional destination Host header values with `HttpServerOptions.allowedHosts`, preserving the bound-address and loopback defaults and DNS-rebinding protection.
+
 ### Changed
 
 - Removed maintainer-only strategy, experiment notes, and draft outreach copy from the tracked documentation while keeping contributor workflow configuration under `docs/agents/`.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,36 @@ MCP_HTTP_TOKEN=your-secret npx -y obsidian-mcp-pro --transport=http
 The HTTP server binds to `127.0.0.1` by default with DNS rebinding protection enabled.
 Startup always requires `MCP_HTTP_TOKEN`, including loopback-only local servers. The old `--token` flag was removed because command-line secrets can be exposed through OS process listings.
 
+When embedding the library, set `allowedHosts` to accept additional destination
+addresses, such as the hostname forwarded by an HTTPS reverse proxy:
+
+```ts
+import { buildMcpServer, startHttpServer } from "obsidian-mcp-pro";
+
+const vaultPath = process.env.OBSIDIAN_VAULT_PATH!;
+const server = await startHttpServer({
+  host: "127.0.0.1",
+  port: 3333,
+  bearerToken: process.env.MCP_HTTP_TOKEN!,
+  allowedHosts: ["vault.example.com", "192.0.2.10:3333"],
+  buildMcpServer: () => buildMcpServer(vaultPath),
+  installSignalHandlers: false,
+});
+
+// On application shutdown:
+await server.stop();
+```
+
+- Entries match the HTTP `Host` header exactly, including a port when present.
+  Use `vault.example.com:443` if the proxy forwards that value instead of
+  `vault.example.com`. Do not include schemes, paths, or wildcards.
+- Configured entries extend the bound-address and loopback defaults. Omitting
+  `allowedHosts` or passing `[]` preserves the defaults.
+- The server copies the list at startup. Restart it to apply configuration changes.
+- This controls destination addresses, not client identity. Bearer authentication
+  and Origin validation still apply; DNS-rebinding protection remains enabled.
+- This is an embedding API option, not a CLI flag.
+
 > [!WARNING]
 > **Never bind `--host=0.0.0.0` directly to the public internet.** Doing so exposes your entire Obsidian vault to anyone who can reach the port. The server refuses HTTP startup without a bearer token, but if you need remote access:
 > - Put the server behind a reverse proxy (nginx, Caddy, Cloudflare Tunnel) that terminates TLS, **and**

--- a/README.md
+++ b/README.md
@@ -212,12 +212,18 @@ const server = await startHttpServer({
 await server.stop();
 ```
 
-- Entries match the HTTP `Host` header exactly, including a port when present.
-  Use `vault.example.com:443` if the proxy forwards that value instead of
-  `vault.example.com`. Do not include schemes, paths, or wildcards.
+- Entries match the HTTP `Host` header exactly and case-sensitively, including a
+  port when present. Use `vault.example.com:443` if the proxy forwards that
+  value instead of `vault.example.com`. IPv6 must keep brackets (`[::1]:port`).
+  There is no IDN / punycode normalization. Do not include schemes, paths, or
+  wildcards; `"*"` is rejected at startup (it is not a wildcard).
 - Configured entries extend the bound-address and loopback defaults. Omitting
   `allowedHosts` or passing `[]` preserves the defaults.
-- The server copies the list at startup. Restart it to apply configuration changes.
+- The server copies and validates the list at startup. Restart it to apply
+  configuration changes. Listen-time logs include the effective Host allowlist
+  (never the bearer token).
+- `/health` and `/version` skip Host validation (pre-existing). `/mcp` rejects a
+  disallowed Host with 403 and a warn log, including when the bearer is valid.
 - This controls destination addresses, not client identity. Bearer authentication
   and Origin validation still apply; DNS-rebinding protection remains enabled.
 - This is an embedding API option, not a CLI flag.

--- a/src/__tests__/regression-http-fixes.test.ts
+++ b/src/__tests__/regression-http-fixes.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import * as http from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { startHttpServer, type HttpServerHandle } from "../http-server.js";
+import { log } from "../lib/logger.js";
 
 const TEST_TOKEN = "test-http-token";
 const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
@@ -23,7 +24,7 @@ function buildNoopServer(): McpServer {
 }
 
 async function startOnEphemeral(
-  overrides: Partial<Parameters<typeof startHttpServer>[0]> = {},
+  overrides: Partial<Parameters<typeof startHttpServer>[0]> = {}
 ): Promise<HttpServerHandle> {
   return startHttpServer({
     host: "127.0.0.1",
@@ -41,14 +42,21 @@ afterEach(async () => {
   while (handles.length > 0) {
     const h = handles.pop();
     if (h) {
-      try { await h.stop(); } catch { /* ignore */ }
+      try {
+        await h.stop();
+      } catch {
+        /* ignore */
+      }
     }
   }
 });
 
 describe("regression: malformed Host is rejected before auth and routing", () => {
   it("returns 400 instead of leaving the response open", async () => {
-    const handle = await startOnEphemeral({ bearerToken: "secret", rateLimitPerMinute: 1 });
+    const handle = await startOnEphemeral({
+      bearerToken: "secret",
+      rateLimitPerMinute: 1,
+    });
     handles.push(handle);
 
     const res = await rawRequest(handle.port, {
@@ -80,7 +88,7 @@ function rawRequest(
     headers?: Record<string, string>;
     body?: string;
     timeoutMs?: number;
-  },
+  }
 ): Promise<RawResponse> {
   return new Promise((resolve, reject) => {
     const finish = (fn: () => void): void => {
@@ -106,13 +114,15 @@ function rawRequest(
         const chunks: Buffer[] = [];
         res.on("data", (c: Buffer) => chunks.push(c));
         res.on("end", () => {
-          finish(() => resolve({
-            status: res.statusCode ?? 0,
-            headers: res.headers,
-            body: Buffer.concat(chunks).toString("utf-8"),
-          }));
+          finish(() =>
+            resolve({
+              status: res.statusCode ?? 0,
+              headers: res.headers,
+              body: Buffer.concat(chunks).toString("utf-8"),
+            })
+          );
         });
-      },
+      }
     );
     const timeout = setTimeout(() => {
       req.destroy(new Error("raw request timed out"));
@@ -132,7 +142,7 @@ function rawOpenBodyRequest(
     headers?: Record<string, string>;
     initialBody?: string | Buffer;
     timeoutMs?: number;
-  },
+  }
 ): Promise<RawResponse> {
   return new Promise((resolve, reject) => {
     let settled = false;
@@ -159,13 +169,15 @@ function rawOpenBodyRequest(
         const chunks: Buffer[] = [];
         res.on("data", (c: Buffer) => chunks.push(c));
         res.on("end", () => {
-          finish(() => resolve({
-            status: res.statusCode ?? 0,
-            headers: res.headers,
-            body: Buffer.concat(chunks).toString("utf-8"),
-          }));
+          finish(() =>
+            resolve({
+              status: res.statusCode ?? 0,
+              headers: res.headers,
+              body: Buffer.concat(chunks).toString("utf-8"),
+            })
+          );
         });
-      },
+      }
     );
     const timeout = setTimeout(() => {
       finish(() => reject(new Error("raw open-body request timed out")));
@@ -214,7 +226,11 @@ describe("HTTP server — configurable allowedHosts", () => {
       `[::1]:${handle.port}`,
     ]) {
       const res = await rawRequest(handle.port, {
-        method: "POST", path: "/mcp", host, headers, body,
+        method: "POST",
+        path: "/mcp",
+        host,
+        headers,
+        body,
       });
       expect(res.status, host).toBe(200);
       expect(res.headers["mcp-session-id"], host).toEqual(expect.any(String));
@@ -222,23 +238,38 @@ describe("HTTP server — configurable allowedHosts", () => {
   });
 
   it("requires an exact configured Host and valid credentials", async () => {
-    const handle = await startOnEphemeral({ allowedHosts: ["vault.example.com:443"] });
+    const handle = await startOnEphemeral({
+      allowedHosts: ["vault.example.com:443"],
+    });
     handles.push(handle);
 
     const wrongPort = await rawRequest(handle.port, {
-      method: "POST", path: "/mcp", host: "vault.example.com:444", headers, body,
+      method: "POST",
+      path: "/mcp",
+      host: "vault.example.com:444",
+      headers,
+      body,
     });
     expect(wrongPort.status).toBe(403);
 
     const wrongToken = await rawRequest(handle.port, {
-      method: "POST", path: "/mcp", host: "vault.example.com:443",
-      headers: { ...headers, Authorization: "Bearer wrong-token" }, body,
+      method: "POST",
+      path: "/mcp",
+      host: "vault.example.com:443",
+      headers: { ...headers, Authorization: "Bearer wrong-token" },
+      body,
     });
     expect(wrongToken.status).toBe(401);
 
     const missingToken = await rawRequest(handle.port, {
-      method: "POST", path: "/mcp", host: "vault.example.com:443",
-      headers: { "Content-Type": headers["Content-Type"], Accept: headers.Accept }, body,
+      method: "POST",
+      path: "/mcp",
+      host: "vault.example.com:443",
+      headers: {
+        "Content-Type": headers["Content-Type"],
+        Accept: headers.Accept,
+      },
+      body,
     });
     expect(missingToken.status).toBe(401);
   });
@@ -248,17 +279,26 @@ describe("HTTP server — configurable allowedHosts", () => {
     const handle = await startOnEphemeral({ allowedHosts });
     handles.push(handle);
     const initialized = await rawRequest(handle.port, {
-      method: "POST", path: "/mcp", host: "vault.example.com", headers, body,
+      method: "POST",
+      path: "/mcp",
+      host: "vault.example.com",
+      headers,
+      body,
     });
     expect(initialized.status).toBe(200);
     const sessionId = initialized.headers["mcp-session-id"];
     expect(sessionId).toEqual(expect.any(String));
-    const sessionHeaders = { ...headers, "Mcp-Session-Id": sessionId as string };
+    const sessionHeaders = {
+      ...headers,
+      "Mcp-Session-Id": sessionId as string,
+    };
 
     allowedHosts.push("attacker.example.com");
     for (const method of ["POST", "GET", "DELETE"]) {
       const rejected = await rawRequest(handle.port, {
-        method, path: "/mcp", host: "attacker.example.com",
+        method,
+        path: "/mcp",
+        host: "attacker.example.com",
         headers: sessionHeaders,
         ...(method === "POST" ? { body } : {}),
       });
@@ -266,9 +306,78 @@ describe("HTTP server — configurable allowedHosts", () => {
     }
 
     const closed = await rawRequest(handle.port, {
-      method: "DELETE", path: "/mcp", host: "vault.example.com", headers: sessionHeaders,
+      method: "DELETE",
+      path: "/mcp",
+      host: "vault.example.com",
+      headers: sessionHeaders,
     });
     expect(closed.status).toBe(200);
+  });
+
+  it("rejects a disallowed Host with a valid token and logs a warn", async () => {
+    const handle = await startOnEphemeral({
+      allowedHosts: ["vault.example.com"],
+    });
+    handles.push(handle);
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+    try {
+      const res = await rawRequest(handle.port, {
+        method: "POST",
+        path: "/mcp",
+        host: "attacker.example.com",
+        headers,
+        body,
+      });
+      expect(res.status).toBe(403);
+      expect(res.body).toContain("Host not allowed");
+      const logged = warnSpy.mock.calls.find(
+        (c) => c[0] === "Rejected request from disallowed Host"
+      );
+      expect(logged).toBeDefined();
+      expect(logged?.[1]).toMatchObject({
+        host: "attacker.example.com",
+        method: "POST",
+        path: "/mcp",
+      });
+      expect(JSON.stringify(logged?.[1])).not.toContain(TEST_TOKEN);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("trims configured hosts and refuses empty strings, URLs, paths, and *", async () => {
+    const handle = await startOnEphemeral({
+      allowedHosts: [" vault.example.com "],
+    });
+    handles.push(handle);
+    const trimmed = await rawRequest(handle.port, {
+      method: "POST",
+      path: "/mcp",
+      host: "vault.example.com",
+      headers,
+      body,
+    });
+    expect(trimmed.status).toBe(200);
+
+    const invalid = [
+      ["*"],
+      ["https://vault.example.com"],
+      ["vault.example.com/mcp"],
+      [" "],
+    ];
+    for (const allowedHosts of invalid) {
+      await expect(startOnEphemeral({ allowedHosts })).rejects.toThrow(
+        /allowedHosts/
+      );
+    }
+  });
+
+  it("does not treat * as a wildcard even if it reached the matcher", async () => {
+    // Startup rejects "*". This test pins the fail-closed outcome: a server
+    // that somehow listed "*" as a Host value would still 403 attacker hosts.
+    await expect(startOnEphemeral({ allowedHosts: ["*"] })).rejects.toThrow(
+      /\*/
+    );
   });
 });
 
@@ -420,7 +529,12 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
         ...AUTH_HEADERS,
         "Content-Type": "text/plain; profile=application/json",
       },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {},
+      }),
     });
 
     expect(res.status).toBe(415);
@@ -431,8 +545,16 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
     handles.push(handle);
     const res = await fetch(handle.url, {
       method: "POST",
-      headers: { "Content-Type": "application/json; charset=utf-8", ...AUTH_HEADERS },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        ...AUTH_HEADERS,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {},
+      }),
     });
     // Whatever the MCP layer does next, it must NOT be a Content-Type 415.
     expect(res.status).not.toBe(415);
@@ -441,7 +563,10 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
 
 describe("regression: M2 — /version gates non-GET methods when bearerToken is set", () => {
   it("POST /version with no auth returns 401 when bearerToken is set", async () => {
-    const handle = await startOnEphemeral({ bearerToken: "secret", version: "1.2.3" });
+    const handle = await startOnEphemeral({
+      bearerToken: "secret",
+      version: "1.2.3",
+    });
     handles.push(handle);
 
     const res = await fetch(`http://127.0.0.1:${handle.port}/version`, {
@@ -454,17 +579,22 @@ describe("regression: M2 — /version gates non-GET methods when bearerToken is 
   });
 
   it("refuses to start without bearer auth instead of exposing tokenless /version writes", async () => {
-    await expect(startHttpServer({
-      host: "127.0.0.1",
-      port: 0,
-      version: "9.9.9",
-      buildMcpServer: buildNoopServer,
-      installSignalHandlers: false,
-    } as Parameters<typeof startHttpServer>[0])).rejects.toThrow(/bearer token is required/i);
+    await expect(
+      startHttpServer({
+        host: "127.0.0.1",
+        port: 0,
+        version: "9.9.9",
+        buildMcpServer: buildNoopServer,
+        installSignalHandlers: false,
+      } as Parameters<typeof startHttpServer>[0])
+    ).rejects.toThrow(/bearer token is required/i);
   });
 
   it("POST /version with the correct bearer token returns 200", async () => {
-    const handle = await startOnEphemeral({ bearerToken: "secret", version: "1.2.3" });
+    const handle = await startOnEphemeral({
+      bearerToken: "secret",
+      version: "1.2.3",
+    });
     handles.push(handle);
 
     const res = await fetch(`http://127.0.0.1:${handle.port}/version`, {
@@ -479,7 +609,10 @@ describe("regression: M2 — /version gates non-GET methods when bearerToken is 
   });
 
   it("GET /version stays unauthenticated even when bearerToken is set (existing public-monitoring behavior)", async () => {
-    const handle = await startOnEphemeral({ bearerToken: "secret", version: "1.2.3" });
+    const handle = await startOnEphemeral({
+      bearerToken: "secret",
+      version: "1.2.3",
+    });
     handles.push(handle);
 
     const res = await fetch(`http://127.0.0.1:${handle.port}/version`);
@@ -567,7 +700,9 @@ describe("regression: HTTP Origin validation rejects browser DNS-rebinding attem
   });
 
   it("rejects preflight requests from an Origin outside the allowlist", async () => {
-    const handle = await startOnEphemeral({ allowedOrigins: ["https://app.example"] });
+    const handle = await startOnEphemeral({
+      allowedOrigins: ["https://app.example"],
+    });
     handles.push(handle);
 
     const res = await rawRequest(handle.port, {
@@ -598,17 +733,21 @@ describe("regression: HTTP Origin validation rejects browser DNS-rebinding attem
 
 describe("regression: HTTP bearer token must not be empty", () => {
   it("rejects whitespace-only programmatic tokens", async () => {
-    await expect(startOnEphemeral({ bearerToken: "   " })).rejects.toThrow(/token.*empty/i);
+    await expect(startOnEphemeral({ bearerToken: "   " })).rejects.toThrow(
+      /token.*empty/i
+    );
   });
 
   it("rejects wildcard CORS without bearer auth", async () => {
-    await expect(startHttpServer({
-      host: "127.0.0.1",
-      port: 0,
-      allowedOrigins: ["*"],
-      buildMcpServer: buildNoopServer,
-      installSignalHandlers: false,
-    } as Parameters<typeof startHttpServer>[0])).rejects.toThrow(/bearer token is required/i);
+    await expect(
+      startHttpServer({
+        host: "127.0.0.1",
+        port: 0,
+        allowedOrigins: ["*"],
+        buildMcpServer: buildNoopServer,
+        installSignalHandlers: false,
+      } as Parameters<typeof startHttpServer>[0])
+    ).rejects.toThrow(/bearer token is required/i);
   });
 
   it("allows wildcard CORS when bearer auth is configured", async () => {

--- a/src/__tests__/regression-http-fixes.test.ts
+++ b/src/__tests__/regression-http-fixes.test.ts
@@ -23,7 +23,7 @@ function buildNoopServer(): McpServer {
 }
 
 async function startOnEphemeral(
-  overrides: Partial<Parameters<typeof startHttpServer>[0]> = {}
+  overrides: Partial<Parameters<typeof startHttpServer>[0]> = {},
 ): Promise<HttpServerHandle> {
   return startHttpServer({
     host: "127.0.0.1",
@@ -41,21 +41,14 @@ afterEach(async () => {
   while (handles.length > 0) {
     const h = handles.pop();
     if (h) {
-      try {
-        await h.stop();
-      } catch {
-        /* ignore */
-      }
+      try { await h.stop(); } catch { /* ignore */ }
     }
   }
 });
 
 describe("regression: malformed Host is rejected before auth and routing", () => {
   it("returns 400 instead of leaving the response open", async () => {
-    const handle = await startOnEphemeral({
-      bearerToken: "secret",
-      rateLimitPerMinute: 1,
-    });
+    const handle = await startOnEphemeral({ bearerToken: "secret", rateLimitPerMinute: 1 });
     handles.push(handle);
 
     const res = await rawRequest(handle.port, {
@@ -87,7 +80,7 @@ function rawRequest(
     headers?: Record<string, string>;
     body?: string;
     timeoutMs?: number;
-  }
+  },
 ): Promise<RawResponse> {
   return new Promise((resolve, reject) => {
     const finish = (fn: () => void): void => {
@@ -113,15 +106,13 @@ function rawRequest(
         const chunks: Buffer[] = [];
         res.on("data", (c: Buffer) => chunks.push(c));
         res.on("end", () => {
-          finish(() =>
-            resolve({
-              status: res.statusCode ?? 0,
-              headers: res.headers,
-              body: Buffer.concat(chunks).toString("utf-8"),
-            })
-          );
+          finish(() => resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString("utf-8"),
+          }));
         });
-      }
+      },
     );
     const timeout = setTimeout(() => {
       req.destroy(new Error("raw request timed out"));
@@ -141,7 +132,7 @@ function rawOpenBodyRequest(
     headers?: Record<string, string>;
     initialBody?: string | Buffer;
     timeoutMs?: number;
-  }
+  },
 ): Promise<RawResponse> {
   return new Promise((resolve, reject) => {
     let settled = false;
@@ -168,15 +159,13 @@ function rawOpenBodyRequest(
         const chunks: Buffer[] = [];
         res.on("data", (c: Buffer) => chunks.push(c));
         res.on("end", () => {
-          finish(() =>
-            resolve({
-              status: res.statusCode ?? 0,
-              headers: res.headers,
-              body: Buffer.concat(chunks).toString("utf-8"),
-            })
-          );
+          finish(() => resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString("utf-8"),
+          }));
         });
-      }
+      },
     );
     const timeout = setTimeout(() => {
       finish(() => reject(new Error("raw open-body request timed out")));
@@ -225,11 +214,7 @@ describe("HTTP server — configurable allowedHosts", () => {
       `[::1]:${handle.port}`,
     ]) {
       const res = await rawRequest(handle.port, {
-        method: "POST",
-        path: "/mcp",
-        host,
-        headers,
-        body,
+        method: "POST", path: "/mcp", host, headers, body,
       });
       expect(res.status, host).toBe(200);
       expect(res.headers["mcp-session-id"], host).toEqual(expect.any(String));
@@ -237,38 +222,23 @@ describe("HTTP server — configurable allowedHosts", () => {
   });
 
   it("requires an exact configured Host and valid credentials", async () => {
-    const handle = await startOnEphemeral({
-      allowedHosts: ["vault.example.com:443"],
-    });
+    const handle = await startOnEphemeral({ allowedHosts: ["vault.example.com:443"] });
     handles.push(handle);
 
     const wrongPort = await rawRequest(handle.port, {
-      method: "POST",
-      path: "/mcp",
-      host: "vault.example.com:444",
-      headers,
-      body,
+      method: "POST", path: "/mcp", host: "vault.example.com:444", headers, body,
     });
     expect(wrongPort.status).toBe(403);
 
     const wrongToken = await rawRequest(handle.port, {
-      method: "POST",
-      path: "/mcp",
-      host: "vault.example.com:443",
-      headers: { ...headers, Authorization: "Bearer wrong-token" },
-      body,
+      method: "POST", path: "/mcp", host: "vault.example.com:443",
+      headers: { ...headers, Authorization: "Bearer wrong-token" }, body,
     });
     expect(wrongToken.status).toBe(401);
 
     const missingToken = await rawRequest(handle.port, {
-      method: "POST",
-      path: "/mcp",
-      host: "vault.example.com:443",
-      headers: {
-        "Content-Type": headers["Content-Type"],
-        Accept: headers.Accept,
-      },
-      body,
+      method: "POST", path: "/mcp", host: "vault.example.com:443",
+      headers: { "Content-Type": headers["Content-Type"], Accept: headers.Accept }, body,
     });
     expect(missingToken.status).toBe(401);
   });
@@ -278,26 +248,17 @@ describe("HTTP server — configurable allowedHosts", () => {
     const handle = await startOnEphemeral({ allowedHosts });
     handles.push(handle);
     const initialized = await rawRequest(handle.port, {
-      method: "POST",
-      path: "/mcp",
-      host: "vault.example.com",
-      headers,
-      body,
+      method: "POST", path: "/mcp", host: "vault.example.com", headers, body,
     });
     expect(initialized.status).toBe(200);
     const sessionId = initialized.headers["mcp-session-id"];
     expect(sessionId).toEqual(expect.any(String));
-    const sessionHeaders = {
-      ...headers,
-      "Mcp-Session-Id": sessionId as string,
-    };
+    const sessionHeaders = { ...headers, "Mcp-Session-Id": sessionId as string };
 
     allowedHosts.push("attacker.example.com");
     for (const method of ["POST", "GET", "DELETE"]) {
       const rejected = await rawRequest(handle.port, {
-        method,
-        path: "/mcp",
-        host: "attacker.example.com",
+        method, path: "/mcp", host: "attacker.example.com",
         headers: sessionHeaders,
         ...(method === "POST" ? { body } : {}),
       });
@@ -305,10 +266,7 @@ describe("HTTP server — configurable allowedHosts", () => {
     }
 
     const closed = await rawRequest(handle.port, {
-      method: "DELETE",
-      path: "/mcp",
-      host: "vault.example.com",
-      headers: sessionHeaders,
+      method: "DELETE", path: "/mcp", host: "vault.example.com", headers: sessionHeaders,
     });
     expect(closed.status).toBe(200);
   });
@@ -462,12 +420,7 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
         ...AUTH_HEADERS,
         "Content-Type": "text/plain; profile=application/json",
       },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "initialize",
-        params: {},
-      }),
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
     });
 
     expect(res.status).toBe(415);
@@ -478,16 +431,8 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
     handles.push(handle);
     const res = await fetch(handle.url, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        ...AUTH_HEADERS,
-      },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "initialize",
-        params: {},
-      }),
+      headers: { "Content-Type": "application/json; charset=utf-8", ...AUTH_HEADERS },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
     });
     // Whatever the MCP layer does next, it must NOT be a Content-Type 415.
     expect(res.status).not.toBe(415);
@@ -496,10 +441,7 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
 
 describe("regression: M2 — /version gates non-GET methods when bearerToken is set", () => {
   it("POST /version with no auth returns 401 when bearerToken is set", async () => {
-    const handle = await startOnEphemeral({
-      bearerToken: "secret",
-      version: "1.2.3",
-    });
+    const handle = await startOnEphemeral({ bearerToken: "secret", version: "1.2.3" });
     handles.push(handle);
 
     const res = await fetch(`http://127.0.0.1:${handle.port}/version`, {
@@ -512,22 +454,17 @@ describe("regression: M2 — /version gates non-GET methods when bearerToken is 
   });
 
   it("refuses to start without bearer auth instead of exposing tokenless /version writes", async () => {
-    await expect(
-      startHttpServer({
-        host: "127.0.0.1",
-        port: 0,
-        version: "9.9.9",
-        buildMcpServer: buildNoopServer,
-        installSignalHandlers: false,
-      } as Parameters<typeof startHttpServer>[0])
-    ).rejects.toThrow(/bearer token is required/i);
+    await expect(startHttpServer({
+      host: "127.0.0.1",
+      port: 0,
+      version: "9.9.9",
+      buildMcpServer: buildNoopServer,
+      installSignalHandlers: false,
+    } as Parameters<typeof startHttpServer>[0])).rejects.toThrow(/bearer token is required/i);
   });
 
   it("POST /version with the correct bearer token returns 200", async () => {
-    const handle = await startOnEphemeral({
-      bearerToken: "secret",
-      version: "1.2.3",
-    });
+    const handle = await startOnEphemeral({ bearerToken: "secret", version: "1.2.3" });
     handles.push(handle);
 
     const res = await fetch(`http://127.0.0.1:${handle.port}/version`, {
@@ -542,10 +479,7 @@ describe("regression: M2 — /version gates non-GET methods when bearerToken is 
   });
 
   it("GET /version stays unauthenticated even when bearerToken is set (existing public-monitoring behavior)", async () => {
-    const handle = await startOnEphemeral({
-      bearerToken: "secret",
-      version: "1.2.3",
-    });
+    const handle = await startOnEphemeral({ bearerToken: "secret", version: "1.2.3" });
     handles.push(handle);
 
     const res = await fetch(`http://127.0.0.1:${handle.port}/version`);
@@ -633,9 +567,7 @@ describe("regression: HTTP Origin validation rejects browser DNS-rebinding attem
   });
 
   it("rejects preflight requests from an Origin outside the allowlist", async () => {
-    const handle = await startOnEphemeral({
-      allowedOrigins: ["https://app.example"],
-    });
+    const handle = await startOnEphemeral({ allowedOrigins: ["https://app.example"] });
     handles.push(handle);
 
     const res = await rawRequest(handle.port, {
@@ -666,21 +598,17 @@ describe("regression: HTTP Origin validation rejects browser DNS-rebinding attem
 
 describe("regression: HTTP bearer token must not be empty", () => {
   it("rejects whitespace-only programmatic tokens", async () => {
-    await expect(startOnEphemeral({ bearerToken: "   " })).rejects.toThrow(
-      /token.*empty/i
-    );
+    await expect(startOnEphemeral({ bearerToken: "   " })).rejects.toThrow(/token.*empty/i);
   });
 
   it("rejects wildcard CORS without bearer auth", async () => {
-    await expect(
-      startHttpServer({
-        host: "127.0.0.1",
-        port: 0,
-        allowedOrigins: ["*"],
-        buildMcpServer: buildNoopServer,
-        installSignalHandlers: false,
-      } as Parameters<typeof startHttpServer>[0])
-    ).rejects.toThrow(/bearer token is required/i);
+    await expect(startHttpServer({
+      host: "127.0.0.1",
+      port: 0,
+      allowedOrigins: ["*"],
+      buildMcpServer: buildNoopServer,
+      installSignalHandlers: false,
+    } as Parameters<typeof startHttpServer>[0])).rejects.toThrow(/bearer token is required/i);
   });
 
   it("allows wildcard CORS when bearer auth is configured", async () => {

--- a/src/__tests__/regression-http-fixes.test.ts
+++ b/src/__tests__/regression-http-fixes.test.ts
@@ -23,7 +23,7 @@ function buildNoopServer(): McpServer {
 }
 
 async function startOnEphemeral(
-  overrides: Partial<Parameters<typeof startHttpServer>[0]> = {},
+  overrides: Partial<Parameters<typeof startHttpServer>[0]> = {}
 ): Promise<HttpServerHandle> {
   return startHttpServer({
     host: "127.0.0.1",
@@ -41,14 +41,21 @@ afterEach(async () => {
   while (handles.length > 0) {
     const h = handles.pop();
     if (h) {
-      try { await h.stop(); } catch { /* ignore */ }
+      try {
+        await h.stop();
+      } catch {
+        /* ignore */
+      }
     }
   }
 });
 
 describe("regression: malformed Host is rejected before auth and routing", () => {
   it("returns 400 instead of leaving the response open", async () => {
-    const handle = await startOnEphemeral({ bearerToken: "secret", rateLimitPerMinute: 1 });
+    const handle = await startOnEphemeral({
+      bearerToken: "secret",
+      rateLimitPerMinute: 1,
+    });
     handles.push(handle);
 
     const res = await rawRequest(handle.port, {
@@ -80,7 +87,7 @@ function rawRequest(
     headers?: Record<string, string>;
     body?: string;
     timeoutMs?: number;
-  },
+  }
 ): Promise<RawResponse> {
   return new Promise((resolve, reject) => {
     const finish = (fn: () => void): void => {
@@ -106,13 +113,15 @@ function rawRequest(
         const chunks: Buffer[] = [];
         res.on("data", (c: Buffer) => chunks.push(c));
         res.on("end", () => {
-          finish(() => resolve({
-            status: res.statusCode ?? 0,
-            headers: res.headers,
-            body: Buffer.concat(chunks).toString("utf-8"),
-          }));
+          finish(() =>
+            resolve({
+              status: res.statusCode ?? 0,
+              headers: res.headers,
+              body: Buffer.concat(chunks).toString("utf-8"),
+            })
+          );
         });
-      },
+      }
     );
     const timeout = setTimeout(() => {
       req.destroy(new Error("raw request timed out"));
@@ -132,7 +141,7 @@ function rawOpenBodyRequest(
     headers?: Record<string, string>;
     initialBody?: string | Buffer;
     timeoutMs?: number;
-  },
+  }
 ): Promise<RawResponse> {
   return new Promise((resolve, reject) => {
     let settled = false;
@@ -159,13 +168,15 @@ function rawOpenBodyRequest(
         const chunks: Buffer[] = [];
         res.on("data", (c: Buffer) => chunks.push(c));
         res.on("end", () => {
-          finish(() => resolve({
-            status: res.statusCode ?? 0,
-            headers: res.headers,
-            body: Buffer.concat(chunks).toString("utf-8"),
-          }));
+          finish(() =>
+            resolve({
+              status: res.statusCode ?? 0,
+              headers: res.headers,
+              body: Buffer.concat(chunks).toString("utf-8"),
+            })
+          );
         });
-      },
+      }
     );
     const timeout = setTimeout(() => {
       finish(() => reject(new Error("raw open-body request timed out")));
@@ -181,6 +192,127 @@ function rawOpenBodyRequest(
     if (options.initialBody !== undefined) req.write(options.initialBody);
   });
 }
+
+describe("HTTP server — configurable allowedHosts", () => {
+  const headers = {
+    ...AUTH_HEADERS,
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "allowed-hosts-test", version: "0.0.0" },
+    },
+  });
+
+  it("accepts configured destination hosts without replacing loopback defaults", async () => {
+    const handle = await startOnEphemeral({
+      host: "0.0.0.0",
+      allowedHosts: ["vault.example.com", "192.0.2.10:3333"],
+    });
+    handles.push(handle);
+
+    for (const host of [
+      "vault.example.com",
+      "192.0.2.10:3333",
+      `127.0.0.1:${handle.port}`,
+      `localhost:${handle.port}`,
+      `[::1]:${handle.port}`,
+    ]) {
+      const res = await rawRequest(handle.port, {
+        method: "POST",
+        path: "/mcp",
+        host,
+        headers,
+        body,
+      });
+      expect(res.status, host).toBe(200);
+      expect(res.headers["mcp-session-id"], host).toEqual(expect.any(String));
+    }
+  });
+
+  it("requires an exact configured Host and valid credentials", async () => {
+    const handle = await startOnEphemeral({
+      allowedHosts: ["vault.example.com:443"],
+    });
+    handles.push(handle);
+
+    const wrongPort = await rawRequest(handle.port, {
+      method: "POST",
+      path: "/mcp",
+      host: "vault.example.com:444",
+      headers,
+      body,
+    });
+    expect(wrongPort.status).toBe(403);
+
+    const wrongToken = await rawRequest(handle.port, {
+      method: "POST",
+      path: "/mcp",
+      host: "vault.example.com:443",
+      headers: { ...headers, Authorization: "Bearer wrong-token" },
+      body,
+    });
+    expect(wrongToken.status).toBe(401);
+
+    const missingToken = await rawRequest(handle.port, {
+      method: "POST",
+      path: "/mcp",
+      host: "vault.example.com:443",
+      headers: {
+        "Content-Type": headers["Content-Type"],
+        Accept: headers.Accept,
+      },
+      body,
+    });
+    expect(missingToken.status).toBe(401);
+  });
+
+  it("checks Host on existing sessions and does not retain the caller's mutable list", async () => {
+    const allowedHosts = ["vault.example.com"];
+    const handle = await startOnEphemeral({ allowedHosts });
+    handles.push(handle);
+    const initialized = await rawRequest(handle.port, {
+      method: "POST",
+      path: "/mcp",
+      host: "vault.example.com",
+      headers,
+      body,
+    });
+    expect(initialized.status).toBe(200);
+    const sessionId = initialized.headers["mcp-session-id"];
+    expect(sessionId).toEqual(expect.any(String));
+    const sessionHeaders = {
+      ...headers,
+      "Mcp-Session-Id": sessionId as string,
+    };
+
+    allowedHosts.push("attacker.example.com");
+    for (const method of ["POST", "GET", "DELETE"]) {
+      const rejected = await rawRequest(handle.port, {
+        method,
+        path: "/mcp",
+        host: "attacker.example.com",
+        headers: sessionHeaders,
+        ...(method === "POST" ? { body } : {}),
+      });
+      expect(rejected.status, method).toBe(403);
+    }
+
+    const closed = await rawRequest(handle.port, {
+      method: "DELETE",
+      path: "/mcp",
+      host: "vault.example.com",
+      headers: sessionHeaders,
+    });
+    expect(closed.status).toBe(200);
+  });
+});
 
 describe("regression: C1 — DNS rebinding protection actually rejects bad Host", () => {
   it("rejects a POST to /mcp whose Host header is not in the allowedHosts list", async () => {
@@ -330,7 +462,12 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
         ...AUTH_HEADERS,
         "Content-Type": "text/plain; profile=application/json",
       },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {},
+      }),
     });
 
     expect(res.status).toBe(415);
@@ -341,8 +478,16 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
     handles.push(handle);
     const res = await fetch(handle.url, {
       method: "POST",
-      headers: { "Content-Type": "application/json; charset=utf-8", ...AUTH_HEADERS },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        ...AUTH_HEADERS,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {},
+      }),
     });
     // Whatever the MCP layer does next, it must NOT be a Content-Type 415.
     expect(res.status).not.toBe(415);
@@ -351,7 +496,10 @@ describe("regression: M1 — POST with non-JSON Content-Type returns 415", () =>
 
 describe("regression: M2 — /version gates non-GET methods when bearerToken is set", () => {
   it("POST /version with no auth returns 401 when bearerToken is set", async () => {
-    const handle = await startOnEphemeral({ bearerToken: "secret", version: "1.2.3" });
+    const handle = await startOnEphemeral({
+      bearerToken: "secret",
+      version: "1.2.3",
+    });
     handles.push(handle);
 
     const res = await fetch(`http://127.0.0.1:${handle.port}/version`, {
@@ -364,17 +512,22 @@ describe("regression: M2 — /version gates non-GET methods when bearerToken is 
   });
 
   it("refuses to start without bearer auth instead of exposing tokenless /version writes", async () => {
-    await expect(startHttpServer({
-      host: "127.0.0.1",
-      port: 0,
-      version: "9.9.9",
-      buildMcpServer: buildNoopServer,
-      installSignalHandlers: false,
-    } as Parameters<typeof startHttpServer>[0])).rejects.toThrow(/bearer token is required/i);
+    await expect(
+      startHttpServer({
+        host: "127.0.0.1",
+        port: 0,
+        version: "9.9.9",
+        buildMcpServer: buildNoopServer,
+        installSignalHandlers: false,
+      } as Parameters<typeof startHttpServer>[0])
+    ).rejects.toThrow(/bearer token is required/i);
   });
 
   it("POST /version with the correct bearer token returns 200", async () => {
-    const handle = await startOnEphemeral({ bearerToken: "secret", version: "1.2.3" });
+    const handle = await startOnEphemeral({
+      bearerToken: "secret",
+      version: "1.2.3",
+    });
     handles.push(handle);
 
     const res = await fetch(`http://127.0.0.1:${handle.port}/version`, {
@@ -389,7 +542,10 @@ describe("regression: M2 — /version gates non-GET methods when bearerToken is 
   });
 
   it("GET /version stays unauthenticated even when bearerToken is set (existing public-monitoring behavior)", async () => {
-    const handle = await startOnEphemeral({ bearerToken: "secret", version: "1.2.3" });
+    const handle = await startOnEphemeral({
+      bearerToken: "secret",
+      version: "1.2.3",
+    });
     handles.push(handle);
 
     const res = await fetch(`http://127.0.0.1:${handle.port}/version`);
@@ -477,7 +633,9 @@ describe("regression: HTTP Origin validation rejects browser DNS-rebinding attem
   });
 
   it("rejects preflight requests from an Origin outside the allowlist", async () => {
-    const handle = await startOnEphemeral({ allowedOrigins: ["https://app.example"] });
+    const handle = await startOnEphemeral({
+      allowedOrigins: ["https://app.example"],
+    });
     handles.push(handle);
 
     const res = await rawRequest(handle.port, {
@@ -508,17 +666,21 @@ describe("regression: HTTP Origin validation rejects browser DNS-rebinding attem
 
 describe("regression: HTTP bearer token must not be empty", () => {
   it("rejects whitespace-only programmatic tokens", async () => {
-    await expect(startOnEphemeral({ bearerToken: "   " })).rejects.toThrow(/token.*empty/i);
+    await expect(startOnEphemeral({ bearerToken: "   " })).rejects.toThrow(
+      /token.*empty/i
+    );
   });
 
   it("rejects wildcard CORS without bearer auth", async () => {
-    await expect(startHttpServer({
-      host: "127.0.0.1",
-      port: 0,
-      allowedOrigins: ["*"],
-      buildMcpServer: buildNoopServer,
-      installSignalHandlers: false,
-    } as Parameters<typeof startHttpServer>[0])).rejects.toThrow(/bearer token is required/i);
+    await expect(
+      startHttpServer({
+        host: "127.0.0.1",
+        port: 0,
+        allowedOrigins: ["*"],
+        buildMcpServer: buildNoopServer,
+        installSignalHandlers: false,
+      } as Parameters<typeof startHttpServer>[0])
+    ).rejects.toThrow(/bearer token is required/i);
   });
 
   it("allows wildcard CORS when bearer auth is configured", async () => {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,4 +1,8 @@
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -18,9 +22,11 @@ export interface HttpServerOptions {
   /** Reported on `/health` and `/version`. Defaults to empty string. */
   version?: string;
   /** Additional HTTP Host header values accepted by the MCP transport.
-   *  Matched exactly, including a port when present (e.g. "vault.example.com"
-   *  or "192.0.2.10:3333"). No schemes, paths, or wildcard matching.
-   *  Extends the bound-address and loopback defaults; does not replace them.
+   *  Matched exactly and case-sensitively, including a port when present
+   *  (e.g. "vault.example.com" or "192.0.2.10:3333"). IPv6 must keep
+   *  brackets (`[::1]:port`). No schemes, paths, IDN normalization, or
+   *  wildcard matching — `"*"` is rejected at startup. Extends the
+   *  bound-address and loopback defaults; does not replace them.
    *  Identifies destination hosts, not connecting clients. Copied at startup. */
   allowedHosts?: string[];
   /** Allowed CORS origins. Defaults to localhost-only patterns
@@ -42,7 +48,8 @@ export interface HttpServerHandle {
   stop: () => Promise<void>;
 }
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MAX_BODY_BYTES = 4 * 1024 * 1024;
 const SESSION_IDLE_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
 const SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
@@ -64,11 +71,14 @@ class BodyTooLargeError extends Error {
 
 function declaredBodyTooLarge(req: IncomingMessage): boolean {
   const contentLength = req.headers["content-length"];
-  if (typeof contentLength !== "string" || !/^\d+$/.test(contentLength)) return false;
+  if (typeof contentLength !== "string" || !/^\d+$/.test(contentLength))
+    return false;
   return BigInt(contentLength) > BigInt(MAX_BODY_BYTES);
 }
 
-function isJsonContentType(contentType: string | string[] | undefined): boolean {
+function isJsonContentType(
+  contentType: string | string[] | undefined
+): boolean {
   if (typeof contentType !== "string") return false;
   const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
   return mediaType === "application/json";
@@ -180,7 +190,7 @@ function originAllowed(origin: string, allowedOrigins: string[]): boolean {
 function setCors(
   req: IncomingMessage,
   res: ServerResponse,
-  allowedOrigins: string[],
+  allowedOrigins: string[]
 ): void {
   // Reflect the request origin only when it matches the allowlist; fall back
   // to the first allowlist entry otherwise. `*` short-circuits to the
@@ -194,7 +204,10 @@ function setCors(
     // pinned to a different origin's request. This must fire regardless of
     // whether *this particular* origin matched the allowlist.
     res.setHeader("Vary", "Origin");
-    if (requestOrigin && allowedOrigins.some((p) => originMatches(requestOrigin, p))) {
+    if (
+      requestOrigin &&
+      allowedOrigins.some((p) => originMatches(requestOrigin, p))
+    ) {
       allowOrigin = requestOrigin;
     } else {
       allowOrigin = allowedOrigins[0] ?? "";
@@ -203,11 +216,11 @@ function setCors(
   if (allowOrigin) res.setHeader("Access-Control-Allow-Origin", allowOrigin);
   res.setHeader(
     "Access-Control-Allow-Headers",
-    "Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version",
+    "Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version"
   );
   res.setHeader(
     "Access-Control-Expose-Headers",
-    "Mcp-Session-Id, Mcp-Protocol-Version, WWW-Authenticate",
+    "Mcp-Session-Id, Mcp-Protocol-Version, WWW-Authenticate"
   );
   res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
 }
@@ -218,7 +231,10 @@ function setCors(
 // request timestamps per IP pruned on read.
 class RateLimiter {
   private readonly windows = new Map<string, number[]>();
-  constructor(private readonly limit: number, private readonly windowMs = 60_000) {}
+  constructor(
+    private readonly limit: number,
+    private readonly windowMs = 60_000
+  ) {}
   check(ip: string): boolean {
     const now = Date.now();
     const floor = now - this.windowMs;
@@ -245,6 +261,42 @@ class RateLimiter {
   }
 }
 
+function copyConfiguredHosts(raw: string[] | undefined): string[] {
+  if (!raw || raw.length === 0) return [];
+  const copied: string[] = [];
+  for (const entry of raw) {
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      throw new Error(
+        "allowedHosts entries must be non-empty Host header values"
+      );
+    }
+    if (trimmed === "*") {
+      throw new Error(
+        'allowedHosts does not accept "*": it is not a wildcard and does not disable DNS-rebinding protection'
+      );
+    }
+    if (trimmed.includes("://") || trimmed.includes("/")) {
+      throw new Error(
+        `allowedHosts entry ${JSON.stringify(entry)} must be a Host header value (host or host:port), not a URL`
+      );
+    }
+    copied.push(trimmed);
+  }
+  return copied;
+}
+
+function hostAllowed(
+  hostHeader: string | string[] | undefined,
+  allowedHosts: string[]
+): boolean {
+  return (
+    typeof hostHeader === "string" &&
+    hostHeader.length > 0 &&
+    allowedHosts.includes(hostHeader)
+  );
+}
+
 function clientIp(req: IncomingMessage): string {
   // No X-Forwarded-For trust here: the server binds to localhost by default
   // and does not know whether a reverse proxy is terminating TLS. Operators
@@ -256,20 +308,27 @@ function clientIp(req: IncomingMessage): string {
   return addr.startsWith("::ffff:") ? addr.slice(7) : addr;
 }
 
-export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServerHandle> {
+export async function startHttpServer(
+  opts: HttpServerOptions
+): Promise<HttpServerHandle> {
   const bearerToken = opts.bearerToken?.trim();
   if (opts.bearerToken !== undefined && !bearerToken) {
     throw new Error("HTTP bearer token cannot be empty");
   }
   if (!bearerToken) {
-    throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN in the CLI or pass bearerToken when embedding.");
+    throw new Error(
+      "HTTP bearer token is required. Set MCP_HTTP_TOKEN in the CLI or pass bearerToken when embedding."
+    );
   }
-  const allowedOrigins = opts.allowedOrigins && opts.allowedOrigins.length > 0
-    ? opts.allowedOrigins
-    : ["http://localhost:*", "http://127.0.0.1:*", "http://[::1]:*"];
+  const allowedOrigins =
+    opts.allowedOrigins && opts.allowedOrigins.length > 0
+      ? opts.allowedOrigins
+      : ["http://localhost:*", "http://127.0.0.1:*", "http://[::1]:*"];
   const transports = new Map<string, StreamableHTTPServerTransport>();
   const lastActivity = new Map<string, number>();
-  const touch = (sid: string): void => { lastActivity.set(sid, Date.now()); };
+  const touch = (sid: string): void => {
+    lastActivity.set(sid, Date.now());
+  };
   // One `McpServer` per session: the underlying SDK `Protocol` rejects a
   // second `connect()` while a transport is still attached, so a singleton
   // 500s every reconnect and every concurrent client past the first. Each
@@ -277,11 +336,14 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
   // transport closes (Protocol._onclose clears the transport reference).
   // See https://github.com/rps321321/obsidian-mcp-pro/issues/8.
   if (allowedOrigins.includes("*")) {
-    log.warn("CORS configured with wildcard origin '*'. Consider restricting to specific origins for production deployments.");
+    log.warn(
+      "CORS configured with wildcard origin '*'. Consider restricting to specific origins for production deployments."
+    );
   }
-  const rateLimiter = opts.rateLimitPerMinute && opts.rateLimitPerMinute > 0
-    ? new RateLimiter(opts.rateLimitPerMinute)
-    : null;
+  const rateLimiter =
+    opts.rateLimitPerMinute && opts.rateLimitPerMinute > 0
+      ? new RateLimiter(opts.rateLimitPerMinute)
+      : null;
 
   // Evict sessions that have been idle past the timeout so dropped clients
   // (crash, network loss, no DELETE) don't leak transports forever.
@@ -290,7 +352,9 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
     for (const [sid, ts] of lastActivity) {
       if (now - ts > SESSION_IDLE_TIMEOUT_MS) {
         const t = transports.get(sid);
-        if (t) { void t.close().catch(() => undefined); }
+        if (t) {
+          void t.close().catch(() => undefined);
+        }
         transports.delete(sid);
         lastActivity.delete(sid);
       }
@@ -308,9 +372,12 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
   // re-assigning the binding: a new array would be invisible to transports
   // that already grabbed the original reference, silently disabling
   // DNS-rebinding protection.
-  const allowedHosts: string[] = [...(opts.allowedHosts ?? [])];
+  const allowedHosts: string[] = copyConfiguredHosts(opts.allowedHosts);
 
-  const handleRequest = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+  const handleRequest = async (
+    req: IncomingMessage,
+    res: ServerResponse
+  ): Promise<void> => {
     // Cap wall-clock time for POST requests only. GET is used by the
     // Streamable HTTP transport for long-lived SSE streams that intentionally
     // go write-silent between events — `socket.setTimeout` would reap them
@@ -341,7 +408,10 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
       return;
     }
     const requestOrigin = req.headers.origin;
-    if (typeof requestOrigin === "string" && !originAllowed(requestOrigin, allowedOrigins)) {
+    if (
+      typeof requestOrigin === "string" &&
+      !originAllowed(requestOrigin, allowedOrigins)
+    ) {
       log.warn("Rejected request from disallowed Origin", {
         origin: requestOrigin,
         method: req.method,
@@ -393,7 +463,10 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
           const header = req.headers.authorization ?? "";
           const token = header.startsWith("Bearer ") ? header.slice(7) : "";
           if (!constantTimeEqual(token, bearerToken)) {
-            res.setHeader("WWW-Authenticate", 'Bearer realm="obsidian-mcp-pro"');
+            res.setHeader(
+              "WWW-Authenticate",
+              'Bearer realm="obsidian-mcp-pro"'
+            );
             sendJson(res, 401, { error: "Unauthorized" });
             return;
           }
@@ -402,6 +475,21 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
         return;
       }
       sendJson(res, 404, { error: "Not found" });
+      return;
+    }
+
+    // HTTP-layer Host check (same shape as Origin): SDK Host validation is
+    // 403 + optional onerror only, and runs after bearer auth, so probes
+    // otherwise produce no Host diagnostic. /health and /version skip this
+    // (pre-existing). Keep the SDK allowedHosts list as defense in depth.
+    if (!hostAllowed(req.headers.host, allowedHosts)) {
+      log.warn("Rejected request from disallowed Host", {
+        host: typeof req.headers.host === "string" ? req.headers.host : "",
+        method: req.method,
+        path: req.url ?? "",
+        ip: clientIp(req),
+      });
+      sendJson(res, 403, { error: "Host not allowed" });
       return;
     }
 
@@ -435,7 +523,9 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
         // a clearer 415 ("the server understands the request method but
         // the media type is unsupported") than a generic 400.
         if (!isJsonContentType(req.headers["content-type"])) {
-          sendJson(res, 415, { error: "Unsupported Media Type: expected application/json" });
+          sendJson(res, 415, {
+            error: "Unsupported Media Type: expected application/json",
+          });
           return;
         }
         if (declaredBodyTooLarge(req)) {
@@ -499,7 +589,11 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
 
         sendJson(res, 400, {
           jsonrpc: "2.0",
-          error: { code: -32000, message: "Invalid session or non-initialize request without session" },
+          error: {
+            code: -32000,
+            message:
+              "Invalid session or non-initialize request without session",
+          },
           id: null,
         });
         return;
@@ -544,13 +638,14 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
     `${opts.host}:${boundPort}`,
     `127.0.0.1:${boundPort}`,
     `localhost:${boundPort}`,
-    `[::1]:${boundPort}`,
+    `[::1]:${boundPort}`
   );
 
   log.info(`HTTP server listening`, {
     url: `http://${opts.host}:${boundPort}/mcp`,
     bearerAuth: Boolean(bearerToken),
     allowedOrigins: allowedOrigins.join(","),
+    allowedHosts: allowedHosts.join(","),
     rateLimitPerMinute: opts.rateLimitPerMinute ?? 0,
   });
   const installSignals = opts.installSignalHandlers ?? true;
@@ -564,7 +659,11 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
     log.info(`Shutting down HTTP server`);
     clearInterval(sweeper);
     for (const t of transports.values()) {
-      try { await t.close(); } catch { /* ignore */ }
+      try {
+        await t.close();
+      } catch {
+        /* ignore */
+      }
     }
     transports.clear();
     lastActivity.clear();

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,8 +1,4 @@
-import {
-  createServer,
-  type IncomingMessage,
-  type ServerResponse,
-} from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -46,8 +42,7 @@ export interface HttpServerHandle {
   stop: () => Promise<void>;
 }
 
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MAX_BODY_BYTES = 4 * 1024 * 1024;
 const SESSION_IDLE_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
 const SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
@@ -69,14 +64,11 @@ class BodyTooLargeError extends Error {
 
 function declaredBodyTooLarge(req: IncomingMessage): boolean {
   const contentLength = req.headers["content-length"];
-  if (typeof contentLength !== "string" || !/^\d+$/.test(contentLength))
-    return false;
+  if (typeof contentLength !== "string" || !/^\d+$/.test(contentLength)) return false;
   return BigInt(contentLength) > BigInt(MAX_BODY_BYTES);
 }
 
-function isJsonContentType(
-  contentType: string | string[] | undefined
-): boolean {
+function isJsonContentType(contentType: string | string[] | undefined): boolean {
   if (typeof contentType !== "string") return false;
   const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
   return mediaType === "application/json";
@@ -188,7 +180,7 @@ function originAllowed(origin: string, allowedOrigins: string[]): boolean {
 function setCors(
   req: IncomingMessage,
   res: ServerResponse,
-  allowedOrigins: string[]
+  allowedOrigins: string[],
 ): void {
   // Reflect the request origin only when it matches the allowlist; fall back
   // to the first allowlist entry otherwise. `*` short-circuits to the
@@ -202,10 +194,7 @@ function setCors(
     // pinned to a different origin's request. This must fire regardless of
     // whether *this particular* origin matched the allowlist.
     res.setHeader("Vary", "Origin");
-    if (
-      requestOrigin &&
-      allowedOrigins.some((p) => originMatches(requestOrigin, p))
-    ) {
+    if (requestOrigin && allowedOrigins.some((p) => originMatches(requestOrigin, p))) {
       allowOrigin = requestOrigin;
     } else {
       allowOrigin = allowedOrigins[0] ?? "";
@@ -214,11 +203,11 @@ function setCors(
   if (allowOrigin) res.setHeader("Access-Control-Allow-Origin", allowOrigin);
   res.setHeader(
     "Access-Control-Allow-Headers",
-    "Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version"
+    "Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version",
   );
   res.setHeader(
     "Access-Control-Expose-Headers",
-    "Mcp-Session-Id, Mcp-Protocol-Version, WWW-Authenticate"
+    "Mcp-Session-Id, Mcp-Protocol-Version, WWW-Authenticate",
   );
   res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
 }
@@ -229,10 +218,7 @@ function setCors(
 // request timestamps per IP pruned on read.
 class RateLimiter {
   private readonly windows = new Map<string, number[]>();
-  constructor(
-    private readonly limit: number,
-    private readonly windowMs = 60_000
-  ) {}
+  constructor(private readonly limit: number, private readonly windowMs = 60_000) {}
   check(ip: string): boolean {
     const now = Date.now();
     const floor = now - this.windowMs;
@@ -270,27 +256,20 @@ function clientIp(req: IncomingMessage): string {
   return addr.startsWith("::ffff:") ? addr.slice(7) : addr;
 }
 
-export async function startHttpServer(
-  opts: HttpServerOptions
-): Promise<HttpServerHandle> {
+export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServerHandle> {
   const bearerToken = opts.bearerToken?.trim();
   if (opts.bearerToken !== undefined && !bearerToken) {
     throw new Error("HTTP bearer token cannot be empty");
   }
   if (!bearerToken) {
-    throw new Error(
-      "HTTP bearer token is required. Set MCP_HTTP_TOKEN in the CLI or pass bearerToken when embedding."
-    );
+    throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN in the CLI or pass bearerToken when embedding.");
   }
-  const allowedOrigins =
-    opts.allowedOrigins && opts.allowedOrigins.length > 0
-      ? opts.allowedOrigins
-      : ["http://localhost:*", "http://127.0.0.1:*", "http://[::1]:*"];
+  const allowedOrigins = opts.allowedOrigins && opts.allowedOrigins.length > 0
+    ? opts.allowedOrigins
+    : ["http://localhost:*", "http://127.0.0.1:*", "http://[::1]:*"];
   const transports = new Map<string, StreamableHTTPServerTransport>();
   const lastActivity = new Map<string, number>();
-  const touch = (sid: string): void => {
-    lastActivity.set(sid, Date.now());
-  };
+  const touch = (sid: string): void => { lastActivity.set(sid, Date.now()); };
   // One `McpServer` per session: the underlying SDK `Protocol` rejects a
   // second `connect()` while a transport is still attached, so a singleton
   // 500s every reconnect and every concurrent client past the first. Each
@@ -298,14 +277,11 @@ export async function startHttpServer(
   // transport closes (Protocol._onclose clears the transport reference).
   // See https://github.com/rps321321/obsidian-mcp-pro/issues/8.
   if (allowedOrigins.includes("*")) {
-    log.warn(
-      "CORS configured with wildcard origin '*'. Consider restricting to specific origins for production deployments."
-    );
+    log.warn("CORS configured with wildcard origin '*'. Consider restricting to specific origins for production deployments.");
   }
-  const rateLimiter =
-    opts.rateLimitPerMinute && opts.rateLimitPerMinute > 0
-      ? new RateLimiter(opts.rateLimitPerMinute)
-      : null;
+  const rateLimiter = opts.rateLimitPerMinute && opts.rateLimitPerMinute > 0
+    ? new RateLimiter(opts.rateLimitPerMinute)
+    : null;
 
   // Evict sessions that have been idle past the timeout so dropped clients
   // (crash, network loss, no DELETE) don't leak transports forever.
@@ -314,9 +290,7 @@ export async function startHttpServer(
     for (const [sid, ts] of lastActivity) {
       if (now - ts > SESSION_IDLE_TIMEOUT_MS) {
         const t = transports.get(sid);
-        if (t) {
-          void t.close().catch(() => undefined);
-        }
+        if (t) { void t.close().catch(() => undefined); }
         transports.delete(sid);
         lastActivity.delete(sid);
       }
@@ -336,10 +310,7 @@ export async function startHttpServer(
   // DNS-rebinding protection.
   const allowedHosts: string[] = [...(opts.allowedHosts ?? [])];
 
-  const handleRequest = async (
-    req: IncomingMessage,
-    res: ServerResponse
-  ): Promise<void> => {
+  const handleRequest = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     // Cap wall-clock time for POST requests only. GET is used by the
     // Streamable HTTP transport for long-lived SSE streams that intentionally
     // go write-silent between events — `socket.setTimeout` would reap them
@@ -370,10 +341,7 @@ export async function startHttpServer(
       return;
     }
     const requestOrigin = req.headers.origin;
-    if (
-      typeof requestOrigin === "string" &&
-      !originAllowed(requestOrigin, allowedOrigins)
-    ) {
+    if (typeof requestOrigin === "string" && !originAllowed(requestOrigin, allowedOrigins)) {
       log.warn("Rejected request from disallowed Origin", {
         origin: requestOrigin,
         method: req.method,
@@ -425,10 +393,7 @@ export async function startHttpServer(
           const header = req.headers.authorization ?? "";
           const token = header.startsWith("Bearer ") ? header.slice(7) : "";
           if (!constantTimeEqual(token, bearerToken)) {
-            res.setHeader(
-              "WWW-Authenticate",
-              'Bearer realm="obsidian-mcp-pro"'
-            );
+            res.setHeader("WWW-Authenticate", 'Bearer realm="obsidian-mcp-pro"');
             sendJson(res, 401, { error: "Unauthorized" });
             return;
           }
@@ -470,9 +435,7 @@ export async function startHttpServer(
         // a clearer 415 ("the server understands the request method but
         // the media type is unsupported") than a generic 400.
         if (!isJsonContentType(req.headers["content-type"])) {
-          sendJson(res, 415, {
-            error: "Unsupported Media Type: expected application/json",
-          });
+          sendJson(res, 415, { error: "Unsupported Media Type: expected application/json" });
           return;
         }
         if (declaredBodyTooLarge(req)) {
@@ -536,11 +499,7 @@ export async function startHttpServer(
 
         sendJson(res, 400, {
           jsonrpc: "2.0",
-          error: {
-            code: -32000,
-            message:
-              "Invalid session or non-initialize request without session",
-          },
+          error: { code: -32000, message: "Invalid session or non-initialize request without session" },
           id: null,
         });
         return;
@@ -585,7 +544,7 @@ export async function startHttpServer(
     `${opts.host}:${boundPort}`,
     `127.0.0.1:${boundPort}`,
     `localhost:${boundPort}`,
-    `[::1]:${boundPort}`
+    `[::1]:${boundPort}`,
   );
 
   log.info(`HTTP server listening`, {
@@ -605,11 +564,7 @@ export async function startHttpServer(
     log.info(`Shutting down HTTP server`);
     clearInterval(sweeper);
     for (const t of transports.values()) {
-      try {
-        await t.close();
-      } catch {
-        /* ignore */
-      }
+      try { await t.close(); } catch { /* ignore */ }
     }
     transports.clear();
     lastActivity.clear();

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,4 +1,8 @@
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -17,6 +21,12 @@ export interface HttpServerOptions {
   installSignalHandlers?: boolean;
   /** Reported on `/health` and `/version`. Defaults to empty string. */
   version?: string;
+  /** Additional HTTP Host header values accepted by the MCP transport.
+   *  Matched exactly, including a port when present (e.g. "vault.example.com"
+   *  or "192.0.2.10:3333"). No schemes, paths, or wildcard matching.
+   *  Extends the bound-address and loopback defaults; does not replace them.
+   *  Identifies destination hosts, not connecting clients. Copied at startup. */
+  allowedHosts?: string[];
   /** Allowed CORS origins. Defaults to localhost-only patterns
    *  (`["http://localhost:*", "http://127.0.0.1:*", "http://[::1]:*"]`).
    *  Use an explicit list (e.g. `["https://claude.ai"]`) for browser-facing
@@ -36,7 +46,8 @@ export interface HttpServerHandle {
   stop: () => Promise<void>;
 }
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MAX_BODY_BYTES = 4 * 1024 * 1024;
 const SESSION_IDLE_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
 const SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
@@ -58,11 +69,14 @@ class BodyTooLargeError extends Error {
 
 function declaredBodyTooLarge(req: IncomingMessage): boolean {
   const contentLength = req.headers["content-length"];
-  if (typeof contentLength !== "string" || !/^\d+$/.test(contentLength)) return false;
+  if (typeof contentLength !== "string" || !/^\d+$/.test(contentLength))
+    return false;
   return BigInt(contentLength) > BigInt(MAX_BODY_BYTES);
 }
 
-function isJsonContentType(contentType: string | string[] | undefined): boolean {
+function isJsonContentType(
+  contentType: string | string[] | undefined
+): boolean {
   if (typeof contentType !== "string") return false;
   const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
   return mediaType === "application/json";
@@ -174,7 +188,7 @@ function originAllowed(origin: string, allowedOrigins: string[]): boolean {
 function setCors(
   req: IncomingMessage,
   res: ServerResponse,
-  allowedOrigins: string[],
+  allowedOrigins: string[]
 ): void {
   // Reflect the request origin only when it matches the allowlist; fall back
   // to the first allowlist entry otherwise. `*` short-circuits to the
@@ -188,7 +202,10 @@ function setCors(
     // pinned to a different origin's request. This must fire regardless of
     // whether *this particular* origin matched the allowlist.
     res.setHeader("Vary", "Origin");
-    if (requestOrigin && allowedOrigins.some((p) => originMatches(requestOrigin, p))) {
+    if (
+      requestOrigin &&
+      allowedOrigins.some((p) => originMatches(requestOrigin, p))
+    ) {
       allowOrigin = requestOrigin;
     } else {
       allowOrigin = allowedOrigins[0] ?? "";
@@ -197,11 +214,11 @@ function setCors(
   if (allowOrigin) res.setHeader("Access-Control-Allow-Origin", allowOrigin);
   res.setHeader(
     "Access-Control-Allow-Headers",
-    "Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version",
+    "Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version"
   );
   res.setHeader(
     "Access-Control-Expose-Headers",
-    "Mcp-Session-Id, Mcp-Protocol-Version, WWW-Authenticate",
+    "Mcp-Session-Id, Mcp-Protocol-Version, WWW-Authenticate"
   );
   res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
 }
@@ -212,7 +229,10 @@ function setCors(
 // request timestamps per IP pruned on read.
 class RateLimiter {
   private readonly windows = new Map<string, number[]>();
-  constructor(private readonly limit: number, private readonly windowMs = 60_000) {}
+  constructor(
+    private readonly limit: number,
+    private readonly windowMs = 60_000
+  ) {}
   check(ip: string): boolean {
     const now = Date.now();
     const floor = now - this.windowMs;
@@ -250,20 +270,27 @@ function clientIp(req: IncomingMessage): string {
   return addr.startsWith("::ffff:") ? addr.slice(7) : addr;
 }
 
-export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServerHandle> {
+export async function startHttpServer(
+  opts: HttpServerOptions
+): Promise<HttpServerHandle> {
   const bearerToken = opts.bearerToken?.trim();
   if (opts.bearerToken !== undefined && !bearerToken) {
     throw new Error("HTTP bearer token cannot be empty");
   }
   if (!bearerToken) {
-    throw new Error("HTTP bearer token is required. Set MCP_HTTP_TOKEN in the CLI or pass bearerToken when embedding.");
+    throw new Error(
+      "HTTP bearer token is required. Set MCP_HTTP_TOKEN in the CLI or pass bearerToken when embedding."
+    );
   }
-  const allowedOrigins = opts.allowedOrigins && opts.allowedOrigins.length > 0
-    ? opts.allowedOrigins
-    : ["http://localhost:*", "http://127.0.0.1:*", "http://[::1]:*"];
+  const allowedOrigins =
+    opts.allowedOrigins && opts.allowedOrigins.length > 0
+      ? opts.allowedOrigins
+      : ["http://localhost:*", "http://127.0.0.1:*", "http://[::1]:*"];
   const transports = new Map<string, StreamableHTTPServerTransport>();
   const lastActivity = new Map<string, number>();
-  const touch = (sid: string): void => { lastActivity.set(sid, Date.now()); };
+  const touch = (sid: string): void => {
+    lastActivity.set(sid, Date.now());
+  };
   // One `McpServer` per session: the underlying SDK `Protocol` rejects a
   // second `connect()` while a transport is still attached, so a singleton
   // 500s every reconnect and every concurrent client past the first. Each
@@ -271,11 +298,14 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
   // transport closes (Protocol._onclose clears the transport reference).
   // See https://github.com/rps321321/obsidian-mcp-pro/issues/8.
   if (allowedOrigins.includes("*")) {
-    log.warn("CORS configured with wildcard origin '*'. Consider restricting to specific origins for production deployments.");
+    log.warn(
+      "CORS configured with wildcard origin '*'. Consider restricting to specific origins for production deployments."
+    );
   }
-  const rateLimiter = opts.rateLimitPerMinute && opts.rateLimitPerMinute > 0
-    ? new RateLimiter(opts.rateLimitPerMinute)
-    : null;
+  const rateLimiter =
+    opts.rateLimitPerMinute && opts.rateLimitPerMinute > 0
+      ? new RateLimiter(opts.rateLimitPerMinute)
+      : null;
 
   // Evict sessions that have been idle past the timeout so dropped clients
   // (crash, network loss, no DELETE) don't leak transports forever.
@@ -284,7 +314,9 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
     for (const [sid, ts] of lastActivity) {
       if (now - ts > SESSION_IDLE_TIMEOUT_MS) {
         const t = transports.get(sid);
-        if (t) { void t.close().catch(() => undefined); }
+        if (t) {
+          void t.close().catch(() => undefined);
+        }
         transports.delete(sid);
         lastActivity.delete(sid);
       }
@@ -293,19 +325,21 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
   }, SESSION_SWEEP_INTERVAL_MS);
   sweeper.unref?.();
 
-  // DNS rebinding protection: restrict Host header to the bound interface +
-  // localhost aliases. Browsers attacking via dns-rebinding will present a
-  // third-party hostname and be rejected. Populated after `listen()` so we
-  // know the bound port; this matters when callers pass `port: 0` (tests,
+  // DNS rebinding protection: restrict Host to configured destinations plus
+  // the bound interface and localhost aliases. Append defaults after listen()
+  // when we know the bound port; this matters when callers pass `port: 0` (tests,
   // embedders) and the OS assigns one. The array reference is captured by
   // each `StreamableHTTPServerTransport` constructor and read on every
   // request, so we MUST mutate this array in place (push) rather than
   // re-assigning the binding: a new array would be invisible to transports
   // that already grabbed the original reference, silently disabling
   // DNS-rebinding protection.
-  const allowedHosts: string[] = [];
+  const allowedHosts: string[] = [...(opts.allowedHosts ?? [])];
 
-  const handleRequest = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+  const handleRequest = async (
+    req: IncomingMessage,
+    res: ServerResponse
+  ): Promise<void> => {
     // Cap wall-clock time for POST requests only. GET is used by the
     // Streamable HTTP transport for long-lived SSE streams that intentionally
     // go write-silent between events — `socket.setTimeout` would reap them
@@ -336,7 +370,10 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
       return;
     }
     const requestOrigin = req.headers.origin;
-    if (typeof requestOrigin === "string" && !originAllowed(requestOrigin, allowedOrigins)) {
+    if (
+      typeof requestOrigin === "string" &&
+      !originAllowed(requestOrigin, allowedOrigins)
+    ) {
       log.warn("Rejected request from disallowed Origin", {
         origin: requestOrigin,
         method: req.method,
@@ -388,7 +425,10 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
           const header = req.headers.authorization ?? "";
           const token = header.startsWith("Bearer ") ? header.slice(7) : "";
           if (!constantTimeEqual(token, bearerToken)) {
-            res.setHeader("WWW-Authenticate", 'Bearer realm="obsidian-mcp-pro"');
+            res.setHeader(
+              "WWW-Authenticate",
+              'Bearer realm="obsidian-mcp-pro"'
+            );
             sendJson(res, 401, { error: "Unauthorized" });
             return;
           }
@@ -430,7 +470,9 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
         // a clearer 415 ("the server understands the request method but
         // the media type is unsupported") than a generic 400.
         if (!isJsonContentType(req.headers["content-type"])) {
-          sendJson(res, 415, { error: "Unsupported Media Type: expected application/json" });
+          sendJson(res, 415, {
+            error: "Unsupported Media Type: expected application/json",
+          });
           return;
         }
         if (declaredBodyTooLarge(req)) {
@@ -494,7 +536,11 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
 
         sendJson(res, 400, {
           jsonrpc: "2.0",
-          error: { code: -32000, message: "Invalid session or non-initialize request without session" },
+          error: {
+            code: -32000,
+            message:
+              "Invalid session or non-initialize request without session",
+          },
           id: null,
         });
         return;
@@ -539,7 +585,7 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
     `${opts.host}:${boundPort}`,
     `127.0.0.1:${boundPort}`,
     `localhost:${boundPort}`,
-    `[::1]:${boundPort}`,
+    `[::1]:${boundPort}`
   );
 
   log.info(`HTTP server listening`, {
@@ -559,7 +605,11 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<HttpServ
     log.info(`Shutting down HTTP server`);
     clearInterval(sweeper);
     for (const t of transports.values()) {
-      try { await t.close(); } catch { /* ignore */ }
+      try {
+        await t.close();
+      } catch {
+        /* ignore */
+      }
     }
     transports.clear();
     lastActivity.clear();


### PR DESCRIPTION
Allow HTTP embedders to configure additional destination hosts without disabling DNS-rebinding protection.

- Add `HttpServerOptions.allowedHosts`, extending existing defaults.
- Preserve authentication and Host validation on new and existing sessions.
- Document exact host/port matching and add regression coverage.

Addresses the library `allowedHosts` portion of #284. No plugin UI, CLI flag, role, or rate-limit changes.

**Verification:** 999 tests passed, 12 skipped; lint, typecheck, build, and compiled-server smoke passed.